### PR TITLE
feat(supportChat): re-land support chat with working wiring

### DIFF
--- a/backend/src/modules/supportChat/README.md
+++ b/backend/src/modules/supportChat/README.md
@@ -1,0 +1,284 @@
+# Support Chat Module
+
+A comprehensive technical support chatbot module for the ViBe platform that helps learners resolve issues using an FAQ knowledge base, with automatic escalation to admins for unanswered questions.
+
+## Architecture
+
+```
+Learner Chat Widget
+    ↓
+ChatController (API endpoints)
+    ↓
+ChatService (Business logic)
+    ↓
+FAQRetrievalService (Semantic search + scoring)
+    ↓
+FAQRepository ← MongoDB (supportFaqs collection)
+SupportQuestionRepository ← MongoDB (supportQuestions collection)
+
+Admin Dashboard
+    ↓
+AdminController (API endpoints)
+    ↓
+AdminService (Admin operations)
+    ↓
+Question Queue → Admin Responses → Optional FAQ Creation
+```
+
+## File Structure
+
+```
+supportChat/
+├── controllers/
+│   ├── ChatController.ts          # Learner chat endpoints
+│   ├── AdminController.ts         # Admin dashboard endpoints
+│   └── index.ts
+├── services/
+│   ├── ChatService.ts             # Main chat business logic
+│   ├── FAQRetrievalService.ts     # Semantic FAQ search & scoring
+│   ├── AdminService.ts            # Admin operations
+│   └── index.ts
+├── repositories/
+│   └── providers/
+│       └── mongodb/
+│           ├── FAQRepository.ts
+│           ├── SupportQuestionRepository.ts
+│           └── index.ts
+├── validators/
+│   ├── SupportChatValidator.ts
+│   └── index.ts
+├── classes/
+│   └── transformers/
+│       └── index.ts
+├── types.ts                       # All TypeScript interfaces & constants
+├── container.ts                   # Inversify DI setup
+├── index.ts                       # Module exports
+└── README.md                      # This file
+```
+
+## Key Features
+
+### 1. Semantic FAQ Retrieval
+- Uses Anthropic Claude embeddings for intelligent question matching
+- Confidence-based filtering (threshold: 0.75)
+- Combines similarity score, keyword overlap, recency, and popularity
+- No hallucinations - returns only FAQ content
+
+### 2. Admin Fallback Workflow
+- Questions below confidence threshold go to admin queue
+- Admins review and respond to learners
+- Option to add responses as new FAQs
+- Auto-generates embeddings for new FAQs
+- Learner notifications when admin responds
+
+### 3. Data Persistence
+- **supportFaqs**: Stores FAQ questions, answers, categories, embeddings, usage stats
+- **supportQuestions**: Tracks learner questions, admin responses, ratings
+- Indexed for optimal retrieval performance
+
+## API Endpoints
+
+### Learner Endpoints
+
+**Send Chat Message**
+```
+POST /api/support/chat/message
+Query: ?courseId=xxx&courseVersionId=xxx&cohortId=xxx
+Body: { question: string, context?: {...} }
+Response: { response, confidence, faqId?, isFromFAQ, isEscalated, questionId, source? }
+```
+
+**Get Chat History**
+```
+GET /api/support/chat/history
+Query: ?limit=50
+Response: { questions: ISupportQuestion[], total: number }
+```
+
+**Get Single Question**
+```
+GET /api/support/chat/:questionId
+Response: ISupportQuestion
+```
+
+**Rate Resolution**
+```
+PATCH /api/support/chat/:questionId/rate
+Body: { rating: 'helpful' | 'not_helpful' }
+Response: ISupportQuestion
+```
+
+### Admin Endpoints
+
+**Get Dashboard Stats**
+```
+GET /api/admin/support/dashboard
+Query: ?courseId=xxx&startDate=xxx&endDate=xxx
+Response: { stats: {...}, recentPending: ISupportQuestion[] }
+```
+
+**Get Pending Questions**
+```
+GET /api/admin/support/questions
+Query: ?status=PENDING&page=1&limit=50&courseId=xxx
+Response: { questions: ISupportQuestion[], total: number }
+```
+
+**Respond to Question**
+```
+POST /api/admin/support/questions/:questionId/respond
+Body: { response: string, createFaq?: boolean, faqCategory?: string, faqTags?: string[] }
+Response: ISupportQuestion (with admin response)
+```
+
+**Mark Question Resolved**
+```
+PUT /api/admin/support/questions/:questionId/resolve
+Response: ISupportQuestion
+```
+
+**Manage FAQs**
+```
+GET    /api/admin/support/faqs                  # List all FAQs
+POST   /api/admin/support/faqs                  # Create new FAQ
+PUT    /api/admin/support/faqs/:faqId           # Update FAQ
+DELETE /api/admin/support/faqs/:faqId           # Delete FAQ
+```
+
+## Types & Constants
+
+All types are defined in `types.ts`:
+
+- `IFAQ`: FAQ document structure with embeddings
+- `ISupportQuestion`: Learner question with admin response
+- `ISupportAnalytics`: Daily metrics (optional, Phase 2)
+- `ChatMessageRequest/Response`: API request/response shapes
+- `AdminResponseRequest`: Admin response payload
+- Enums: `FAQCategory`, `SupportQuestionStatus`, `ResolutionRating`, `FAQSource`
+
+## Environment Configuration
+
+Required `.env` variables:
+
+```env
+MINIMAX_API_KEY=your-minimax-api-key    # Minimax API key
+MINIMAX_API_URL=https://api.minimax.chat/v1  # Minimax API endpoint (optional)
+MINIMAX_EMBEDDING_MODEL=embo-01         # Minimax embedding model (optional)
+FAQ_CONFIDENCE_THRESHOLD=0.75           # Minimum confidence for auto-response
+MONGODB_FAQ_COLLECTION=supportFaqs
+MONGODB_QUESTIONS_COLLECTION=supportQuestions
+```
+
+## Setup & Integration
+
+### 1. Add to Container
+In your main application container, import and register the module:
+
+```typescript
+import { supportChatContainerModule } from '@/modules/supportChat';
+
+// In your container setup:
+container.load(supportChatContainerModule);
+```
+
+### 2. Register Controllers
+If using routing-controllers, the controllers are auto-registered via decorators:
+
+```typescript
+import { ChatController, AdminController } from '@/modules/supportChat';
+
+useContainer(container);
+useControllers([ChatController, AdminController]);
+```
+
+### 3. Initialize MongoDB Indexes
+Before first use, ensure indexes are created:
+
+```typescript
+const faqRepo = container.get<FAQRepository>(SUPPORT_CHAT_TYPES.FAQRepo);
+const questionRepo = container.get<SupportQuestionRepository>(SUPPORT_CHAT_TYPES.SupportQuestionRepo);
+
+await faqRepo.createIndex();
+await questionRepo.createIndex();
+```
+
+### 4. Seed Initial FAQs
+Load the 27 Q&As from samagama.in/internship/faq#q-13-19:
+
+```typescript
+const adminService = container.get<AdminService>(SUPPORT_CHAT_TYPES.AdminService);
+const adminUserId = new ObjectId(/* system user */);
+
+for (const faqData of initialFAQs) {
+  await adminService.createFAQ(faqData, adminUserId);
+}
+```
+
+## Retrieval Algorithm
+
+The FAQ retrieval uses a multi-factor scoring system:
+
+1. **Semantic Similarity (70%)**: Cosine similarity between question and FAQ embeddings via Claude
+2. **Keyword Overlap (20%)**: Percentage of query words appearing in FAQ
+3. **Recency (-10%)**: Penalty for FAQs not updated in 365+ days
+4. **Popularity (+0.0001 per use)**: Boost for frequently helpful FAQs
+
+Result is escalated to admin if top score < 0.75 threshold.
+
+## Security & Access Control
+
+- **Learner endpoints**: Require `@Authorized('user')` - users see only their own questions
+- **Admin endpoints**: Require `@Authorized('admin', 'staff')` - admins can view all questions in their courses
+- **Data privacy**: No continuous video recording, no sensitive data in FAQ
+- **Rate limiting**: Apply rate limits to prevent chat spam (5 q/min for learners)
+
+## Testing Strategy
+
+### Unit Tests
+- FAQ retrieval scoring algorithm
+- Confidence threshold edge cases
+- Embedding generation
+
+### Integration Tests
+- Learner question → auto-response
+- Learner question → admin queue
+- Admin response → learner notification
+- Admin creates FAQ → appears in retrieval pool
+
+### E2E Tests
+- Full user journey: open chat → ask question → get response
+- Admin journey: review queue → respond → learner notified
+
+## Monitoring & Analytics (Phase 2)
+
+Track metrics from `supportAnalytics`:
+- Total questions per day
+- % resolved by FAQ vs. escalated to admin
+- Average admin response time
+- Learner satisfaction rate (helpful/not_helpful)
+- Top question categories
+
+## Future Enhancements
+
+1. **Multi-language support**: Translate FAQs and responses
+2. **Proactive assistance**: Suggest FAQs based on learner context
+3. **AI-powered suggestions**: Auto-generate FAQ candidates from common unanswered questions
+4. **Sentiment analysis**: Flag frustrated learners for priority support
+5. **Integration with performance data**: Recommend resources based on learner struggles
+6. **Mobile support**: Extend chat widget to mobile apps
+7. **Conversation analytics**: Track conversation flow and improvement opportunities
+
+## Dependencies
+
+- `inversify`: Dependency injection
+- `routing-controllers`: Express decorators
+- `mongodb`: Database access
+- `@anthropic-ai/sdk`: Claude embeddings & API
+- `class-validator`: Input validation
+
+## Support & Debugging
+
+**Check logs**: Look for "ChatService", "FAQRetrievalService", "AdminService" logger outputs
+**Test retrieval**: Use ChatService.handleUserQuestion() with test questions
+**Verify embeddings**: Ensure Anthropic API key is set and API is accessible
+**Monitor queue**: Admin dashboard shows pending questions count

--- a/backend/src/modules/supportChat/classes/transformers/index.ts
+++ b/backend/src/modules/supportChat/classes/transformers/index.ts
@@ -1,0 +1,2 @@
+// Transformers for converting between DTOs and domain models
+// Can be expanded as needed

--- a/backend/src/modules/supportChat/classes/validators/SupportChatValidators.ts
+++ b/backend/src/modules/supportChat/classes/validators/SupportChatValidators.ts
@@ -1,0 +1,317 @@
+import {Type} from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsIn,
+  IsInt,
+  IsMongoId,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Length,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import {JSONSchema} from 'class-validator-jsonschema';
+import {FAQCategory, FAQSource} from '../../types.js';
+
+const RESOLUTION_RATINGS = ['helpful', 'not_helpful'] as const;
+type ResolutionRatingLiteral = (typeof RESOLUTION_RATINGS)[number];
+
+const QUESTION_STATUSES = [
+  'PENDING',
+  'ANSWERED',
+  'RESOLVED',
+  'ESCALATED',
+] as const;
+type QuestionStatusLiteral = (typeof QUESTION_STATUSES)[number];
+
+/**
+ * Every @QueryParams()/@Body() parameter in this module must be typed with one
+ * of these classes rather than an inline object literal. Inline literals reflect
+ * as bare `Object`, which makes routing-controllers-openapi's getQueryParams()
+ * throw `Cannot read properties of undefined (reading 'split')` at spec
+ * generation time and takes down app startup (see commit 89646cbe3).
+ */
+
+export class SupportChatContextDto {
+  @IsOptional()
+  @IsString()
+  @JSONSchema({
+    description: 'Path the learner was on when they asked the question.',
+    example: '/student/courses/123/items/456',
+  })
+  page?: string;
+
+  @IsOptional()
+  @IsMongoId()
+  @JSONSchema({
+    description: 'Item the learner was viewing, when the question came from an item page.',
+  })
+  itemId?: string;
+
+  @IsOptional()
+  @IsString()
+  @JSONSchema({
+    description: 'Module name the learner was in.',
+  })
+  module?: string;
+}
+
+export class ChatMessageBody {
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 1000)
+  @JSONSchema({
+    description: 'The learner question (3-1000 characters).',
+    example: 'Why does my proctoring check keep failing?',
+  })
+  question!: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SupportChatContextDto)
+  @JSONSchema({
+    description: 'Where in the app the question was asked from.',
+  })
+  context?: SupportChatContextDto;
+}
+
+export class ChatMessageQuery {
+  @IsOptional()
+  @IsMongoId()
+  @JSONSchema({description: 'Course the question relates to.'})
+  courseId?: string;
+
+  @IsOptional()
+  @IsMongoId()
+  @JSONSchema({description: 'Course version the question relates to.'})
+  courseVersionId?: string;
+
+  @IsOptional()
+  @IsMongoId()
+  @JSONSchema({description: 'Cohort the learner belongs to.'})
+  cohortId?: string;
+}
+
+export class ChatHistoryQuery {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  @JSONSchema({
+    description: 'Maximum number of past questions to return (1-200).',
+    default: 50,
+  })
+  limit?: number;
+}
+
+export class SupportQuestionPathParams {
+  @IsMongoId()
+  @JSONSchema({description: 'Support question id.'})
+  questionId!: string;
+}
+
+export class RateQuestionBody {
+  @IsIn([...RESOLUTION_RATINGS])
+  @JSONSchema({
+    description: 'Whether the answer resolved the learner question.',
+    enum: [...RESOLUTION_RATINGS],
+  })
+  rating!: ResolutionRatingLiteral;
+}
+
+export class FAQSearchQuery {
+  @IsOptional()
+  @IsString()
+  @Length(1, 200)
+  @JSONSchema({description: 'Free-text search over FAQ questions and answers.'})
+  search?: string;
+
+  @IsOptional()
+  @IsEnum(FAQCategory)
+  @JSONSchema({
+    description: 'Restrict results to a single FAQ category.',
+    enum: Object.values(FAQCategory),
+  })
+  category?: FAQCategory;
+}
+
+export class AdminDashboardQuery {
+  @IsOptional()
+  @IsMongoId()
+  @JSONSchema({description: 'Restrict dashboard stats to a single course.'})
+  courseId?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @JSONSchema({
+    description: 'Start of the reporting window (ISO 8601).',
+    example: '2026-08-01T00:00:00.000Z',
+  })
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @JSONSchema({
+    description: 'End of the reporting window (ISO 8601).',
+    example: '2026-08-14T00:00:00.000Z',
+  })
+  endDate?: string;
+}
+
+export class AdminQuestionsQuery {
+  @IsOptional()
+  @IsIn([...QUESTION_STATUSES])
+  @JSONSchema({
+    description: 'Filter questions by status.',
+    enum: [...QUESTION_STATUSES],
+  })
+  status?: QuestionStatusLiteral;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @JSONSchema({description: '1-indexed page number.', default: 1})
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  @JSONSchema({description: 'Page size (1-200).', default: 50})
+  limit?: number;
+
+  @IsOptional()
+  @IsMongoId()
+  @JSONSchema({description: 'Restrict results to a single course.'})
+  courseId?: string;
+}
+
+export class AdminResponseBody {
+  @IsString()
+  @IsNotEmpty()
+  @Length(10, 5000)
+  @JSONSchema({
+    description: 'The admin answer sent back to the learner (10-5000 characters).',
+  })
+  response!: string;
+
+  @IsOptional()
+  @IsBoolean()
+  @JSONSchema({
+    description: 'Promote this answer into the FAQ bank as well.',
+    default: false,
+  })
+  createFaq?: boolean;
+
+  @IsOptional()
+  @IsEnum(FAQCategory)
+  @JSONSchema({
+    description: 'Category for the FAQ created from this response.',
+    enum: Object.values(FAQCategory),
+  })
+  faqCategory?: FAQCategory;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({each: true})
+  @JSONSchema({description: 'Tags for the FAQ created from this response.'})
+  faqTags?: string[];
+}
+
+export class FAQPathParams {
+  @IsMongoId()
+  @JSONSchema({description: 'FAQ id.'})
+  faqId!: string;
+}
+
+export class AdminFAQListQuery {
+  @IsOptional()
+  @IsEnum(FAQCategory)
+  @JSONSchema({
+    description: 'Restrict results to a single FAQ category.',
+    enum: Object.values(FAQCategory),
+  })
+  category?: FAQCategory;
+}
+
+export class CreateFAQBody {
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 500)
+  @JSONSchema({description: 'The FAQ question (3-500 characters).'})
+  question!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 5000)
+  @JSONSchema({description: 'The FAQ answer (3-5000 characters).'})
+  answer!: string;
+
+  @IsEnum(FAQCategory)
+  @JSONSchema({
+    description: 'FAQ category.',
+    enum: Object.values(FAQCategory),
+  })
+  category!: FAQCategory;
+
+  @IsArray()
+  @IsString({each: true})
+  @JSONSchema({description: 'Tags used to help retrieval.'})
+  tags!: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  @JSONSchema({description: 'Whether the FAQ is eligible for retrieval.', default: true})
+  isActive?: boolean;
+
+  @IsOptional()
+  @IsEnum(FAQSource)
+  @JSONSchema({
+    description: 'How this FAQ came to exist.',
+    enum: Object.values(FAQSource),
+  })
+  source?: FAQSource;
+}
+
+export class UpdateFAQBody {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 500)
+  @JSONSchema({description: 'The FAQ question (3-500 characters).'})
+  question?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 5000)
+  @JSONSchema({description: 'The FAQ answer (3-5000 characters).'})
+  answer?: string;
+
+  @IsOptional()
+  @IsEnum(FAQCategory)
+  @JSONSchema({
+    description: 'FAQ category.',
+    enum: Object.values(FAQCategory),
+  })
+  category?: FAQCategory;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({each: true})
+  @JSONSchema({description: 'Tags used to help retrieval.'})
+  tags?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  @JSONSchema({description: 'Whether the FAQ is eligible for retrieval.'})
+  isActive?: boolean;
+}

--- a/backend/src/modules/supportChat/container.ts
+++ b/backend/src/modules/supportChat/container.ts
@@ -1,0 +1,28 @@
+import { ContainerModule } from 'inversify';
+import { SUPPORT_CHAT_TYPES } from './types.js';
+import { FAQRepository, SupportQuestionRepository } from './repositories/providers/mongodb/index.js';
+import { ChatService, FAQRetrievalService, AdminService } from './services/index.js';
+import { ChatController, AdminController } from './controllers/index.js';
+
+export const supportChatContainerModule = new ContainerModule(options => {
+  // Repositories
+  options.bind(FAQRepository).toSelf().inSingletonScope();
+  options.bind(SUPPORT_CHAT_TYPES.FAQRepo).to(FAQRepository);
+
+  options.bind(SupportQuestionRepository).toSelf().inSingletonScope();
+  options.bind(SUPPORT_CHAT_TYPES.SupportQuestionRepo).to(SupportQuestionRepository);
+
+  // Services
+  options.bind(FAQRetrievalService).toSelf().inSingletonScope();
+  options.bind(SUPPORT_CHAT_TYPES.FAQRetrievalService).to(FAQRetrievalService);
+
+  options.bind(ChatService).toSelf().inSingletonScope();
+  options.bind(SUPPORT_CHAT_TYPES.ChatService).to(ChatService);
+
+  options.bind(AdminService).toSelf().inSingletonScope();
+  options.bind(SUPPORT_CHAT_TYPES.AdminService).to(AdminService);
+
+  // Controllers
+  options.bind(ChatController).toSelf().inSingletonScope();
+  options.bind(AdminController).toSelf().inSingletonScope();
+});

--- a/backend/src/modules/supportChat/controllers/AdminController.ts
+++ b/backend/src/modules/supportChat/controllers/AdminController.ts
@@ -1,0 +1,131 @@
+import { inject, injectable } from 'inversify';
+import {
+  JsonController,
+  Post,
+  Get,
+  Put,
+  Delete,
+  Body,
+  Params,
+  QueryParams,
+  Authorized,
+  CurrentUser,
+} from 'routing-controllers';
+import { ObjectId } from 'mongodb';
+import { SUPPORT_CHAT_TYPES } from '../types.js';
+import { AdminService } from '../services/index.js';
+import {
+  AdminDashboardQuery,
+  AdminFAQListQuery,
+  AdminQuestionsQuery,
+  AdminResponseBody,
+  CreateFAQBody,
+  FAQPathParams,
+  SupportQuestionPathParams,
+  UpdateFAQBody,
+} from '../classes/validators/SupportChatValidators.js';
+
+@JsonController('/api/admin/support')
+@injectable()
+export class AdminController {
+  constructor(@inject(SUPPORT_CHAT_TYPES.AdminService) private adminService: AdminService) {}
+
+  @Get('/dashboard')
+  @Authorized()
+  async getDashboard(@QueryParams() query: AdminDashboardQuery) {
+    const courseId = query.courseId ? new ObjectId(query.courseId) : undefined;
+    const startDate = query.startDate ? new Date(query.startDate) : undefined;
+    const endDate = query.endDate ? new Date(query.endDate) : undefined;
+
+    const stats = await this.adminService.getDashboardStats(courseId, startDate, endDate);
+    const pendingQuestions = await this.adminService.getPendingQuestions(courseId, 10);
+
+    return {
+      stats,
+      recentPending: pendingQuestions,
+    };
+  }
+
+  @Get('/questions')
+  @Authorized()
+  async getQuestions(@QueryParams() query: AdminQuestionsQuery) {
+    const limit = query.limit ?? 50;
+    const courseId = query.courseId ? new ObjectId(query.courseId) : undefined;
+
+    const questions = await this.adminService.getPendingQuestions(courseId, limit);
+
+    return {
+      questions,
+      total: questions.length,
+    };
+  }
+
+  @Post('/questions/:questionId/respond')
+  @Authorized()
+  async respondToQuestion(
+    @CurrentUser() user: any,
+    @Params() params: SupportQuestionPathParams,
+    @Body() request: AdminResponseBody
+  ) {
+    const qId = new ObjectId(params.questionId);
+    const adminUserId = new ObjectId(user.id);
+
+    return await this.adminService.respondToQuestion(qId, adminUserId, request);
+  }
+
+  @Put('/questions/:questionId/resolve')
+  @Authorized()
+  async resolveQuestion(@Params() params: SupportQuestionPathParams) {
+    const qId = new ObjectId(params.questionId);
+    return await this.adminService.markQuestionResolved(qId);
+  }
+
+  @Get('/faqs')
+  @Authorized()
+  async getFAQs(@QueryParams() query: AdminFAQListQuery) {
+    const faqs = await this.adminService.getAllFAQs(query.category);
+
+    return {
+      faqs,
+      total: faqs.length,
+    };
+  }
+
+  @Post('/faqs')
+  @Authorized()
+  async createFAQ(@CurrentUser() user: any, @Body() faq: CreateFAQBody) {
+    const adminUserId = new ObjectId(user.id);
+    return await this.adminService.createFAQ(
+      {
+        ...faq,
+        upvotes: 0,
+        downvotes: 0,
+        usageCount: 0,
+        isActive: faq.isActive !== false,
+      },
+      adminUserId
+    );
+  }
+
+  @Put('/faqs/:faqId')
+  @Authorized()
+  async updateFAQ(
+    @Params() params: FAQPathParams,
+    @Body() updates: UpdateFAQBody
+  ) {
+    const id = new ObjectId(params.faqId);
+    return await this.adminService.updateFAQ(id, updates);
+  }
+
+  @Delete('/faqs/:faqId')
+  @Authorized()
+  async deleteFAQ(@Params() params: FAQPathParams) {
+    const id = new ObjectId(params.faqId);
+    const deleted = await this.adminService.deleteFAQ(id);
+
+    return {
+      success: deleted,
+      message: deleted ? 'FAQ deleted successfully' : 'FAQ not found',
+    };
+  }
+}

--- a/backend/src/modules/supportChat/controllers/ChatController.ts
+++ b/backend/src/modules/supportChat/controllers/ChatController.ts
@@ -1,0 +1,133 @@
+import { inject, injectable } from 'inversify';
+import {
+  JsonController,
+  Post,
+  Get,
+  Patch,
+  Body,
+  Params,
+  QueryParams,
+  Authorized,
+  CurrentUser,
+  ForbiddenError,
+  NotFoundError,
+} from 'routing-controllers';
+import { ObjectId } from 'mongodb';
+import { ChatMessageResponse, SUPPORT_CHAT_TYPES } from '../types.js';
+import { ChatService } from '../services/index.js';
+import {
+  ChatHistoryQuery,
+  ChatMessageBody,
+  ChatMessageQuery,
+  FAQSearchQuery,
+  RateQuestionBody,
+  SupportQuestionPathParams,
+} from '../classes/validators/SupportChatValidators.js';
+
+@JsonController('/api/support/chat')
+@injectable()
+export class ChatController {
+  constructor(@inject(SUPPORT_CHAT_TYPES.ChatService) private chatService: ChatService) {}
+
+  @Post('/message')
+  @Authorized()
+  async sendMessage(
+    @CurrentUser() user: any,
+    @Body() messageRequest: ChatMessageBody,
+    @QueryParams() query: ChatMessageQuery
+  ): Promise<ChatMessageResponse> {
+    const userId = new ObjectId(user.id);
+    const courseId = query.courseId ? new ObjectId(query.courseId) : undefined;
+    const courseVersionId = query.courseVersionId ? new ObjectId(query.courseVersionId) : undefined;
+    const cohortId = query.cohortId ? new ObjectId(query.cohortId) : undefined;
+
+    return this.chatService.handleUserQuestion(
+      userId,
+      {
+        question: messageRequest.question,
+        context: messageRequest.context
+          ? {
+              page: messageRequest.context.page,
+              itemId: messageRequest.context.itemId
+                ? new ObjectId(messageRequest.context.itemId)
+                : undefined,
+              module: messageRequest.context.module,
+            }
+          : undefined,
+      },
+      courseId,
+      courseVersionId,
+      cohortId
+    );
+  }
+
+  @Get('/history')
+  @Authorized()
+  async getHistory(
+    @CurrentUser() user: any,
+    @QueryParams() query: ChatHistoryQuery
+  ) {
+    const userId = new ObjectId(user.id);
+    const limit = query.limit ?? 50;
+
+    const questions = await this.chatService.getQuestionHistory(userId, limit);
+
+    return {
+      questions,
+      total: questions.length,
+    };
+  }
+
+  @Get('/faqs/search')
+  async searchFAQs(@QueryParams() query: FAQSearchQuery) {
+    // This would be implemented with FAQ retrieval and search logic
+    // For now, returning placeholder
+    return {
+      faqs: [],
+      total: 0,
+    };
+  }
+
+  @Get('/:questionId')
+  @Authorized()
+  async getQuestion(
+    @CurrentUser() user: any,
+    @Params() params: SupportQuestionPathParams
+  ) {
+    const qId = new ObjectId(params.questionId);
+    const question = await this.chatService.getQuestion(qId);
+
+    if (!question) {
+      throw new NotFoundError('Question not found');
+    }
+
+    // Verify ownership
+    if (question.userId.toString() !== user.id) {
+      throw new ForbiddenError('Unauthorized');
+    }
+
+    return question;
+  }
+
+  @Patch('/:questionId/rate')
+  @Authorized()
+  async rateQuestion(
+    @CurrentUser() user: any,
+    @Params() params: SupportQuestionPathParams,
+    @Body() body: RateQuestionBody
+  ) {
+    const qId2 = new ObjectId(params.questionId);
+    const question = await this.chatService.getQuestion(qId2);
+
+    if (!question) {
+      throw new NotFoundError('Question not found');
+    }
+
+    // Verify ownership
+    if (question.userId.toString() !== user.id) {
+      throw new ForbiddenError('Unauthorized');
+    }
+
+    return await this.chatService.rateResolution(qId2, body.rating);
+  }
+}

--- a/backend/src/modules/supportChat/controllers/index.ts
+++ b/backend/src/modules/supportChat/controllers/index.ts
@@ -1,0 +1,2 @@
+export { ChatController } from './ChatController.js';
+export { AdminController } from './AdminController.js';

--- a/backend/src/modules/supportChat/index.ts
+++ b/backend/src/modules/supportChat/index.ts
@@ -1,0 +1,75 @@
+import {Container, ContainerModule} from 'inversify';
+import {RoutingControllersOptions, useContainer} from 'routing-controllers';
+import {sharedContainerModule} from '#root/container.js';
+import {InversifyAdapter} from '#root/inversify-adapter.js';
+import {authContainerModule} from '../auth/container.js';
+import {supportChatContainerModule} from './container.js';
+import {AdminController, ChatController} from './controllers/index.js';
+import {
+  AdminDashboardQuery,
+  AdminFAQListQuery,
+  AdminQuestionsQuery,
+  AdminResponseBody,
+  ChatHistoryQuery,
+  ChatMessageBody,
+  ChatMessageQuery,
+  CreateFAQBody,
+  FAQPathParams,
+  FAQSearchQuery,
+  RateQuestionBody,
+  SupportChatContextDto,
+  SupportQuestionPathParams,
+  UpdateFAQBody,
+} from './classes/validators/SupportChatValidators.js';
+
+export const supportChatContainerModules: ContainerModule[] = [
+  supportChatContainerModule,
+  sharedContainerModule,
+  authContainerModule,
+];
+
+export const supportChatModuleControllers: Function[] = [
+  ChatController,
+  AdminController,
+];
+
+export async function setupSupportChatContainer(): Promise<void> {
+  const container = new Container();
+  await container.load(...supportChatContainerModules);
+  const inversifyAdapter = new InversifyAdapter(container);
+  useContainer(inversifyAdapter);
+}
+
+export const supportChatModuleOptions: RoutingControllersOptions = {
+  controllers: supportChatModuleControllers,
+  middlewares: [],
+  defaultErrorHandler: true,
+  authorizationChecker: async function () {
+    return true;
+  },
+  validation: true,
+};
+
+export const supportChatModuleValidators: Function[] = [
+  SupportChatContextDto,
+  ChatMessageBody,
+  ChatMessageQuery,
+  ChatHistoryQuery,
+  SupportQuestionPathParams,
+  RateQuestionBody,
+  FAQSearchQuery,
+  AdminDashboardQuery,
+  AdminQuestionsQuery,
+  AdminResponseBody,
+  FAQPathParams,
+  AdminFAQListQuery,
+  CreateFAQBody,
+  UpdateFAQBody,
+];
+
+export * from './classes/validators/SupportChatValidators.js';
+export * from './controllers/index.js';
+export * from './services/index.js';
+export * from './repositories/providers/mongodb/index.js';
+export * from './types.js';
+export * from './container.js';

--- a/backend/src/modules/supportChat/repositories/providers/mongodb/FAQRepository.ts
+++ b/backend/src/modules/supportChat/repositories/providers/mongodb/FAQRepository.ts
@@ -1,0 +1,120 @@
+import { inject, injectable } from 'inversify';
+import { Collection, ObjectId } from 'mongodb';
+import { IFAQ, SUPPORT_CHAT_CONFIG, FAQCategory } from '../../../types.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+
+@injectable()
+export class FAQRepository {
+  constructor(@inject(GLOBAL_TYPES.Database) private db: any) {}
+
+  private getCollection(): Collection<IFAQ> {
+    return this.db.collection(SUPPORT_CHAT_CONFIG.collectionsNames.faq);
+  }
+
+  async create(faq: Omit<IFAQ, '_id' | 'createdAt' | 'updatedAt'>): Promise<IFAQ> {
+    const collection = this.getCollection();
+    const now = new Date();
+    const document = {
+      ...faq,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const result = await collection.insertOne(document);
+
+    return {
+      ...document,
+      _id: result.insertedId,
+    } as IFAQ;
+  }
+
+  async findById(id: ObjectId): Promise<IFAQ | null> {
+    const collection = this.getCollection();
+    return collection.findOne({ _id: id });
+  }
+
+  async findAll(filters?: { isActive?: boolean; category?: FAQCategory }): Promise<IFAQ[]> {
+    const collection = this.getCollection();
+    const query: any = {};
+
+    if (filters?.isActive !== undefined) {
+      query.isActive = filters.isActive;
+    }
+    if (filters?.category) {
+      query.category = filters.category;
+    }
+
+    return collection.find(query).toArray();
+  }
+
+  async updateById(id: ObjectId, updates: Partial<IFAQ>): Promise<IFAQ | null> {
+    const collection = this.getCollection();
+    const result = await collection.findOneAndUpdate(
+      { _id: id },
+      {
+        $set: {
+          ...updates,
+          updatedAt: new Date(),
+        },
+      },
+      { returnDocument: 'after' }
+    );
+
+    return result as IFAQ | null;
+  }
+
+  async incrementUsageCount(id: ObjectId): Promise<void> {
+    const collection = this.getCollection();
+    await collection.updateOne({ _id: id }, { $inc: { usageCount: 1 } });
+  }
+
+  async deleteById(id: ObjectId): Promise<boolean> {
+    const collection = this.getCollection();
+    const result = await collection.deleteOne({ _id: id });
+    return result.deletedCount === 1;
+  }
+
+  async search(query: string, limit: number = 10): Promise<IFAQ[]> {
+    const collection = this.getCollection();
+    return collection
+      .find({
+        isActive: true,
+        $text: { $search: query },
+      })
+      .limit(limit)
+      .toArray();
+  }
+
+  async findByCategory(category: FAQCategory): Promise<IFAQ[]> {
+    const collection = this.getCollection();
+    return collection.find({ category, isActive: true }).toArray();
+  }
+
+  async findByTag(tag: string): Promise<IFAQ[]> {
+    const collection = this.getCollection();
+    return collection.find({ tags: tag, isActive: true }).toArray();
+  }
+
+  async findRelated(faqId: ObjectId): Promise<IFAQ[]> {
+    const collection = this.getCollection();
+    const faq = await this.findById(faqId);
+    if (!faq?.relatedFaqIds || faq.relatedFaqIds.length === 0) {
+      return [];
+    }
+
+    return collection
+      .find({
+        _id: { $in: faq.relatedFaqIds },
+        isActive: true,
+      })
+      .toArray();
+  }
+
+  async createIndex(): Promise<void> {
+    const collection = this.getCollection();
+    await collection.createIndex({ category: 1, isActive: 1 });
+    await collection.createIndex({ tags: 1 });
+    await collection.createIndex({ createdAt: -1 });
+    await collection.createIndex({ question: 'text', answer: 'text' });
+  }
+}

--- a/backend/src/modules/supportChat/repositories/providers/mongodb/SupportQuestionRepository.ts
+++ b/backend/src/modules/supportChat/repositories/providers/mongodb/SupportQuestionRepository.ts
@@ -1,0 +1,216 @@
+import { inject, injectable } from 'inversify';
+import { Collection, ObjectId } from 'mongodb';
+import { ISupportQuestion, SUPPORT_CHAT_CONFIG, SupportQuestionStatus, ResolutionRating } from '../../../types.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+
+@injectable()
+export class SupportQuestionRepository {
+  constructor(@inject(GLOBAL_TYPES.Database) private db: any) {}
+
+  private getCollection(): Collection<ISupportQuestion> {
+    return this.db.collection(SUPPORT_CHAT_CONFIG.collectionsNames.questions);
+  }
+
+  async create(question: Omit<ISupportQuestion, '_id' | 'createdAt' | 'updatedAt'>): Promise<ISupportQuestion> {
+    const collection = this.getCollection();
+    const now = new Date();
+    const document = {
+      ...question,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const result = await collection.insertOne(document);
+
+    return {
+      ...document,
+      _id: result.insertedId,
+    } as ISupportQuestion;
+  }
+
+  async findById(id: ObjectId): Promise<ISupportQuestion | null> {
+    const collection = this.getCollection();
+    return collection.findOne({ _id: id });
+  }
+
+  async findByUserId(userId: ObjectId, limit: number = 50): Promise<ISupportQuestion[]> {
+    const collection = this.getCollection();
+    return collection
+      .find({ userId })
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .toArray();
+  }
+
+  async findByCourseId(courseId: ObjectId, filters?: { status?: SupportQuestionStatus }): Promise<ISupportQuestion[]> {
+    const collection = this.getCollection();
+    const query: any = { courseId };
+
+    if (filters?.status) {
+      query.status = filters.status;
+    }
+
+    return collection.find(query).sort({ createdAt: -1 }).toArray();
+  }
+
+  async findByStatus(status: SupportQuestionStatus, limit: number = 50): Promise<ISupportQuestion[]> {
+    const collection = this.getCollection();
+    return collection
+      .find({ status })
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .toArray();
+  }
+
+  async findPending(limit: number = 50): Promise<ISupportQuestion[]> {
+    return this.findByStatus(SupportQuestionStatus.PENDING, limit);
+  }
+
+  async updateById(id: ObjectId, updates: Partial<ISupportQuestion>): Promise<ISupportQuestion | null> {
+    const collection = this.getCollection();
+    const result = await collection.findOneAndUpdate(
+      { _id: id },
+      {
+        $set: {
+          ...updates,
+          updatedAt: new Date(),
+        },
+      },
+      { returnDocument: 'after' }
+    );
+
+    return result as ISupportQuestion | null;
+  }
+
+  async updateStatus(id: ObjectId, status: SupportQuestionStatus): Promise<ISupportQuestion | null> {
+    return this.updateById(id, { status });
+  }
+
+  async setAdminResponse(
+    id: ObjectId,
+    response: string,
+    respondedByUserId: ObjectId
+  ): Promise<ISupportQuestion | null> {
+    const collection = this.getCollection();
+    const result = await collection.findOneAndUpdate(
+      { _id: id },
+      {
+        $set: {
+          adminResponse: {
+            respondedBy: respondedByUserId,
+            response,
+            responseAt: new Date(),
+          },
+          status: SupportQuestionStatus.ANSWERED,
+          updatedAt: new Date(),
+        },
+      },
+      { returnDocument: 'after' }
+    );
+
+    return result as ISupportQuestion | null;
+  }
+
+  async setFaqMatch(id: ObjectId, faqId: ObjectId, confidence: number): Promise<ISupportQuestion | null> {
+    return this.updateById(id, {
+      matchedFaqId: faqId,
+      confidenceScore: confidence,
+      status: SupportQuestionStatus.ANSWERED,
+    });
+  }
+
+  async linkFaqCreated(id: ObjectId, faqId: ObjectId): Promise<ISupportQuestion | null> {
+    return this.updateById(id, { faqCreatedFromThis: faqId });
+  }
+
+  async setResolutionRating(id: ObjectId, rating: 'helpful' | 'not_helpful'): Promise<ISupportQuestion | null> {
+    const resolutionRating =
+      rating === 'helpful' ? ResolutionRating.HELPFUL : ResolutionRating.NOT_HELPFUL;
+    return this.updateById(id, { resolutionRating });
+  }
+
+  async markAsSeenByLearner(id: ObjectId): Promise<ISupportQuestion | null> {
+    return this.updateById(id, { learnersSeenResponse: true });
+  }
+
+  async getStats(courseId?: ObjectId, startDate?: Date, endDate?: Date): Promise<{
+    total: number;
+    byStatus: Record<string, number>;
+    avgResolutionTime: number;
+  }> {
+    const collection = this.getCollection();
+
+    const matchStage: any = {};
+    if (courseId) {
+      matchStage.courseId = courseId;
+    }
+    if (startDate || endDate) {
+      matchStage.createdAt = {};
+      if (startDate) matchStage.createdAt.$gte = startDate;
+      if (endDate) matchStage.createdAt.$lte = endDate;
+    }
+
+    const stats = await collection
+      .aggregate([
+        { $match: matchStage },
+        {
+          $group: {
+            _id: null,
+            total: { $sum: 1 },
+            pending: {
+              $sum: { $cond: [{ $eq: ['$status', SupportQuestionStatus.PENDING] }, 1, 0] },
+            },
+            answered: {
+              $sum: { $cond: [{ $eq: ['$status', SupportQuestionStatus.ANSWERED] }, 1, 0] },
+            },
+            resolved: {
+              $sum: { $cond: [{ $eq: ['$status', SupportQuestionStatus.RESOLVED] }, 1, 0] },
+            },
+            avgResolutionTime: {
+              $avg: {
+                $cond: [
+                  { $ne: ['$adminResponse', null] },
+                  {
+                    $subtract: ['$adminResponse.responseAt', '$createdAt'],
+                  },
+                  null,
+                ],
+              },
+            },
+          },
+        },
+      ])
+      .toArray();
+
+    if (stats.length === 0) {
+      return {
+        total: 0,
+        byStatus: {
+          [SupportQuestionStatus.PENDING]: 0,
+          [SupportQuestionStatus.ANSWERED]: 0,
+          [SupportQuestionStatus.RESOLVED]: 0,
+        },
+        avgResolutionTime: 0,
+      };
+    }
+
+    const result = stats[0];
+    return {
+      total: result.total,
+      byStatus: {
+        [SupportQuestionStatus.PENDING]: result.pending,
+        [SupportQuestionStatus.ANSWERED]: result.answered,
+        [SupportQuestionStatus.RESOLVED]: result.resolved,
+      },
+      avgResolutionTime: Math.floor(result.avgResolutionTime / (1000 * 60)) || 0,
+    };
+  }
+
+  async createIndex(): Promise<void> {
+    const collection = this.getCollection();
+    await collection.createIndex({ userId: 1, createdAt: -1 });
+    await collection.createIndex({ status: 1, createdAt: -1 });
+    await collection.createIndex({ courseId: 1, status: 1 });
+    await collection.createIndex({ createdAt: -1 });
+  }
+}

--- a/backend/src/modules/supportChat/repositories/providers/mongodb/index.ts
+++ b/backend/src/modules/supportChat/repositories/providers/mongodb/index.ts
@@ -1,0 +1,2 @@
+export { FAQRepository } from './FAQRepository.js';
+export { SupportQuestionRepository } from './SupportQuestionRepository.js';

--- a/backend/src/modules/supportChat/seeds/seedFAQs.ts
+++ b/backend/src/modules/supportChat/seeds/seedFAQs.ts
@@ -1,0 +1,342 @@
+import { MongoClient, ObjectId } from 'mongodb';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env' });
+
+const FAQ_COLLECTION_NAME = process.env.MONGODB_FAQ_COLLECTION || 'supportFaqs';
+
+const FAQS = [
+  {
+    question: 'How do I log in to ViBe?',
+    answer: `Sign up as a student with the registered mail ID into the ViBe platform. To log in to the ViBe platform, follow the steps below carefully:
+
+1. Log in to the ViBe platform as a student from registered email ID
+2. Check the "Notifications" tab in the Top right side of the Dashboard.
+3. Accept the course invite sent for your respective MERN Course.
+
+⚠️ Logging in with a different email ID may result in access issues or missing course visibility.
+
+Link for the website: https://vibe.vicharanashala.ai/auth`,
+    category: 'getting-started',
+    tags: ['login', 'authentication', 'signup'],
+  },
+  {
+    question: 'Why are videos stuck or repeating?',
+    answer: `This may happen due to ViBe's monitored learning system. Common reasons include:
+
+- Videos must be watched fully and in sequence (no skipping).
+- Camera and microphone permissions must be enabled.
+- Poor lighting or high background noise can affect playback.
+- Switching tabs or staying idle may restart the video.
+
+✅ For smooth playback, stay on the ViBe tab, keep your camera on, and watch videos in a quiet, well-lit environment.`,
+    category: 'troubleshooting',
+    tags: ['video', 'playback', 'stuck', 'looping'],
+  },
+  {
+    question: 'I\'m experiencing video issues (stuck, looping, skipping) on ViBe. How do I troubleshoot?',
+    answer: `Try these troubleshooting steps in order:
+
+1. Refresh the page and check multiple times
+2. Inspect browser console: Right-click → Inspect → Go to Network or Console tab → Try watching the video and check for any visible errors
+3. Log out and log in again
+4. Use a different browser
+5. Clear browsing data and cache, then try to re-login
+
+If the issue persists after trying all steps, record the issue and describe it to Yaksha in the chat — Yaksha will escalate it to the team.`,
+    category: 'troubleshooting',
+    tags: ['video', 'browser', 'cache', 'debugging'],
+  },
+  {
+    question: 'I have completed all videos and quizzes in the ViBe course, but my progress is still showing less than 100%. What should I do?',
+    answer: `Please do not worry. This might be a skip made in the quiz/video item due to penalty score as the quiz/video item might not have been successfully completed/marked. Please verify that you've completed all the course items (1006/1006). If not, please retry the missed contents again.
+
+In the meantime, you may try the following steps once:
+
+1. Refresh your browser
+2. Log out, clear your browser cache, and log in again`,
+    category: 'progress',
+    tags: ['completion', 'progress', 'quiz', 'video'],
+  },
+  {
+    question: 'I feel the ViBe content or platform is not good or I am unhappy with the way progress is evaluated. Can I request an exception or bypass the system?',
+    answer: `ViBe is built and continuously improved by interns and students themselves. It is a free and open-source learning platform, and our goal is to keep it that way by encouraging the community to actively contribute, improve, and strengthen it rather than bypass it.
+
+If a learner strongly feels that the regular ViBe flow does not fairly reflect their understanding, there is a formal alternative evaluation path. However, this path is intentionally rigorous to ensure fairness for everyone.
+
+In such cases, you will be asked to:
+
+1. Watch the specified YouTube video content completely (links will be provided).
+2. Appear for a three-hour proctored examination based only on that content.
+3. Write the exam under strict supervision with:
+   - Two cameras (front and side view), and
+   - One online human proctor monitoring you live.
+
+This examination becomes the sole basis for evaluation in place of the regular internship track.
+
+The scoring rules are strict:
+
+- Score below 60%: You are considered not qualified and must join the next cohort and continue only through the normal ViBe mode.
+- Score between 60% and 80%: You get one more chance in the next scheduled exam.
+- Score above 80%: You are considered to have passed.
+
+This special exam is conducted once every fortnight, so choosing this route may significantly delay your progress compared to continuing normally on ViBe.
+
+Because this path is far more demanding and time-consuming than simply completing the regular videos, quizzes, and activities, most students find that continuing with the standard ViBe workflow is the faster and better option.`,
+    category: 'evaluation',
+    tags: ['exception', 'proctored', 'evaluation', 'alternative'],
+  },
+  {
+    question: 'Is the ViBe consent form compulsory? What if I don\'t want to grant camera access?',
+    answer: `Yes — the consent form is compulsory.
+
+We would like to clearly inform you that providing consent is a mandatory requirement for any candidate enrolling in and continuing a course on the ViBe Learning Platform.
+
+The platform is designed with proctoring enabled throughout the learning process, which requires access to your webcam and microphone. This is essential to ensure:
+
+- Fairness across all participants
+- Academic integrity
+- Active and genuine participation
+
+If you choose not to grant camera and microphone access, you will not be able to proceed with the course, as proctoring is an integral part of the learning and evaluation workflow.
+
+**Privacy & Monitoring Clarification**
+
+As outlined in the consent form:
+
+- ViBe does not continuously record videos.
+- Proctoring operates via real-time monitoring mechanisms during learning and assessments.
+- All data is handled strictly in accordance with the stated consent terms and applicable data-protection guidelines.
+
+In short, consent is not optional — it is a core requirement for participation on the platform.`,
+    category: 'privacy',
+    tags: ['consent', 'camera', 'proctoring', 'privacy'],
+  },
+  {
+    question: 'What are penalty scores on the ViBe platform, and how do they affect our performance or HP?',
+    answer: `Penalty scores are generated when anomalies are detected during your activity on the ViBe platform (for example, irregular behavior while watching video lessons or attempting quizzes).
+
+If the penalty score becomes high, you may be required to:
+
+1. Rewatch the video lesson, and
+2. Retake the associated quiz.
+
+At present, these penalty scores do not impact your HP (Health Points) or overall performance evaluation, as they are not being considered for scoring. Their primary purpose is to ensure proper engagement with the learning content.`,
+    category: 'scoring',
+    tags: ['penalty', 'score', 'hp', 'performance'],
+  },
+  {
+    question: 'When should I use the Flag option on ViBe, and when should I contact support?',
+    answer: `Use the Flag feature on ViBe only for course content-related issues, such as problems with video content or quiz questions.
+
+For technical issues, platform errors, login problems, or logistics-related queries, do not use the flag option. Instead, contact Yaksha so the team can assist you faster.
+
+Using the correct method helps resolve issues quickly and keeps the learning process smooth for everyone.`,
+    category: 'support',
+    tags: ['flag', 'support', 'contact', 'issue'],
+  },
+  {
+    question: 'What is Linear Progression on ViBe?',
+    answer: `Linear progression is enabled for every course on ViBe. This means each learner must watch the videos and attempt the quizzes in the exact order they appear on the left panel of the course page.
+
+In practice:
+
+- You cannot click on a video or quiz that lies far ahead of your current position.
+- You must complete each item before the next one unlocks.
+- Skipping videos or quizzes is not allowed by design.
+- Progress is sequential — finish the item in front of you, and the next one opens up automatically.`,
+    category: 'learning',
+    tags: ['progression', 'sequential', 'order', 'unlocking'],
+  },
+  {
+    question: 'I am seeing a red "Access Restricted" banner. Is this a bug?',
+    answer: `No, this is not a bug. The red Access Restricted banner is an intentional alert from the platform.
+
+The banner looks like this: a red toast notification with an exclamation icon, the title "Access Restricted", and the message "Returning to previous valid content." below it.
+
+It appears when you try to open an item (video or quiz) before completing all the items that come before it. If you are on the nth item but haven't completed every video and quiz from item 1 through item n−1, the platform will show this alert.
+
+When the banner appears, ViBe automatically returns you to the previous valid content — that is, the last item you had legitimately reached in the sequence. You will not lose any progress; you'll simply be sent back to where you actually are in the course.
+
+It is the system gently telling you: "Please check — there is something earlier in the course that you haven't finished yet."`,
+    category: 'learning',
+    tags: ['access', 'restricted', 'progression', 'error'],
+  },
+  {
+    question: 'Why does ViBe sometimes make me re-watch a clip after a quiz?',
+    answer: `If your answer to the check-in quiz didn't go through correctly, ViBe will take you back to the same clip and let you try again. This is called a re-watch, and it is part of the design — not a penalty.
+
+A few things to keep in mind:
+
+- Re-watches are not recorded against you. They do not affect your HP or evaluation.
+- The clips are short, so a re-watch usually costs less time than guessing through multiple retries.
+- Think of the re-watch as the platform helping the idea actually stick before you move on, rather than scolding you for getting it wrong.`,
+    category: 'learning',
+    tags: ['rewatch', 'quiz', 'reinforcement', 'learning'],
+  },
+  {
+    question: 'What kinds of quiz questions will I see on ViBe?',
+    answer: `ViBe quizzes come in four formats:
+
+1. **Pick one (MCQ)**: One right answer out of four or so options. Read all the options before clicking.
+2. **Pick one or more (MSQ)**: "Select all that apply" — could be one correct option or several. Read each option carefully; small mistakes happen here most.
+3. **Type a number (NAT)**: A text box asking for a numeric value. Type just the number — no units or extra symbols, unless the question explicitly asks.
+4. **True or False**: A statement with only two options — True or False. Read the statement carefully; a single word like "always," "never," or "only" can flip the correct answer.
+
+A small tip: watch the clip first, then answer. Trying to read the question while the clip is still playing splits your attention.`,
+    category: 'quiz',
+    tags: ['quiz', 'mcq', 'msq', 'nat', 'true-false'],
+  },
+  {
+    question: 'Are the same proctoring rules applied to every course on ViBe?',
+    answer: `No — and this is one of the most important things to understand before reading the rest of this section.
+
+ViBe's proctoring system is modular. Each individual check — face visibility, single-face-in-frame, lighting, background voices, gaze on screen, camera/microphone access — can be independently switched on or off by the instructor for a given course or cohort.
+
+This means:
+
+- The instructor decides which proctoring elements are active for their course.
+- Some courses may run with all checks active (typical for internships, faculty FDPs, and credentialed programmes).
+- Other courses may run with only a subset active — for example, face visibility on but background-voice detection off — depending on the learning context.
+- Certain pilot or open courses may have most proctoring relaxed, especially where the focus is exploration rather than verified evaluation.
+
+⚠️ Please do not assume rules carry across courses. A relaxation given in one course (for example, allowing two faces in frame for a paired-learning module) does not transfer to another course on the same platform. Always check the course-specific guidelines shared by your instructor or programme team before each course you join.
+
+When in doubt, ask your instructor or programme coordinator which proctoring elements are active for your current course.`,
+    category: 'proctoring',
+    tags: ['proctoring', 'rules', 'instructor', 'monitoring'],
+  },
+  {
+    question: 'What does the "quiet helper" on ViBe actually do?',
+    answer: `While a lesson plays, a small helper runs gently on your device using your camera and microphone. It checks, in real time, that the basic conditions for learning are present.
+
+Specifically, it looks at five things:
+
+1. A face is visible — to confirm you are really there.
+2. Only one face is in frame — to confirm the learning is yours.
+3. There is enough light on your face — a silhouette is hard to recognise.
+4. The room isn't full of voices — no talking, TV, or background podcasts.
+5. You are looking at the screen — brief glances away are fine; long stretches feel like drifting off.
+
+The helper is not a judge. Brief, normal movements (a stretch, a sneeze, a glance at your notebook) are absolutely fine. It only pays attention to sustained patterns, not split-second things.`,
+    category: 'proctoring',
+    tags: ['helper', 'monitoring', 'proctoring', 'realtime'],
+  },
+  {
+    question: 'Does ViBe record long videos of me while I\'m learning?',
+    answer: `No. ViBe does not continuously record videos of you.
+
+- The camera and microphone are used for real-time presence checks only.
+- Long recordings of your face or voice are not stored.
+- When the lesson ends, the helper goes quiet too.
+- All data is handled strictly in accordance with the consent terms shown when you signed up.
+
+Think of the helper as a quiet study partner sitting beside you — there if needed, invisible otherwise.`,
+    category: 'privacy',
+    tags: ['recording', 'privacy', 'data', 'camera'],
+  },
+  {
+    question: 'Why does the lesson keep pausing or restarting even when I\'m paying attention?',
+    answer: `If a clip keeps stopping or going back to the start, the cause is almost always something small in your environment, not the platform itself. Run through this checklist:
+
+1. Your face is too dark → add a lamp in front of you.
+2. Your face is partly out of frame → raise the laptop or sit a bit closer to the camera.
+3. There are voices in the background → close the door, or move to a quieter room.
+4. You switched tabs or went idle → stay on the ViBe tab; take breaks between clips, not during them.
+5. Camera or mic permission dropped → check the lock icon in your browser's address bar and confirm both are set to "Allow".`,
+    category: 'troubleshooting',
+    tags: ['pausing', 'restarting', 'environment', 'checklist'],
+  },
+  {
+    question: 'Can I study with a friend on camera since we\'re learning together?',
+    answer: `In most courses, no. Only you — the registered Learner — should be in the camera frame during a lesson. The helper checks that exactly one face is visible at a time.
+
+Group study is genuinely a wonderful habit, just not inside a ViBe session itself. A good way to do it:
+
+1. Hop on a separate call with your friend on your phone or a second device.
+2. Discuss concepts before or after a ViBe lesson, not during it.
+3. Return to ViBe alone when you're ready to watch the clip and attempt the quiz.
+
+📌 **Note**: As explained in section 13.17, the single-face-in-frame check is an instructor-controlled setting. A few courses (typically paired-learning or collaborative pilots) may explicitly relax this rule. Do not assume that relaxation in one course applies to another — even on the same platform with the same login. Always default to studying alone unless your instructor has clearly stated otherwise for that specific course.`,
+    category: 'learning',
+    tags: ['groupstudy', 'collaborative', 'camera', 'friends'],
+  },
+  {
+    question: 'Is there a recommended daily learning rhythm on ViBe?',
+    answer: `Yes — small, regular sessions work far better than long marathon sessions. A practical rhythm:
+
+- Show up daily, even if only for thirty minutes. Daily consistency beats a five-hour weekend cram.
+- Take breaks between clips, not during them. A clip is short — finish it first.
+- Treat each quiz as a gentle check-in, not a high-stakes test.
+- For programmes with deadlines (such as internships or faculty cohorts), aim for the daily progress target announced by your programme team — typically around 3.33% per day.
+
+📌 **A note on milestones**: The pacing above is a general guideline only. For any specific programme (Vinternship cohort, faculty FDP, NPTEL internship, institutional pilot, etc.), the actual milestones, deadlines, and weekly progress targets will be announced by your instructors or programme team. Always follow the milestone schedule communicated for your specific cohort — that takes precedence over the general guidance here.`,
+    category: 'learning',
+    tags: ['rhythm', 'daily', 'consistency', 'pacing'],
+  },
+  {
+    question: 'What should my "study corner" look like before I start a ViBe session?',
+    answer: `A ViBe-friendly study spot needs only three things:
+
+1. **Light in front of your face** — a lamp or window facing you, never behind.
+2. **Just you in the camera frame** — ask family, friends, or pets not to wander through.
+3. **A reasonably quiet room** — no TV, no music with words, no one else on a call nearby.
+
+Two minutes of setup before you start saves a lot of small frustrations during the lesson.`,
+    category: 'setup',
+    tags: ['environment', 'lighting', 'sound', 'camera'],
+  },
+  {
+    question: 'I\'m facing a technical issue on ViBe that I can\'t resolve. Is there live support available?',
+    answer: `Yes. A Live Support Breakout Session is held every day from 9:00 PM to 9:30 PM, right after the daily standup. If you are facing any platform issue on ViBe — videos not loading, progress not updating, access errors, login problems, or anything else you cannot resolve on your own — join the breakout session and the support team will assist you in real time.
+
+This is the fastest way to get a ViBe issue resolved. Please attempt the self-troubleshooting steps in section 13.5 first, then bring the issue to the 9 PM session if it persists.`,
+    category: 'support',
+    tags: ['support', 'livehelp', 'breakout', 'assistance'],
+  },
+];
+
+async function seedFAQs() {
+  // Use the same connection string as the app
+  const uri = process.env.DB_URL || process.env.MONGODB_URI || 'mongodb://localhost:27017';
+  const dbName = process.env.DB_NAME || 'vibe';
+
+  console.log(`Connecting to: ${uri.substring(0, 50)}...`);
+  console.log(`Database: ${dbName}`);
+
+  const client = new MongoClient(uri);
+
+  try {
+    await client.connect();
+    console.log('Connected to MongoDB');
+
+    const db = client.db(dbName);
+    const collection = db.collection(FAQ_COLLECTION_NAME);
+
+    // Clear existing FAQs
+    await collection.deleteMany({});
+    console.log('Cleared existing FAQs');
+
+    // Insert FAQs without embeddings (they will be generated on first use)
+    const result = await collection.insertMany(
+      FAQS.map((faq) => ({
+        ...faq,
+        isActive: true,
+        upvotes: 0,
+        downvotes: 0,
+        usageCount: 0,
+        createdBy: new ObjectId(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }))
+    );
+
+    console.log(`✅ Successfully seeded ${result.insertedCount} FAQs`);
+  } catch (error) {
+    console.error('Error seeding FAQs:', error);
+  } finally {
+    await client.close();
+  }
+}
+
+seedFAQs();

--- a/backend/src/modules/supportChat/services/AdminService.ts
+++ b/backend/src/modules/supportChat/services/AdminService.ts
@@ -1,0 +1,180 @@
+import { inject, injectable } from 'inversify';
+import { ObjectId } from 'mongodb';
+import {
+  AdminResponseRequest,
+  IFAQ,
+  ISupportQuestion,
+  SupportQuestionStatus,
+  SUPPORT_CHAT_TYPES,
+  FAQCategory,
+  FAQSource,
+} from '../types.js';
+import { FAQRepository } from '../repositories/providers/mongodb/index.js';
+import { SupportQuestionRepository } from '../repositories/providers/mongodb/index.js';
+import { FAQRetrievalService } from './FAQRetrievalService.js';
+@injectable()
+export class AdminService {
+
+  constructor(
+    @inject(SUPPORT_CHAT_TYPES.FAQRepo) private faqRepo: FAQRepository,
+    @inject(SUPPORT_CHAT_TYPES.SupportQuestionRepo) private questionRepo: SupportQuestionRepository,
+    @inject(SUPPORT_CHAT_TYPES.FAQRetrievalService) private faqRetrieval: FAQRetrievalService
+  ) {}
+
+  async getPendingQuestions(courseId?: ObjectId, limit: number = 50): Promise<ISupportQuestion[]> {
+    try {
+      if (courseId) {
+        return await this.questionRepo.findByCourseId(courseId, {
+          status: SupportQuestionStatus.PENDING,
+        });
+      }
+      return await this.questionRepo.findPending(limit);
+    } catch (error) {
+      console.error('Error fetching pending questions', error);
+      throw error;
+    }
+  }
+
+  async respondToQuestion(
+    questionId: ObjectId,
+    adminUserId: ObjectId,
+    request: AdminResponseRequest
+  ): Promise<ISupportQuestion | null> {
+    try {
+      let faqId: ObjectId | undefined;
+
+      // Create FAQ if requested
+      if (request.createFaq) {
+        const question = await this.questionRepo.findById(questionId);
+        if (!question) {
+          throw new Error(`Question ${questionId} not found`);
+        }
+
+        const newFAQ = await this.faqRepo.create({
+          question: question.question,
+          answer: request.response,
+          category: request.faqCategory || FAQCategory.OTHER,
+          tags: request.faqTags || [],
+          embedding: await this.faqRetrieval.generateEmbeddingForFAQ({
+            question: question.question,
+            answer: request.response,
+          } as IFAQ),
+          upvotes: 0,
+          downvotes: 0,
+          usageCount: 0,
+          createdBy: adminUserId,
+          isActive: true,
+          source: FAQSource.ADMIN_RESPONSE,
+        });
+
+        faqId = newFAQ._id;
+
+        // Link FAQ to original question
+        await this.questionRepo.linkFaqCreated(questionId, newFAQ._id!);
+
+        console.log(`Created FAQ ${newFAQ._id} from question ${questionId}`);
+      }
+
+      // Set admin response on question
+      const updated = await this.questionRepo.setAdminResponse(
+        questionId,
+        request.response,
+        adminUserId
+      );
+
+      console.log(`Admin ${adminUserId} responded to question ${questionId}`);
+
+      return updated;
+    } catch (error) {
+      console.error('Error responding to question', error);
+      throw error;
+    }
+  }
+
+  async getDashboardStats(courseId?: ObjectId, startDate?: Date, endDate?: Date) {
+    try {
+      const stats = await this.questionRepo.getStats(courseId, startDate, endDate);
+
+      const allQuestions = courseId
+        ? await this.questionRepo.findByCourseId(courseId)
+        : await this.questionRepo.findByStatus(SupportQuestionStatus.ANSWERED);
+
+      const helpfulCount = allQuestions.filter((q) => q.resolutionRating === 'helpful').length;
+      const totalRated = allQuestions.filter((q) => q.resolutionRating).length;
+      const satisfactionRate = totalRated > 0 ? (helpfulCount / totalRated) * 100 : 0;
+
+      return {
+        totalQuestions: stats.total,
+        pending: stats.byStatus[SupportQuestionStatus.PENDING],
+        answered: stats.byStatus[SupportQuestionStatus.ANSWERED],
+        resolved: stats.byStatus[SupportQuestionStatus.RESOLVED],
+        avgResolutionTime: stats.avgResolutionTime,
+        satisfactionRate,
+      };
+    } catch (error) {
+      console.error('Error fetching dashboard stats', error);
+      throw error;
+    }
+  }
+
+  async getAllFAQs(category?: FAQCategory): Promise<IFAQ[]> {
+    try {
+      return await this.faqRepo.findAll({
+        isActive: true,
+        category,
+      });
+    } catch (error) {
+      console.error('Error fetching FAQs', error);
+      throw error;
+    }
+  }
+
+  async createFAQ(
+    faq: Omit<IFAQ, '_id' | 'createdAt' | 'updatedAt' | 'embedding' | 'createdBy'>,
+    adminUserId: ObjectId
+  ): Promise<IFAQ> {
+    try {
+      const embedding = await this.faqRetrieval.generateEmbeddingForFAQ(faq as IFAQ);
+
+      return await this.faqRepo.create({
+        ...faq,
+        embedding,
+        createdBy: adminUserId,
+      });
+    } catch (error) {
+      console.error('Error creating FAQ', error);
+      throw error;
+    }
+  }
+
+  async updateFAQ(faqId: ObjectId, updates: Partial<IFAQ>): Promise<IFAQ | null> {
+    try {
+      return await this.faqRepo.updateById(faqId, updates);
+    } catch (error) {
+      console.error('Error updating FAQ', error);
+      throw error;
+    }
+  }
+
+  async deleteFAQ(faqId: ObjectId): Promise<boolean> {
+    try {
+      const result = await this.faqRepo.deleteById(faqId);
+      if (result) {
+        console.log(`FAQ ${faqId} deleted`);
+      }
+      return result;
+    } catch (error) {
+      console.error('Error deleting FAQ', error);
+      throw error;
+    }
+  }
+
+  async markQuestionResolved(questionId: ObjectId): Promise<ISupportQuestion | null> {
+    try {
+      return await this.questionRepo.updateStatus(questionId, SupportQuestionStatus.RESOLVED);
+    } catch (error) {
+      console.error('Error marking question resolved', error);
+      throw error;
+    }
+  }
+}

--- a/backend/src/modules/supportChat/services/ChatService.ts
+++ b/backend/src/modules/supportChat/services/ChatService.ts
@@ -1,0 +1,112 @@
+import { inject, injectable } from 'inversify';
+import { ObjectId } from 'mongodb';
+import {
+  ChatMessageResponse,
+  ISupportQuestion,
+  SupportQuestionStatus,
+  SUPPORT_CHAT_TYPES,
+  ChatMessageRequest,
+} from '../types.js';
+import { FAQRetrievalService } from './FAQRetrievalService.js';
+import { FAQRepository } from '../repositories/providers/mongodb/index.js';
+import { SupportQuestionRepository } from '../repositories/providers/mongodb/index.js';
+@injectable()
+export class ChatService {
+
+  constructor(
+    @inject(SUPPORT_CHAT_TYPES.FAQRetrievalService) private faqRetrieval: FAQRetrievalService,
+    @inject(SUPPORT_CHAT_TYPES.FAQRepo) private faqRepo: FAQRepository,
+    @inject(SUPPORT_CHAT_TYPES.SupportQuestionRepo) private questionRepo: SupportQuestionRepository
+  ) {}
+
+  async handleUserQuestion(
+    userId: ObjectId,
+    messageRequest: ChatMessageRequest,
+    courseId?: ObjectId,
+    courseVersionId?: ObjectId,
+    cohortId?: ObjectId
+  ): Promise<ChatMessageResponse> {
+    try {
+      // Create question record
+      const question = await this.questionRepo.create({
+        userId,
+        courseId,
+        courseVersionId,
+        cohortId,
+        question: messageRequest.question,
+        context: messageRequest.context,
+        status: SupportQuestionStatus.PENDING,
+        learnersSeenResponse: false,
+      });
+
+      // Try to retrieve matching FAQ
+      const retrievalResult = await this.faqRetrieval.retrieveFAQ(messageRequest.question);
+
+      if (retrievalResult) {
+        // Update question with FAQ match
+        await this.questionRepo.setFaqMatch(
+          question._id!,
+          retrievalResult.faq._id!,
+          retrievalResult.score
+        );
+
+        // Increment FAQ usage count
+        await this.faqRepo.incrementUsageCount(retrievalResult.faq._id!);
+
+        return {
+          response: retrievalResult.faq.answer,
+          confidence: retrievalResult.score,
+          faqId: retrievalResult.faq._id,
+          isFromFAQ: true,
+          isEscalated: false,
+          questionId: question._id!,
+          source: `From our FAQ (Added on ${retrievalResult.faq.createdAt.toLocaleDateString()})`,
+        };
+      }
+
+      // No FAQ match - escalate to admin
+      return {
+        response: "I'm not sure about that. Let me connect you with our support team. They'll review your question and get back to you soon.",
+        confidence: 0,
+        isFromFAQ: false,
+        isEscalated: true,
+        questionId: question._id!,
+      };
+    } catch (error) {
+      console.error('Error handling user question', error);
+      throw error;
+    }
+  }
+
+  async getQuestionHistory(userId: ObjectId, limit: number = 50): Promise<ISupportQuestion[]> {
+    try {
+      return await this.questionRepo.findByUserId(userId, limit);
+    } catch (error) {
+      console.error('Error fetching question history', error);
+      throw error;
+    }
+  }
+
+  async getQuestion(questionId: ObjectId): Promise<ISupportQuestion | null> {
+    try {
+      return await this.questionRepo.findById(questionId);
+    } catch (error) {
+      console.error('Error fetching question', error);
+      throw error;
+    }
+  }
+
+  async rateResolution(
+    questionId: ObjectId,
+    rating: 'helpful' | 'not_helpful'
+  ): Promise<ISupportQuestion | null> {
+    try {
+      const updated = await this.questionRepo.setResolutionRating(questionId, rating);
+      console.log(`Question ${questionId} rated as ${rating}`);
+      return updated;
+    } catch (error) {
+      console.error('Error rating resolution', error);
+      throw error;
+    }
+  }
+}

--- a/backend/src/modules/supportChat/services/FAQRetrievalService.ts
+++ b/backend/src/modules/supportChat/services/FAQRetrievalService.ts
@@ -1,0 +1,161 @@
+import { inject, injectable } from 'inversify';
+import {
+  IFAQ,
+  FAQRetrievalResult,
+  SUPPORT_CHAT_CONFIG,
+  SUPPORT_CHAT_TYPES,
+} from '../types.js';
+import { FAQRepository } from '../repositories/providers/mongodb/index.js';
+@injectable()
+export class FAQRetrievalService {
+  private minimaxApiKey = process.env.MINIMAX_API_KEY;
+  private minimaxApiUrl = process.env.MINIMAX_API_URL || 'https://api.minimax.chat/v1';
+  private minimaxEmbeddingModel =
+    process.env.MINIMAX_EMBEDDING_MODEL || 'embo-01';
+
+  constructor(@inject(SUPPORT_CHAT_TYPES.FAQRepo) private faqRepo: FAQRepository) {
+    if (!this.minimaxApiKey) {
+      console.warn('MINIMAX_API_KEY not set - embedding generation will fail');
+    }
+  }
+
+  private cosineSimilarity(a: number[], b: number[]): number {
+    if (!a || !b || a.length !== b.length) return 0;
+
+    let dotProduct = 0;
+    let magnitudeA = 0;
+    let magnitudeB = 0;
+
+    for (let i = 0; i < a.length; i++) {
+      dotProduct += a[i] * b[i];
+      magnitudeA += a[i] * a[i];
+      magnitudeB += b[i] * b[i];
+    }
+
+    magnitudeA = Math.sqrt(magnitudeA);
+    magnitudeB = Math.sqrt(magnitudeB);
+
+    if (magnitudeA === 0 || magnitudeB === 0) return 0;
+
+    return dotProduct / (magnitudeA * magnitudeB);
+  }
+
+  private calculateKeywordOverlap(query: string, text: string): number {
+    const queryWords = query.toLowerCase().split(/\s+/);
+    const textWords = text.toLowerCase().split(/\s+/);
+
+    const matches = queryWords.filter((word) => textWords.some((tw) => tw.includes(word)));
+
+    return matches.length / Math.max(queryWords.length, 1);
+  }
+
+  async getEmbedding(text: string): Promise<number[]> {
+    try {
+      if (!this.minimaxApiKey) {
+        throw new Error('MINIMAX_API_KEY is not configured');
+      }
+
+      const response = await fetch(`${this.minimaxApiUrl}/embeddings`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.minimaxApiKey}`,
+        },
+        body: JSON.stringify({
+          model: this.minimaxEmbeddingModel,
+          input: text,
+          encoding_format: 'float',
+        }),
+      });
+
+      if (!response.ok) {
+        const error = (await response.json()) as { message?: string };
+        throw new Error(`Minimax API error: ${error?.message || response.statusText}`);
+      }
+
+      const data = (await response.json()) as { data?: Array<{ embedding: number[] }> };
+
+      // Minimax returns embeddings in data.data array
+      if (!data?.data || !Array.isArray(data.data) || data.data.length === 0) {
+        throw new Error('Invalid embedding response from Minimax');
+      }
+
+      return data.data[0].embedding;
+    } catch (error) {
+      console.error('Error getting embedding from Minimax', error);
+      throw error;
+    }
+  }
+
+  async retrieveFAQ(
+    question: string,
+    maxResults: number = SUPPORT_CHAT_CONFIG.maxSearchResults
+  ): Promise<FAQRetrievalResult | null> {
+    try {
+      // Get question embedding
+      const queryEmbedding = await this.getEmbedding(question);
+
+      // Fetch all active FAQs
+      const faqs = await this.faqRepo.findAll({ isActive: true });
+
+      if (faqs.length === 0) {
+        console.warn('No active FAQs found');
+        return null;
+      }
+
+      // Score each FAQ
+      const scored = faqs
+        .map((faq) => {
+          const similarity = faq.embedding ? this.cosineSimilarity(queryEmbedding, faq.embedding) : 0;
+
+          const keywordMatch = this.calculateKeywordOverlap(question, faq.question);
+
+          // Recency factor (newer = lower value = better score)
+          const daysSinceUpdate = (Date.now() - faq.updatedAt.getTime()) / (1000 * 60 * 60 * 24);
+          const recency = Math.min(daysSinceUpdate / 365, 1);
+
+          // Popularity factor (more usage = higher score boost)
+          const popularity = Math.min(faq.usageCount / 100, 0.5);
+
+          // Combined score: 70% semantic similarity + 20% keyword + 10% recency + popularity bonus
+          const score =
+            similarity * 0.7 + keywordMatch * 0.2 - recency * 0.1 + popularity * 0.0001;
+
+          return {
+            faq,
+            similarity,
+            recency,
+            popularity,
+            score,
+          };
+        })
+        .sort((a, b) => b.score - a.score)
+        .slice(0, maxResults);
+
+      if (!scored[0]) {
+        return null;
+      }
+
+      const topResult = scored[0];
+
+      if (topResult.score < SUPPORT_CHAT_CONFIG.confidenceThreshold) {
+        return null;
+      }
+
+      return topResult as FAQRetrievalResult;
+    } catch (error) {
+      console.error('Error retrieving FAQ', error);
+      throw error;
+    }
+  }
+
+  async generateEmbeddingForFAQ(faq: IFAQ): Promise<number[]> {
+    try {
+      const textToEmbed = `${faq.question} ${faq.answer}`;
+      return await this.getEmbedding(textToEmbed);
+    } catch (error) {
+      console.error('Error generating FAQ embedding', error);
+      throw error;
+    }
+  }
+}

--- a/backend/src/modules/supportChat/services/index.ts
+++ b/backend/src/modules/supportChat/services/index.ts
@@ -1,0 +1,3 @@
+export { ChatService } from './ChatService.js';
+export { FAQRetrievalService } from './FAQRetrievalService.js';
+export { AdminService } from './AdminService.js';

--- a/backend/src/modules/supportChat/types.ts
+++ b/backend/src/modules/supportChat/types.ts
@@ -1,0 +1,149 @@
+import { ObjectId } from 'mongodb';
+
+export const SUPPORT_CHAT_TYPES = {
+  FAQRepository: Symbol.for('FAQRepository'),
+  FAQRepo: Symbol.for('FAQRepository'),
+  SupportQuestionRepository: Symbol.for('SupportQuestionRepository'),
+  SupportQuestionRepo: Symbol.for('SupportQuestionRepository'),
+  FAQRetrievalService: Symbol.for('FAQRetrievalService'),
+  ChatService: Symbol.for('ChatService'),
+  AdminService: Symbol.for('AdminService'),
+};
+
+export enum FAQCategory {
+  LOGIN = 'login',
+  TECHNICAL = 'technical',
+  PROCTORING = 'proctoring',
+  FEATURES = 'features',
+  OTHER = 'other',
+}
+
+export enum SupportQuestionStatus {
+  PENDING = 'PENDING',
+  ANSWERED = 'ANSWERED',
+  RESOLVED = 'RESOLVED',
+  ESCALATED = 'ESCALATED',
+}
+
+export enum ResolutionRating {
+  HELPFUL = 'helpful',
+  NOT_HELPFUL = 'not_helpful',
+}
+
+export enum FAQSource {
+  ADMIN_RESPONSE = 'admin_response',
+  MANUAL = 'manual',
+  IMPORTED = 'imported',
+}
+
+export interface IFAQ {
+  _id?: ObjectId;
+  question: string;
+  answer: string;
+  category: FAQCategory;
+  tags: string[];
+  embedding?: number[];
+  upvotes: number;
+  downvotes: number;
+  usageCount: number;
+  createdBy: ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+  isActive: boolean;
+  source?: FAQSource;
+  relatedFaqIds?: ObjectId[];
+}
+
+export interface ISupportQuestion {
+  _id?: ObjectId;
+  userId: ObjectId;
+  courseId?: ObjectId;
+  courseVersionId?: ObjectId;
+  cohortId?: ObjectId;
+  question: string;
+  context?: {
+    page?: string;
+    itemId?: ObjectId;
+    module?: string;
+  };
+  status: SupportQuestionStatus;
+  matchedFaqId?: ObjectId;
+  confidenceScore?: number;
+  adminResponse?: {
+    respondedBy: ObjectId;
+    response: string;
+    responseAt: Date;
+  };
+  faqCreatedFromThis?: ObjectId;
+  learnersSeenResponse: boolean;
+  resolutionRating?: ResolutionRating;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ISupportAnalytics {
+  _id?: ObjectId;
+  date: string;
+  courseId?: ObjectId;
+  totalQuestions: number;
+  resolvedByFaq: number;
+  escalatedToAdmin: number;
+  avgResolutionTime: number;
+  topCategories: Array<{
+    category: string;
+    count: number;
+  }>;
+  adminResponseTime: number;
+  learnerSatisfactionRate: number;
+  createdAt: Date;
+}
+
+export interface FAQRetrievalResult {
+  faq: IFAQ;
+  similarity: number;
+  recency: number;
+  popularity: number;
+  score: number;
+}
+
+export interface ChatMessageRequest {
+  question: string;
+  context?: {
+    page?: string;
+    itemId?: ObjectId;
+    module?: string;
+  };
+}
+
+export interface ChatMessageResponse {
+  response: string;
+  confidence: number;
+  faqId?: ObjectId;
+  isFromFAQ: boolean;
+  isEscalated: boolean;
+  questionId: ObjectId;
+  source?: string;
+}
+
+export interface AdminResponseRequest {
+  response: string;
+  createFaq?: boolean;
+  faqCategory?: FAQCategory;
+  faqTags?: string[];
+}
+
+export const FAQ_CONFIDENCE_THRESHOLD = parseFloat(
+  process.env.FAQ_CONFIDENCE_THRESHOLD || '0.75'
+);
+
+export const SUPPORT_CHAT_CONFIG = {
+  confidenceThreshold: FAQ_CONFIDENCE_THRESHOLD,
+  maxSearchResults: 5,
+  embeddingModel: process.env.MINIMAX_EMBEDDING_MODEL || 'embo-01',
+  minimaxApiUrl: process.env.MINIMAX_API_URL || 'https://api.minimax.chat/v1',
+  collectionsNames: {
+    faq: process.env.MONGODB_FAQ_COLLECTION || 'supportFaqs',
+    questions: process.env.MONGODB_QUESTIONS_COLLECTION || 'supportQuestions',
+    analytics: 'supportAnalytics',
+  },
+};

--- a/frontend/src/components/support-chat/ChatWidget.tsx
+++ b/frontend/src/components/support-chat/ChatWidget.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { MessageCircle, X, Send } from 'lucide-react';
+import { useState, useRef, useEffect } from 'react';
+import { MessageCircle, X } from 'lucide-react';
 import ChatWindow from './ChatWindow';
 
 interface ChatWidgetProps {

--- a/frontend/src/components/support-chat/MessageBubble.tsx
+++ b/frontend/src/components/support-chat/MessageBubble.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CheckCircle, AlertCircle } from 'lucide-react';
 
 interface MessageBubbleProps {

--- a/frontend/src/hooks/useAdminSupport.ts
+++ b/frontend/src/hooks/useAdminSupport.ts
@@ -1,10 +1,10 @@
 import { useCallback } from 'react';
 import { AdminResponseRequest, IFAQ, FAQCategory } from '@/modules/supportChat/types';
 
-const API_BASE = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+const API_BASE = import.meta.env.VITE_BASE_URL ?? '';
 
 export default function useAdminSupport() {
-  const getToken = () => localStorage.getItem('authToken');
+  const getToken = () => localStorage.getItem('firebase-auth-token');
 
   const getDashboard = useCallback(
     async (courseId?: string, startDate?: string, endDate?: string) => {

--- a/frontend/src/hooks/useSupportChat.ts
+++ b/frontend/src/hooks/useSupportChat.ts
@@ -1,7 +1,12 @@
 import { useCallback } from 'react';
 import { ChatMessageResponse } from '@/modules/supportChat/types';
 
-const API_BASE = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+const API_BASE = import.meta.env.VITE_BASE_URL ?? '';
+
+const authHeaders = (): Record<string, string> => {
+  const token = localStorage.getItem('firebase-auth-token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
 
 export default function useSupportChat() {
   const sendMessage = useCallback(
@@ -22,7 +27,7 @@ export default function useSupportChat() {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${localStorage.getItem('authToken')}`,
+            ...authHeaders(),
           },
           body: JSON.stringify({
             question,
@@ -47,9 +52,7 @@ export default function useSupportChat() {
       const response = await fetch(
         `${API_BASE}/api/support/chat/history?limit=${limit}`,
         {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('authToken')}`,
-          },
+          headers: authHeaders(),
         }
       );
 
@@ -65,9 +68,7 @@ export default function useSupportChat() {
   const getQuestion = useCallback(
     async (questionId: string) => {
       const response = await fetch(`${API_BASE}/api/support/chat/${questionId}`, {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('authToken')}`,
-        },
+        headers: authHeaders(),
       });
 
       if (!response.ok) {
@@ -87,7 +88,7 @@ export default function useSupportChat() {
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${localStorage.getItem('authToken')}`,
+            ...authHeaders(),
           },
           body: JSON.stringify({ rating }),
         }

--- a/frontend/src/modules/supportChat/types.ts
+++ b/frontend/src/modules/supportChat/types.ts
@@ -1,0 +1,111 @@
+/**
+ * Frontend mirror of backend/src/modules/supportChat/types.ts.
+ *
+ * Ids are `string` here rather than `ObjectId` — they arrive serialized over
+ * JSON. Keep the enum values byte-identical to the backend, since they cross
+ * the wire as-is.
+ */
+
+export enum FAQCategory {
+  LOGIN = 'login',
+  TECHNICAL = 'technical',
+  PROCTORING = 'proctoring',
+  FEATURES = 'features',
+  OTHER = 'other',
+}
+
+export enum SupportQuestionStatus {
+  PENDING = 'PENDING',
+  ANSWERED = 'ANSWERED',
+  RESOLVED = 'RESOLVED',
+  ESCALATED = 'ESCALATED',
+}
+
+export enum ResolutionRating {
+  HELPFUL = 'helpful',
+  NOT_HELPFUL = 'not_helpful',
+}
+
+export enum FAQSource {
+  ADMIN_RESPONSE = 'admin_response',
+  MANUAL = 'manual',
+  IMPORTED = 'imported',
+}
+
+export interface IFAQ {
+  _id?: string;
+  question: string;
+  answer: string;
+  category: FAQCategory;
+  tags: string[];
+  upvotes: number;
+  downvotes: number;
+  usageCount: number;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+  isActive: boolean;
+  source?: FAQSource;
+  relatedFaqIds?: string[];
+}
+
+export interface ISupportQuestionContext {
+  page?: string;
+  itemId?: string;
+  module?: string;
+}
+
+export interface ISupportQuestion {
+  _id?: string;
+  userId: string;
+  courseId?: string;
+  courseVersionId?: string;
+  cohortId?: string;
+  question: string;
+  context?: ISupportQuestionContext;
+  status: SupportQuestionStatus;
+  matchedFaqId?: string;
+  confidenceScore?: number;
+  adminResponse?: {
+    respondedBy: string;
+    response: string;
+    responseAt: string;
+  };
+  faqCreatedFromThis?: string;
+  learnersSeenResponse: boolean;
+  resolutionRating?: ResolutionRating;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChatMessageRequest {
+  question: string;
+  context?: ISupportQuestionContext;
+}
+
+export interface ChatMessageResponse {
+  response: string;
+  confidence: number;
+  faqId?: string;
+  isFromFAQ: boolean;
+  isEscalated: boolean;
+  questionId: string;
+  source?: string;
+}
+
+export interface AdminResponseRequest {
+  response: string;
+  createFaq?: boolean;
+  faqCategory?: FAQCategory;
+  faqTags?: string[];
+}
+
+export interface SupportDashboardStats {
+  totalQuestions: number;
+  resolvedByFaq: number;
+  escalatedToAdmin: number;
+  avgResolutionTime: number;
+  topCategories: Array<{ category: string; count: number }>;
+  adminResponseTime: number;
+  learnerSatisfactionRate: number;
+}

--- a/frontend/src/pages/teacher/support-dashboard/QuestionsTable.tsx
+++ b/frontend/src/pages/teacher/support-dashboard/QuestionsTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ISupportQuestion, SupportQuestionStatus } from '@/modules/supportChat/types';
 import { AlertCircle, CheckCircle, Clock } from 'lucide-react';
 

--- a/frontend/src/pages/teacher/support-dashboard/StatsCards.tsx
+++ b/frontend/src/pages/teacher/support-dashboard/StatsCards.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MessageSquare, AlertCircle, CheckCircle2, Clock, Smile } from 'lucide-react';
 
 interface Stats {

--- a/frontend/src/pages/teacher/support-dashboard/SupportDashboard.tsx
+++ b/frontend/src/pages/teacher/support-dashboard/SupportDashboard.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { MessageSquare, AlertCircle, CheckCircle2, Clock, TrendingUp } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { MessageSquare, AlertCircle } from 'lucide-react';
 import QuestionsTable from './QuestionsTable';
 import ResponsePanel from './ResponsePanel';
 import StatsCards from './StatsCards';
@@ -11,7 +11,7 @@ export default function SupportDashboard() {
   const [stats, setStats] = useState(null);
   const [questions, setQuestions] = useState<ISupportQuestion[]>([]);
   const [loading, setLoading] = useState(true);
-  const [courseFilter, setCourseFilter] = useState<string>('all');
+  const [courseFilter] = useState<string>('all');
 
   const { getDashboard, getQuestions } = useAdminSupport();
 


### PR DESCRIPTION
The Support Assistant widget showed "Sorry, something went wrong" on every message. Its backend module was removed in #1257 to unblock staging, but the frontend stayed mounted, so every send hit a 404.

This re-lands the module with the four defects that made it unshippable fixed.

Backend:

1. index.ts now exports the names bootstrap/loadModules.ts actually looks for (supportChatModuleControllers / supportChatContainerModules / supportChatModuleValidators / setupSupportChatContainer). Previously it exported none of them, so the module contributed zero routes and was never bound into the DI container while its decorator metadata was still live -- the condition that broke spec generation.

2. Every @QueryParams()/@Body()/@Params() is typed with a validator class in classes/validators/SupportChatValidators.ts. The inline object literals reflected as bare Object, which is what made getQueryParams() call .split on undefined and exit the container before it could bind $PORT.

3. @Param -> @Params with IsMongoId path-param classes, and bare `throw new Error` in ownership checks -> NotFoundError / ForbiddenError so they return 404/403 instead of 500.

4. Dropped four stray .ts.bak/.bak2 files and the unreferenced hand-rolled validators/SupportChatValidator.ts, superseded by the class-validator classes.

Frontend:

5. Added src/modules/supportChat/types.ts. Five files imported @/modules/supportChat/types and it had never been created -- the frontend did not typecheck.

6. Hooks used Create-React-App conventions that do not exist in this Vite app: process.env.REACT_APP_API_URL (undefined in the browser, falling back to a hardcoded localhost:3001) -> import.meta.env.VITE_BASE_URL, and localStorage 'authToken' -> 'firebase-auth-token', matching lib/api-client.ts. Without this the requests would have 401'd even once the routes existed.

Verified: backend `tsc --noEmit` clean, frontend `tsc -p tsconfig.app.json` clean for all support-chat files, and replaying the index.ts boot sequence (loadAppModules('all') -> generateOpenAPISpec) loads 47 controllers and generates 280 paths -- up from 45/269 -- with all 11 support routes present and no throw.

Not covered: the module has no tests, and FAQ retrieval still needs a live run against seeded FAQs to confirm it returns matches.

