### PR TITLE
fix(supportChat): replace nonexistent Logger with console

### DIFF
--- a/backend/src/modules/supportChat/services/AdminService.ts
+++ b/backend/src/modules/supportChat/services/AdminService.ts
@@ -12,11 +12,8 @@ import {
 import { FAQRepository } from '../repositories/providers/mongodb/index.js';
 import { SupportQuestionRepository } from '../repositories/providers/mongodb/index.js';
 import { FAQRetrievalService } from './FAQRetrievalService.js';
-import { Logger } from '@/shared/logger';
-
 @injectable()
 export class AdminService {
-  private logger = Logger.getLogger('AdminService');
 
   constructor(
     @inject(SUPPORT_CHAT_TYPES.FAQRepo) private faqRepo: FAQRepository,
@@ -33,7 +30,7 @@ export class AdminService {
       }
       return await this.questionRepo.findPending(limit);
     } catch (error) {
-      this.logger.error('Error fetching pending questions', error);
+      console.error('Error fetching pending questions', error);
       throw error;
     }
   }
@@ -75,7 +72,7 @@ export class AdminService {
         // Link FAQ to original question
         await this.questionRepo.linkFaqCreated(questionId, newFAQ._id!);
 
-        this.logger.info(`Created FAQ ${newFAQ._id} from question ${questionId}`);
+        console.log(`Created FAQ ${newFAQ._id} from question ${questionId}`);
       }
 
       // Set admin response on question
@@ -85,11 +82,11 @@ export class AdminService {
         adminUserId
       );
 
-      this.logger.info(`Admin ${adminUserId} responded to question ${questionId}`);
+      console.log(`Admin ${adminUserId} responded to question ${questionId}`);
 
       return updated;
     } catch (error) {
-      this.logger.error('Error responding to question', error);
+      console.error('Error responding to question', error);
       throw error;
     }
   }
@@ -115,7 +112,7 @@ export class AdminService {
         satisfactionRate,
       };
     } catch (error) {
-      this.logger.error('Error fetching dashboard stats', error);
+      console.error('Error fetching dashboard stats', error);
       throw error;
     }
   }
@@ -127,7 +124,7 @@ export class AdminService {
         category,
       });
     } catch (error) {
-      this.logger.error('Error fetching FAQs', error);
+      console.error('Error fetching FAQs', error);
       throw error;
     }
   }
@@ -145,7 +142,7 @@ export class AdminService {
         createdBy: adminUserId,
       });
     } catch (error) {
-      this.logger.error('Error creating FAQ', error);
+      console.error('Error creating FAQ', error);
       throw error;
     }
   }
@@ -154,7 +151,7 @@ export class AdminService {
     try {
       return await this.faqRepo.updateById(faqId, updates);
     } catch (error) {
-      this.logger.error('Error updating FAQ', error);
+      console.error('Error updating FAQ', error);
       throw error;
     }
   }
@@ -163,11 +160,11 @@ export class AdminService {
     try {
       const result = await this.faqRepo.deleteById(faqId);
       if (result) {
-        this.logger.info(`FAQ ${faqId} deleted`);
+        console.log(`FAQ ${faqId} deleted`);
       }
       return result;
     } catch (error) {
-      this.logger.error('Error deleting FAQ', error);
+      console.error('Error deleting FAQ', error);
       throw error;
     }
   }
@@ -176,7 +173,7 @@ export class AdminService {
     try {
       return await this.questionRepo.updateStatus(questionId, SupportQuestionStatus.RESOLVED);
     } catch (error) {
-      this.logger.error('Error marking question resolved', error);
+      console.error('Error marking question resolved', error);
       throw error;
     }
   }

--- a/backend/src/modules/supportChat/services/ChatService.ts
+++ b/backend/src/modules/supportChat/services/ChatService.ts
@@ -10,11 +10,8 @@ import {
 import { FAQRetrievalService } from './FAQRetrievalService.js';
 import { FAQRepository } from '../repositories/providers/mongodb/index.js';
 import { SupportQuestionRepository } from '../repositories/providers/mongodb/index.js';
-import { Logger } from '@/shared/logger';
-
 @injectable()
 export class ChatService {
-  private logger = Logger.getLogger('ChatService');
 
   constructor(
     @inject(SUPPORT_CHAT_TYPES.FAQRetrievalService) private faqRetrieval: FAQRetrievalService,
@@ -76,7 +73,7 @@ export class ChatService {
         questionId: question._id!,
       };
     } catch (error) {
-      this.logger.error('Error handling user question', error);
+      console.error('Error handling user question', error);
       throw error;
     }
   }
@@ -85,7 +82,7 @@ export class ChatService {
     try {
       return await this.questionRepo.findByUserId(userId, limit);
     } catch (error) {
-      this.logger.error('Error fetching question history', error);
+      console.error('Error fetching question history', error);
       throw error;
     }
   }
@@ -94,7 +91,7 @@ export class ChatService {
     try {
       return await this.questionRepo.findById(questionId);
     } catch (error) {
-      this.logger.error('Error fetching question', error);
+      console.error('Error fetching question', error);
       throw error;
     }
   }
@@ -105,10 +102,10 @@ export class ChatService {
   ): Promise<ISupportQuestion | null> {
     try {
       const updated = await this.questionRepo.setResolutionRating(questionId, rating);
-      this.logger.info(`Question ${questionId} rated as ${rating}`);
+      console.log(`Question ${questionId} rated as ${rating}`);
       return updated;
     } catch (error) {
-      this.logger.error('Error rating resolution', error);
+      console.error('Error rating resolution', error);
       throw error;
     }
   }

--- a/backend/src/modules/supportChat/services/FAQRetrievalService.ts
+++ b/backend/src/modules/supportChat/services/FAQRetrievalService.ts
@@ -6,11 +6,8 @@ import {
   SUPPORT_CHAT_TYPES,
 } from '../types.js';
 import { FAQRepository } from '../repositories/providers/mongodb/index.js';
-import { Logger } from '@/shared/logger';
-
 @injectable()
 export class FAQRetrievalService {
-  private logger = Logger.getLogger('FAQRetrievalService');
   private minimaxApiKey = process.env.MINIMAX_API_KEY;
   private minimaxApiUrl = process.env.MINIMAX_API_URL || 'https://api.minimax.chat/v1';
   private minimaxEmbeddingModel =
@@ -18,7 +15,7 @@ export class FAQRetrievalService {
 
   constructor(@inject(SUPPORT_CHAT_TYPES.FAQRepo) private faqRepo: FAQRepository) {
     if (!this.minimaxApiKey) {
-      this.logger.warn('MINIMAX_API_KEY not set - embedding generation will fail');
+      console.warn('MINIMAX_API_KEY not set - embedding generation will fail');
     }
   }
 
@@ -85,7 +82,7 @@ export class FAQRetrievalService {
 
       return data.data[0].embedding;
     } catch (error) {
-      this.logger.error('Error getting embedding from Minimax', error);
+      console.error('Error getting embedding from Minimax', error);
       throw error;
     }
   }
@@ -102,7 +99,7 @@ export class FAQRetrievalService {
       const faqs = await this.faqRepo.findAll({ isActive: true });
 
       if (faqs.length === 0) {
-        this.logger.warn('No active FAQs found');
+        console.warn('No active FAQs found');
         return null;
       }
 
@@ -147,7 +144,7 @@ export class FAQRetrievalService {
 
       return topResult as FAQRetrievalResult;
     } catch (error) {
-      this.logger.error('Error retrieving FAQ', error);
+      console.error('Error retrieving FAQ', error);
       throw error;
     }
   }
@@ -157,7 +154,7 @@ export class FAQRetrievalService {
       const textToEmbed = `${faq.question} ${faq.answer}`;
       return await this.getEmbedding(textToEmbed);
     } catch (error) {
-      this.logger.error('Error generating FAQ embedding', error);
+      console.error('Error generating FAQ embedding', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
The supportChat services imported from a nonexistent `@/shared/logger` module that doesn't exist in the codebase. Other modules in the project use `console` directly for logging. Updated all logging to match this pattern.

## Changes
- Removed `@/shared/logger` import from all service files
- Replaced `Logger.getLogger()` calls with direct `console` usage
- `logger.info()` → `console.log()`
- `logger.warn()` → `console.warn()`
- `logger.error()` → `console.error()`

## Test Plan
- TypeScript compilation succeeds for service files
- Logging statements work at runtime using native `console` API
