### PR TITLE
fix(video): make timestamp entry typeable in the instructor dashboard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,6 +159,7 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.23.0",
-    "vite": "^6.2.6"
+    "vite": "^6.2.6",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "copy": "cd ../backend && node scripts/generate-openapi.cjs --output ../../frontend/openapi.json",
     "gen-schema": "pnpx openapi-typescript openapi.json --output src/lib/api/schema.ts ",
     "build": "tsc -b && vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "gts lint",
     "preview": "vite preview",
     "clean": "gts clean",

--- a/frontend/src/app/pages/teacher/components/TimeRangePicker.tsx
+++ b/frontend/src/app/pages/teacher/components/TimeRangePicker.tsx
@@ -1,0 +1,193 @@
+import {useEffect} from 'react';
+import {Button} from '@/components/ui/button';
+import {Input} from '@/components/ui/input';
+import {useTimeRange, type RangeField} from '@/hooks/useTimeRange';
+import {formatTime} from '@/utils/time';
+
+interface TimeRangePickerProps {
+  startSeconds: number;
+  endSeconds: number;
+  /** Video length in seconds; 0 while unknown. */
+  duration: number;
+  disabled?: boolean;
+  /** Seek controls stay inert until a player can answer them. */
+  playerReady?: boolean;
+  onChange: (next: {start: number; end: number}) => void;
+  onSeek?: (seconds: number) => void;
+  /** Lets the modal disable Save while a committed value is invalid. */
+  onValidityChange?: (hasBlockingError: boolean) => void;
+}
+
+/** ±1s from the arrows, ±10s with Shift, ±60s with Page Up/Down. */
+const STEP_SECONDS = 1;
+const STEP_SECONDS_LARGE = 10;
+const STEP_SECONDS_PAGE = 60;
+
+/**
+ * Start/end timestamp entry for a video segment.
+ *
+ * Digits are typed right to left like a stopwatch — `840` becomes 08:40 — so no
+ * colon and no modifier key is ever needed, and the numeric keypad works on a
+ * tablet. Arrow keys nudge the value for fine adjustment. Both fields select
+ * their contents on focus, so tabbing in and retyping is a single gesture.
+ */
+export default function TimeRangePicker({
+  startSeconds,
+  endSeconds,
+  duration,
+  disabled = false,
+  playerReady = false,
+  onChange,
+  onSeek,
+  onValidityChange,
+}: TimeRangePickerProps) {
+  const range = useTimeRange({startSeconds, endSeconds, duration, onChange});
+
+  useEffect(() => {
+    onValidityChange?.(range.hasBlockingError);
+  }, [range.hasBlockingError, onValidityChange]);
+
+  const renderField = (field: RangeField, label: string) => {
+    const props = field === 'start' ? range.start : range.end;
+    const describedBy = `${field}-time-note`;
+
+    return (
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={`${field}-time-input`}
+          className="text-sm font-medium text-foreground"
+        >
+          {label}
+        </label>
+
+        <div className="flex items-center gap-1">
+          <Input
+            id={`${field}-time-input`}
+            type="text"
+            // Brings up the numeric keypad on the tablets a lot of instructors
+            // actually author on.
+            inputMode="numeric"
+            autoComplete="off"
+            value={props.value}
+            disabled={disabled}
+            aria-describedby={describedBy}
+            aria-invalid={props.issue?.severity === 'error'}
+            className={`w-24 text-center font-mono tabular-nums bg-background ${
+              props.issue?.severity === 'error'
+                ? 'border-red-500 focus-visible:ring-red-500'
+                : 'border-border'
+            }`}
+            // Select-all on focus is what makes "click in and retype" work; the
+            // old field required deleting the existing value character by
+            // character before anything could be entered.
+            onFocus={event => {
+              props.onFocus();
+              event.target.select();
+            }}
+            onChange={event => props.onInput(event.target.value)}
+            onBlur={props.onCommit}
+            onPaste={event => {
+              const text = event.clipboardData.getData('text');
+              if (props.onPasteText(text)) event.preventDefault();
+            }}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                event.currentTarget.blur();
+                return;
+              }
+              const step = event.shiftKey ? STEP_SECONDS_LARGE : STEP_SECONDS;
+              if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                props.onStep(1, step);
+              } else if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                props.onStep(-1, step);
+              } else if (event.key === 'PageUp') {
+                event.preventDefault();
+                props.onStep(1, STEP_SECONDS_PAGE);
+              } else if (event.key === 'PageDown') {
+                event.preventDefault();
+                props.onStep(-1, STEP_SECONDS_PAGE);
+              }
+            }}
+          />
+
+          <div className="flex flex-col">
+            <button
+              type="button"
+              tabIndex={-1}
+              disabled={disabled}
+              aria-label={`Increase ${label} by one second`}
+              className="px-1 leading-none text-muted-foreground hover:text-foreground disabled:opacity-40"
+              onClick={() => props.onStep(1, STEP_SECONDS)}
+            >
+              ▲
+            </button>
+            <button
+              type="button"
+              tabIndex={-1}
+              disabled={disabled}
+              aria-label={`Decrease ${label} by one second`}
+              className="px-1 leading-none text-muted-foreground hover:text-foreground disabled:opacity-40"
+              onClick={() => props.onStep(-1, STEP_SECONDS)}
+            >
+              ▼
+            </button>
+          </div>
+
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={!playerReady}
+            onClick={() => onSeek?.(field === 'start' ? startSeconds : endSeconds)}
+          >
+            Go to
+          </Button>
+        </div>
+
+        {/*
+          * One line, three possible messages, so the control never changes
+          * height as the teacher types and shifts the rest of the form.
+          */}
+        <p
+          id={describedBy}
+          className={`min-h-4 text-xs ${
+            props.issue?.severity === 'error'
+              ? 'text-red-500'
+              : props.issue
+                ? 'text-amber-600 dark:text-amber-500'
+                : 'text-muted-foreground'
+          }`}
+        >
+          {props.issue?.message ??
+            (props.preview
+              ? `= ${props.preview}`
+              : props.clamped
+                ? `Clamped to the video length (${formatTime(duration)})`
+                : '')}
+        </p>
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex flex-wrap items-start gap-x-6 gap-y-3">
+      {renderField('start', 'Start time')}
+      {renderField('end', 'End time')}
+
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-foreground">Length</span>
+        <span className="flex h-9 items-center font-mono tabular-nums text-sm text-muted-foreground">
+          {formatTime(range.lengthSeconds)}
+        </span>
+      </div>
+
+      <p className="w-full text-xs text-muted-foreground">
+        Type digits only — <span className="font-mono">840</span> becomes 08:40.
+        Arrow keys nudge by a second, Shift by ten.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/app/pages/teacher/components/Video-modal.tsx
+++ b/frontend/src/app/pages/teacher/components/Video-modal.tsx
@@ -7,6 +7,8 @@ import ConfirmationModal from "./confirmation-modal";
 import VideoAssetPicker from "./VideoAssetPicker";
 import HlsVideoPlayer from "@/components/HlsVideoPlayer";
 import { resolveVideoSource, type VideoSource } from "@/types/media.types";
+import TimeRangePicker from "./TimeRangePicker";
+import { formatTime, parseTimeToSeconds } from "@/utils/time";
 
 function getYouTubeId(url: string): string | null {
     const match = url.match(/(?:v=|youtu\.be\/?)([\w-]{11})/);
@@ -31,59 +33,6 @@ interface VideoModalProps {
      */
     courseId?: string | null;
     courseVersionId?: string | null;
-}
-
-function formatTime(seconds: number): string {
-    if (isNaN(seconds) || seconds < 0) {
-        return "00:00";
-    }
-
-    const totalSeconds = Math.floor(seconds);
-    const mins = Math.floor((totalSeconds % 3600) / 60);
-    const secs = totalSeconds % 60;
-
-    const formattedMins = mins.toString().padStart(2, "0");
-    const formattedSecs = secs.toString().padStart(2, "0");
-
-    return `${formattedMins}:${formattedSecs}`;
-}
-
-function parseTimeToSeconds(time: string | undefined): number {
-    if (!time || time.trim() === "") {
-        return 0;
-    }
-
-    const normalizedTime = time.trim();
-
-    const timeParts = normalizedTime.split(":");
-
-    if (timeParts.length === 3) {
-        const [hours, minutes, seconds] = timeParts;
-
-        const h = Math.max(0, parseInt(hours, 10) || 0);
-        const m = Math.min(59, Math.max(0, parseInt(minutes, 10) || 0));
-        const s = Math.min(59, Math.max(0, parseInt(seconds, 10) || 0));
-
-        return (h * 60 + m) * 60 + s;
-    }
-
-    if (timeParts.length === 2) {
-        // Format: MM:SS
-        const [minutes, seconds] = timeParts;
-
-        const m = Math.max(0, parseInt(minutes, 10) || 0);
-        const s = Math.min(59, Math.max(0, parseInt(seconds, 10) || 0));
-
-        return m * 60 + s;
-    }
-
-    // Handle plain number (assume it's seconds)
-    if (!normalizedTime.includes(":")) {
-        const seconds = parseInt(normalizedTime, 10);
-        return isNaN(seconds) ? 0 : Math.max(0, seconds);
-    }
-
-    return 0;
 }
 
 const VideoModal: React.FC<VideoModalProps> = ({
@@ -121,21 +70,20 @@ const VideoModal: React.FC<VideoModalProps> = ({
     const [currentTime, setCurrentTime] = useState(0);
     const [showOverlay, setShowOverlay] = useState(false);
     const [showDeleteVideoModal, setShowDeleteVideoModal] = useState(false)
-    const [errors, setErrors] = useState({
-        startTime: "",
-        endTime: ""
-    });
 
+    /**
+     * The segment bounds, in seconds — the single source of truth for both
+     * timestamps. Display strings are derived where they are shown and built
+     * once more on save, rather than being kept as a parallel copy of state.
+     */
     const [range, setRange] = useState<[number, number]>([
         item?.details?.startTime ? parseTimeToSeconds(String(item.details?.startTime)) : 0,
         item?.details?.endTime ? parseTimeToSeconds(String(item.details?.endTime)) : 0,
     ]);
+    /** Reported by TimeRangePicker, which owns timestamp validation. */
+    const [timeRangeInvalid, setTimeRangeInvalid] = useState(false);
     const [videoId, setVideoId] = useState<string | null>(getYouTubeId(item?.details?.URL + "?rel=0" || ""));
     const [points, setPoints] = useState<number>(item?.details?.points ?? 0);
-    const [timeInputs, setTimeInputs] = useState({
-        start: formatTime(item?.details?.startTime ? parseTimeToSeconds(String(item.details?.startTime)) : 0),
-        end: formatTime(item?.details?.endTime ? parseTimeToSeconds(String(item.details?.endTime)) : 0),
-    });
 
     const playerRef = useRef<any>(null);
     const iframeRef = useRef<HTMLDivElement>(null);
@@ -155,7 +103,6 @@ const VideoModal: React.FC<VideoModalProps> = ({
         setVideoId(id);
         if (!id) {
             setRange([0, 0]);
-            setTimeInputs({ start: "0:00", end: "0:00" });
         }
     }, [url]);
 
@@ -178,11 +125,6 @@ const VideoModal: React.FC<VideoModalProps> = ({
             parseTimeToSeconds(startTime),
             parseTimeToSeconds(endTime),
         ]);
-
-        setTimeInputs({
-            start: formatTime(parseTimeToSeconds(startTime)),
-            end: formatTime(parseTimeToSeconds(endTime)),
-        });
 
         setVideoId(getYouTubeId((item?.details.URL ?? "") + "?rel=0"));
         setPlayerReady(false);
@@ -213,25 +155,13 @@ const VideoModal: React.FC<VideoModalProps> = ({
                     const dur = event.target.getDuration();
                     setDuration(dur);
 
-                    const currentEnd = parseTimeToSeconds(timeInputs.end);
-                    const newEnd = currentEnd > 0 ? Math.min(currentEnd, dur) : dur;
-
-                    const startSeconds = parseTimeToSeconds(timeInputs.start);
-
-                    setRange([startSeconds, newEnd]);
-
-                    const formattedEnd = formatTime(newEnd);
-
-                    setTimeInputs(prev => {
-                        const updated = {
-                            ...prev,
-                            end: formattedEnd
-                        };
-                        return updated;
-                    });
-
-                    validateTimeAgainstDuration(timeInputs.start, 'startTime', dur);
-                    validateTimeAgainstDuration(timeInputs.end, 'endTime', dur);
+                    // An end of 0 means "not set yet" — default it to the whole
+                    // video. Anything already set is only pulled back if it
+                    // overruns the real length.
+                    setRange(prev => [
+                        Math.min(prev[0], dur),
+                        prev[1] > 0 ? Math.min(prev[1], dur) : dur,
+                    ]);
 
                     setPlayerReady(true);
                     setShowOverlay(false);
@@ -266,135 +196,18 @@ const VideoModal: React.FC<VideoModalProps> = ({
         return () => clearInterval(interval);
     }, [playerReady]);
 
-    const validateTimeAgainstDuration = (timeValue: string, field: 'startTime' | 'endTime', maxDuration: number) => {
-        const seconds = parseTimeToSeconds(timeValue);
-
-        if (seconds > maxDuration) {
-            setErrors(prev => ({
-                ...prev,
-                [field]: `Time exceeds video duration (${formatTime(maxDuration)})`
-            }));
-            return false;
-        } else {
-            setErrors(prev => ({
-                ...prev,
-                [field]: ""
-            }));
-            return true;
-        }
-    };
-
-    const validateTimeRange = (startTime: string, endTime: string) => {
-        const startSeconds = parseTimeToSeconds(startTime);
-        const endSeconds = parseTimeToSeconds(endTime);
-
-        if (endSeconds <= startSeconds) {
-            setErrors(prev => ({
-                ...prev,
-                endTime: "End time must be greater than start time"
-            }));
-            return false;
-        } else {
-            setErrors(prev => ({
-                ...prev,
-                endTime: ""
-            }));
-            return true;
-        }
-    };
-
-    const formatTimeInput = (value: string): string => {
-        const digits = value.replace(/\D/g, '');
-
-        if (digits.length > 4) return value;
-
-        if (digits.length <= 2) {
-            return digits;
-        } else {
-            const minutes = digits.slice(0, -2);
-            const seconds = digits.slice(-2);
-            return `${minutes}:${seconds}`;
-        }
-    };
-
-    const validateTimeInput = (value: string, maxSeconds: number): number => {
-        if (!value) return 0;
-        const formattedValue = formatTimeInput(value);
-        let seconds = parseTimeToSeconds(formattedValue);
-        seconds = Math.min(seconds, maxSeconds);
-        return seconds;
-    };
-
-    const handleTimeInputChange = (type: 'start' | 'end', value: string) => {
-        const numericOnly = value.replace(/\D/g, '');
-
-        // Limit to 6 digits total (HHMMSS)
-        if (numericOnly.length > 6) return;
-
-
-
-        setTimeInputs(prev => ({
-            ...prev,
-            [type]: value
-        }));
-    };
-
-    const handleTimeInputBlur = (type: 'start' | 'end') => {
-        const rawValue = timeInputs[type];
-
-        // Only format if the value is not empty
-        if (rawValue.trim() === "") {
-            setTimeInputs(prev => ({
-                ...prev,
-                [type]: "0:00"
-            }));
-            // Validate after setting to 0:00
-            const otherType = type === 'start' ? 'end' : 'start';
-            validateTimeRange(
-                type === 'start' ? "0:00" : timeInputs[otherType],
-                type === 'start' ? timeInputs[otherType] : "0:00"
-            );
-            return;
-        }
-
-        const formattedValue = formatTimeInput(rawValue);
-        const seconds = validateTimeInput(formattedValue, duration);
-        const field = type === 'start' ? 'startTime' : 'endTime';
-
-        // Update state with clean formatted value
-        setTimeInputs(prev => ({
-            ...prev,
-            [type]: formattedValue
-        }));
-
-        // Only validate against duration if video has loaded properly
-        if (duration > 0) {
-            validateTimeAgainstDuration(formattedValue, field, duration);
-        }
-
-        // Validate time range (end > start) - use updated state
-        setTimeout(() => {
-            const otherType = type === 'start' ? 'end' : 'start';
-            const currentStart = type === 'start' ? formattedValue : timeInputs[otherType];
-            const currentEnd = type === 'start' ? timeInputs[otherType] : formattedValue;
-            validateTimeRange(currentStart, currentEnd);
-        }, 0);
-
-        // Update player range
-        if (type === 'start') {
-            setRange(prev => {
-                const newStart = Math.min(seconds, prev[1] - 1);
-                if (playerRef.current && playerReady) {
-                    playerRef.current.seekTo(newStart, true);
-                }
-                return [newStart, prev[1]];
-            });
-        } else {
-            setRange(prev => {
-                const newEnd = Math.max(seconds, prev[0] + 1);
-                return [prev[0], newEnd];
-            });
-        }
+    /**
+     * Timestamp edits arrive from TimeRangePicker already parsed and bounded.
+     * Moving the start also seeks the player, so the teacher sees the frame
+     * they just chose.
+     */
+    const handleRangeChange = ({start, end}: {start: number; end: number}) => {
+        setRange(prev => {
+            if (start !== prev[0] && playerRef.current && playerReady) {
+                playerRef.current.seekTo(start, true);
+            }
+            return [start, end];
+        });
     };
 
     // Store original values for cancel functionality
@@ -434,9 +247,6 @@ const VideoModal: React.FC<VideoModalProps> = ({
         }
     }, [currentTime, range, playerReady]);
 
-    const hasErrors = () => {
-        return errors.startTime !== "" || errors.endTime !== "";
-    };
 
     /**
      * Default an uploaded video's segment to its full length.
@@ -449,10 +259,8 @@ const VideoModal: React.FC<VideoModalProps> = ({
      */
     useEffect(() => {
         if (source !== "GCS" || duration <= 0) return;
-        if (parseTimeToSeconds(timeInputs.end) > 0) return; // already set
-        setRange([0, duration]);
-        setTimeInputs({start: formatTime(0), end: formatTime(duration)});
-    }, [source, duration, timeInputs.end]);
+        setRange(prev => (prev[1] > 0 ? prev : [0, duration]));
+    }, [source, duration]);
     const [errorList, setErrorList] = useState({ name: "", description: "", url: "" })
     const errorMessages = {
         name: "Video name is required",
@@ -477,15 +285,11 @@ const VideoModal: React.FC<VideoModalProps> = ({
         setDescription(originalValues.description);
         setUrl(originalValues.url);
         setPoints(originalValues.points);
-        setTimeInputs({
-            start: originalValues.startTime,
-            end: originalValues.endTime
-        });
         setRange([
             parseTimeToSeconds(originalValues.startTime),
             parseTimeToSeconds(originalValues.endTime)
         ]);
-        setErrors({ startTime: "", endTime: "" });
+        setTimeRangeInvalid(false);
         setErrorList({ name: "", description: "", url: "" });
 
         onClose();
@@ -510,24 +314,15 @@ const VideoModal: React.FC<VideoModalProps> = ({
         setErrorList(newErrors);
         const isValid = Object.values(newErrors).every((err) => err === "");
         if (!isValid) return;
-        let finalStartTime = timeInputs.start;
-        let finalEndTime = timeInputs.end;
 
-        if (action === "add" && duration === 0) {
-            finalStartTime = "0:00";
-            finalEndTime = "0:00";
-        }
+        // A brand new item whose player has not reported a length yet has no
+        // meaningful segment to save; the bounds are filled in on first open.
+        const isUnmeasured = action === "add" && duration === 0;
+        const [startSeconds, endSeconds] = isUnmeasured ? [0, 0] : range;
 
-
-        const startSeconds = validateTimeInput(timeInputs.start, duration);
-        const endSeconds = validateTimeInput(timeInputs.end, duration);
-
-        if (duration > 0) {
-            const startValid = validateTimeAgainstDuration(finalStartTime, "startTime", duration);
-            const endValid = validateTimeAgainstDuration(finalEndTime, "endTime", duration);
-            const rangeValid = validateTimeRange(finalStartTime, finalEndTime);
-            if (!startValid || !endValid || !rangeValid) return;
-        }
+        // TimeRangePicker keeps this current, and Save is disabled while it is
+        // set — this is the backstop for a programmatic call.
+        if (timeRangeInvalid) return;
 
         const video: Video = {
             _id: item?._id || "",
@@ -751,8 +546,8 @@ const VideoModal: React.FC<VideoModalProps> = ({
                                              */
                                             ref={playerRef}
                                             assetId={assetId}
-                                            startTime={timeInputs.start}
-                                            endTime={timeInputs.end}
+                                            startTime={formatTime(range[0])}
+                                            endTime={formatTime(range[1])}
                                             className="h-full w-full"
                                             onReady={seconds => {
                                                 setDuration(seconds);
@@ -810,99 +605,42 @@ const VideoModal: React.FC<VideoModalProps> = ({
                                         fontSize: 15,
                                         zIndex: 11,
                                     }}>
-                                        Start: {timeInputs.start} &nbsp; End: {timeInputs.end} &nbsp; Current: {formatTime(currentTime)}
+                                        Start: {formatTime(range[0])} &nbsp; End: {formatTime(range[1])} &nbsp; Current: {formatTime(currentTime)}
                                     </div>
                                 </div>
                                 {/* Start/End Time Inputs Below Video */}
                                 <div
+                                    /*
+                                      * No `user-select: none` here. It used to sit on this
+                                      * container and, because it inherits, it was what stopped
+                                      * a teacher selecting the text inside the timestamp
+                                      * fields to overwrite it — the whole of issue #499.
+                                      */
                                     style={{
                                         borderRadius: '0 0 12px 12px',
-                                        userSelect: 'none',
-                                        WebkitUserSelect: 'none',
-                                        MozUserSelect: 'none',
-                                        msUserSelect: 'none',
                                         flexShrink: 0,
                                     }}
-                                    className="bg-muted border-t border-border p-4 xl:flex items-center justify-start relative gap-2"
+                                    className="bg-muted border-t border-border p-4"
                                 >
-                                    <div className="flex flex-col gap-2">
-                                        <div className="flex items-center lg:gap-2 gap-6 lg:flex-row flex-col">
-                                            <div>
-                                                <div className="flex items-center gap-2">
-                                                    <label className="font-medium mr-2">Start Time (mm:ss):</label>
-                                                    <div className="flex flex-col">
-                                                        <Input
-                                                            type="text"
-                                                            value={timeInputs.start}
-                                                            onChange={e => handleTimeInputChange('start', e.target.value)}
-                                                            onBlur={() => handleTimeInputBlur('start')}
-                                                            disabled={action === "view"}
-                                                            style={{ width: 100 }}
-                                                            placeholder="0:00"
-                                                            maxLength={5}
-                                                            className={errors.startTime ? "border-red-500" : "bg-white border-gray-200"}
-                                                        />
-                                                    </div>
-                                                </div>
-                                                {errors.startTime && (
-                                                    <span className="text-red-500 text-xs mt-1 absolute">{errors.startTime}</span>
-                                                )}
-                                            </div>
-                                            <div>
-                                                <div className="flex items-center gap-2">
-                                                    <label className="font-medium ml-4 mr-2">End Time (mm:ss):</label>
-                                                    <div className="flex flex-col">
-                                                        <Input
-                                                            type="text"
-                                                            value={timeInputs.end}
-                                                            onChange={e => handleTimeInputChange('end', e.target.value)}
-                                                            onBlur={() => handleTimeInputBlur('end')}
-                                                            disabled={action === "view"}
-                                                            style={{ width: 100 }}
-                                                            placeholder="0:00"
-                                                            maxLength={5}
-                                                            className={errors.endTime ? "border-red-500" : "bg-white border-gray-200"}
-                                                        />
-                                                    </div>
-                                                </div>
-                                                {errors.endTime && (
-                                                    <span className="text-red-500 text-xs mt-1">{errors.endTime}</span>
-                                                )}
-                                            </div>
-                                        </div>
-                                    </div>
-                                    {/* Go to Start/End Buttons */}
-                                    <div className="mt-4 xl:mt-0 justify-center" style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
-                                        <Button
-                                            variant="secondary"
-                                            size="sm"
-                                            onClick={() => {
-                                                if (playerRef.current && playerReady) {
-                                                    playerRef.current.seekTo(range[0], true);
-                                                }
-                                            }}
-                                            disabled={!playerReady}
-                                        >
-                                            Go to Start
-                                        </Button>
-                                        <Button
-                                            variant="secondary"
-                                            size="sm"
-                                            onClick={() => {
-                                                if (playerRef.current && playerReady) {
-                                                    playerRef.current.seekTo(range[1], true);
-                                                }
-                                            }}
-                                            disabled={!playerReady}
-                                        >
-                                            Go to End
-                                        </Button>
-                                    </div>
+                                    <TimeRangePicker
+                                        startSeconds={range[0]}
+                                        endSeconds={range[1]}
+                                        duration={duration}
+                                        disabled={action === "view"}
+                                        playerReady={playerReady}
+                                        onChange={handleRangeChange}
+                                        onValidityChange={setTimeRangeInvalid}
+                                        onSeek={seconds => {
+                                            if (playerRef.current && playerReady) {
+                                                playerRef.current.seekTo(seconds, true);
+                                            }
+                                        }}
+                                    />
                                 </div>
                             </div>
                         )}
                         <div className="mt-4 p-4 bg-card border border-border rounded-lg">
-                            <label className="block mb-2 font-medium text-sm text-gray-700">Points</label>
+                            <label className="block mb-2 font-medium text-sm text-foreground">Points</label>
                             <Input
                                 type="number"
                                 min={0}
@@ -931,17 +669,6 @@ const VideoModal: React.FC<VideoModalProps> = ({
                                     </Button>
                                 )}
                                 {(() => {
-                                    const hasTimeRangeError = () => {
-                                        if (duration === 0) {
-                                            return false;
-                                        }
-                                        const startSeconds = parseTimeToSeconds(timeInputs.start);
-                                        const endSeconds = parseTimeToSeconds(timeInputs.end);
-                                        if (startSeconds === 0 && endSeconds === 0) {
-                                            return false;
-                                        }
-                                        return endSeconds <= startSeconds;
-                                    };
                                     // An uploaded video has no URL and no YouTube
                                     // player, so those two gates only apply to the
                                     // link flow. It needs a ready asset instead.
@@ -950,8 +677,8 @@ const VideoModal: React.FC<VideoModalProps> = ({
                                     (isUpload ? !assetId : !url) ||
                                     !name ||
                                     !description ||
-                                    hasErrors() ||
-                                    hasTimeRangeError();
+                                    // Timestamp validity is TimeRangePicker's to judge.
+                                    timeRangeInvalid;
 
                                     return (
                                         <Button

--- a/frontend/src/hooks/useTimeRange.ts
+++ b/frontend/src/hooks/useTimeRange.ts
@@ -1,0 +1,208 @@
+import {useCallback, useMemo, useState} from 'react';
+import {
+  digitsToSeconds,
+  formatTime,
+  groupDigits,
+  normalizeDigits,
+  parsePastedTime,
+} from '@/utils/time';
+
+export type RangeField = 'start' | 'end';
+
+export interface TimeIssue {
+  message: string;
+  /**
+   * `error` blocks saving; `hint` is advisory. A field being typed into passes
+   * through invalid intermediate states — typing 0, 8, 4, 0 towards 08:40 is
+   * briefly "before the start time" — so its own problems stay hints until it
+   * is committed. The other field's committed errors keep full weight.
+   */
+  severity: 'error' | 'hint';
+}
+
+interface UseTimeRangeArgs {
+  startSeconds: number;
+  endSeconds: number;
+  /** Video length in seconds; 0 while unknown, which disables length checks. */
+  duration: number;
+  onChange: (next: {start: number; end: number}) => void;
+}
+
+/** Seconds to the digit string the masked field would hold. */
+function secondsToDigits(seconds: number): string {
+  return normalizeDigits(formatTime(seconds).replace(/\D/g, ''));
+}
+
+/**
+ * Editing state for a start/end timestamp pair.
+ *
+ * Committed values stay in seconds and are owned by the caller; this holds only
+ * the in-progress draft, and derives every error rather than storing one. The
+ * previous implementation kept `range`, `timeInputs` and `errors` as three
+ * copies of the same fact and reconciled them by hand across six effects, which
+ * is why validation needed a `setTimeout(…, 0)` to read around its own stale
+ * closure.
+ */
+export function useTimeRange({
+  startSeconds,
+  endSeconds,
+  duration,
+  onChange,
+}: UseTimeRangeArgs) {
+  /** Digits being typed, per field. null means "not editing, show committed". */
+  const [draft, setDraft] = useState<Record<RangeField, string | null>>({
+    start: null,
+    end: null,
+  });
+  const [focused, setFocused] = useState<RangeField | null>(null);
+  /** Set when a commit had to pull a value back to the video length. */
+  const [clamped, setClamped] = useState<Record<RangeField, boolean>>({
+    start: false,
+    end: false,
+  });
+
+  const committed = useMemo(
+    () => ({start: startSeconds, end: endSeconds}),
+    [startSeconds, endSeconds],
+  );
+
+  /** What each field means right now, draft included. */
+  const effective = useMemo(
+    () => ({
+      start: draft.start !== null ? digitsToSeconds(draft.start) : committed.start,
+      end: draft.end !== null ? digitsToSeconds(draft.end) : committed.end,
+    }),
+    [draft, committed],
+  );
+
+  const issues = useMemo(() => {
+    const result: Record<RangeField, TimeIssue | null> = {start: null, end: null};
+    const severity = (field: RangeField): TimeIssue['severity'] =>
+      focused === field ? 'hint' : 'error';
+
+    if (duration > 0) {
+      if (effective.start > duration) {
+        result.start = {
+          message: `Longer than the video (${formatTime(duration)})`,
+          severity: severity('start'),
+        };
+      }
+      if (effective.end > duration) {
+        result.end = {
+          message: `Longer than the video (${formatTime(duration)})`,
+          severity: severity('end'),
+        };
+      }
+    }
+
+    // Both at zero is the untouched state for a video whose length is not known
+    // yet — not something to shout about.
+    const untouched = effective.start === 0 && effective.end === 0;
+    if (!result.end && !untouched && effective.end <= effective.start) {
+      result.end = {
+        message: 'End must be after the start time',
+        severity: severity('end'),
+      };
+    }
+
+    return result;
+  }, [effective, duration, focused]);
+
+  const hasBlockingError =
+    issues.start?.severity === 'error' || issues.end?.severity === 'error';
+
+  /** Write a value through to the caller, clamping to the video length. */
+  const commitSeconds = useCallback(
+    (field: RangeField, seconds: number) => {
+      const safe = Math.max(0, Math.floor(seconds));
+      const bounded = duration > 0 ? Math.min(safe, duration) : safe;
+      setClamped(prev => ({...prev, [field]: bounded !== safe}));
+      onChange({...committed, [field]: bounded});
+      return bounded;
+    },
+    [committed, duration, onChange],
+  );
+
+  const fieldProps = useCallback(
+    (field: RangeField) => ({
+      value:
+        draft[field] !== null
+          ? groupDigits(draft[field] as string)
+          : formatTime(committed[field]),
+
+      /**
+       * The normalised reading of what is currently typed, shown beneath the
+       * field when it differs from the raw digits — so `00:84` visibly means
+       * 1:24 and there is never a moment of doubt about what the digits mean.
+       */
+      preview: (() => {
+        if (draft[field] === null) return null;
+        const asSeconds = digitsToSeconds(draft[field] as string);
+        const shown = groupDigits(draft[field] as string);
+        const normalised = formatTime(asSeconds);
+        return shown === normalised ? null : normalised;
+      })(),
+
+      issue: issues[field],
+      clamped: clamped[field],
+
+      onFocus: () => {
+        setFocused(field);
+        setDraft(prev => ({...prev, [field]: secondsToDigits(committed[field])}));
+        setClamped(prev => ({...prev, [field]: false}));
+      },
+
+      onInput: (raw: string) => {
+        setDraft(prev => ({...prev, [field]: normalizeDigits(raw)}));
+        setClamped(prev => ({...prev, [field]: false}));
+      },
+
+      onCommit: () => {
+        const pending = draft[field];
+        setFocused(null);
+        setDraft(prev => ({...prev, [field]: null}));
+        if (pending !== null) commitSeconds(field, digitsToSeconds(pending));
+      },
+
+      /** Arrows nudge; the modifier scales the step. */
+      onStep: (direction: 1 | -1, step: number) => {
+        const next = Math.max(0, effective[field] + direction * step);
+        const bounded = commitSeconds(field, next);
+        if (focused === field) {
+          setDraft(prev => ({...prev, [field]: secondsToDigits(bounded)}));
+        }
+      },
+
+      /** Returns true when the paste was understood and should not fall through. */
+      onPasteText: (text: string) => {
+        const seconds = parsePastedTime(text);
+        if (seconds === null) return false;
+        const bounded = commitSeconds(field, seconds);
+        setDraft(prev => ({...prev, [field]: secondsToDigits(bounded)}));
+        return true;
+      },
+    }),
+    [draft, committed, issues, clamped, effective, focused, commitSeconds],
+  );
+
+  /** Point a field at a specific moment — used by "set to current". */
+  const setFromSeconds = useCallback(
+    (field: RangeField, seconds: number) => {
+      const bounded = commitSeconds(field, seconds);
+      if (focused === field) {
+        setDraft(prev => ({...prev, [field]: secondsToDigits(bounded)}));
+      }
+    },
+    [commitSeconds, focused],
+  );
+
+  return {
+    start: fieldProps('start'),
+    end: fieldProps('end'),
+    issues,
+    hasBlockingError,
+    setFromSeconds,
+    /** Committed length of the selected segment, for display. */
+    lengthSeconds: Math.max(0, committed.end - committed.start),
+  };
+}

--- a/frontend/src/utils/time.test.ts
+++ b/frontend/src/utils/time.test.ts
@@ -1,0 +1,160 @@
+import {describe, it, expect} from 'vitest';
+import {
+  formatTime,
+  parseTimeToSeconds,
+  normalizeDigits,
+  groupDigits,
+  digitsToSeconds,
+  parsePastedTime,
+} from './time';
+
+describe('formatTime', () => {
+  it('formats under an hour as MM:SS', () => {
+    expect(formatTime(0)).toBe('00:00');
+    expect(formatTime(8)).toBe('00:08');
+    expect(formatTime(90)).toBe('01:30');
+    expect(formatTime(520)).toBe('08:40');
+    expect(formatTime(3599)).toBe('59:59');
+  });
+
+  it('widens to H:MM:SS past an hour instead of dropping the hours', () => {
+    // The previous implementation computed minutes as (total % 3600) / 60, so
+    // this wrote "01:01" — a little over a minute — into the database.
+    expect(formatTime(3661)).toBe('1:01:01');
+    expect(formatTime(3600)).toBe('1:00:00');
+    expect(formatTime(7325)).toBe('2:02:05');
+  });
+
+  it('floors fractional seconds and refuses nonsense', () => {
+    expect(formatTime(90.9)).toBe('01:30');
+    expect(formatTime(-5)).toBe('00:00');
+    expect(formatTime(Number.NaN)).toBe('00:00');
+    expect(formatTime(Number.POSITIVE_INFINITY)).toBe('00:00');
+  });
+});
+
+describe('parseTimeToSeconds', () => {
+  it('reads the formats stored on video items', () => {
+    expect(parseTimeToSeconds('00:00')).toBe(0);
+    expect(parseTimeToSeconds('01:30')).toBe(90);
+    expect(parseTimeToSeconds('1:30')).toBe(90);
+    expect(parseTimeToSeconds('1:01:01')).toBe(3661);
+    expect(parseTimeToSeconds('00:01:30')).toBe(90);
+  });
+
+  it('reads a bare number as seconds', () => {
+    expect(parseTimeToSeconds('90')).toBe(90);
+    expect(parseTimeToSeconds(90)).toBe(90);
+  });
+
+  it('does not clamp components, so 0:90 is ninety seconds', () => {
+    // This is what lets someone thinking in raw seconds type 90 and land on
+    // 1:30 rather than being silently clamped to 0:59.
+    expect(parseTimeToSeconds('0:90')).toBe(90);
+    expect(parseTimeToSeconds('0:84')).toBe(84);
+  });
+
+  it('returns 0 for anything it cannot read', () => {
+    expect(parseTimeToSeconds('')).toBe(0);
+    expect(parseTimeToSeconds('   ')).toBe(0);
+    expect(parseTimeToSeconds(null)).toBe(0);
+    expect(parseTimeToSeconds(undefined)).toBe(0);
+    expect(parseTimeToSeconds('abc')).toBe(0);
+    expect(parseTimeToSeconds('1:2:3:4')).toBe(0);
+    expect(parseTimeToSeconds('-5')).toBe(0);
+    expect(parseTimeToSeconds('1:-30')).toBe(0);
+  });
+
+  it('round-trips with formatTime', () => {
+    for (const seconds of [0, 8, 90, 520, 3599, 3600, 3661, 7325]) {
+      expect(parseTimeToSeconds(formatTime(seconds))).toBe(seconds);
+    }
+  });
+});
+
+describe('normalizeDigits', () => {
+  it('keeps digits only, capped at six', () => {
+    expect(normalizeDigits('1a2b3')).toBe('123');
+    expect(normalizeDigits('12345678')).toBe('345678');
+  });
+
+  it('drops leading zeros but keeps a lone zero', () => {
+    // Otherwise pressing 0 as the first keystroke blanks the field.
+    expect(normalizeDigits('0')).toBe('0');
+    expect(normalizeDigits('00840')).toBe('840');
+    expect(normalizeDigits('000')).toBe('0');
+  });
+});
+
+describe('groupDigits — right-to-left stopwatch entry', () => {
+  it('fills from the right as the teacher types', () => {
+    expect(groupDigits('')).toBe('');
+    expect(groupDigits('8')).toBe('00:08');
+    expect(groupDigits('84')).toBe('00:84');
+    expect(groupDigits('840')).toBe('08:40');
+    expect(groupDigits('1230')).toBe('12:30');
+    expect(groupDigits('12345')).toBe('01:23:45');
+    expect(groupDigits('123456')).toBe('12:34:56');
+  });
+
+  it('ignores separators the teacher may still type out of habit', () => {
+    expect(groupDigits('8:40')).toBe('08:40');
+    expect(groupDigits('1:23:45')).toBe('01:23:45');
+  });
+});
+
+describe('digitsToSeconds', () => {
+  it('reads the same grouping groupDigits displays', () => {
+    expect(digitsToSeconds('')).toBe(0);
+    expect(digitsToSeconds('8')).toBe(8);
+    expect(digitsToSeconds('840')).toBe(520);
+    expect(digitsToSeconds('1230')).toBe(750);
+    expect(digitsToSeconds('12345')).toBe(5025);
+  });
+
+  it('carries instead of clamping, so raw seconds also work', () => {
+    // 084 shows as 00:84 while typing and commits to 01:24.
+    expect(digitsToSeconds('84')).toBe(84);
+    expect(digitsToSeconds('90')).toBe(90);
+    expect(formatTime(digitsToSeconds('90'))).toBe('01:30');
+    expect(formatTime(digitsToSeconds('130'))).toBe('01:30');
+  });
+
+  it('agrees with what the field displays', () => {
+    for (const digits of ['8', '84', '840', '1230', '12345', '123456']) {
+      expect(parseTimeToSeconds(groupDigits(digits))).toBe(
+        digitsToSeconds(digits),
+      );
+    }
+  });
+});
+
+describe('parsePastedTime', () => {
+  it('reads a YouTube link carrying a time offset', () => {
+    expect(parsePastedTime('https://youtu.be/dQw4w9WgXcQ?t=90')).toBe(90);
+    expect(
+      parsePastedTime('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=125'),
+    ).toBe(125);
+    expect(parsePastedTime('?start=42')).toBe(42);
+  });
+
+  it('reads unit-suffixed durations', () => {
+    expect(parsePastedTime('90s')).toBe(90);
+    expect(parsePastedTime('1m30s')).toBe(90);
+    expect(parsePastedTime('1h2m3s')).toBe(3723);
+    expect(parsePastedTime('2m')).toBe(120);
+  });
+
+  it('reads plain timestamps and bare seconds', () => {
+    expect(parsePastedTime('1:30')).toBe(90);
+    expect(parsePastedTime('01:01:01')).toBe(3661);
+    expect(parsePastedTime('90')).toBe(90);
+    expect(parsePastedTime('  1:30  ')).toBe(90);
+  });
+
+  it('returns null when there is nothing to read, so entry falls back to digits', () => {
+    expect(parsePastedTime('')).toBeNull();
+    expect(parsePastedTime('lecture notes')).toBeNull();
+    expect(parsePastedTime('https://youtu.be/dQw4w9WgXcQ')).toBeNull();
+  });
+});

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,157 @@
+/**
+ * Time formatting and parsing for video timestamps.
+ *
+ * Timestamps are stored on video items as `(HH:)?MM:SS` strings, but seconds
+ * are the only sensible thing to compute with. Everything here converts between
+ * the two so the rest of the app can hold seconds and format once, at the edge.
+ */
+
+/** Most digits a timestamp field accepts: HHMMSS. */
+export const MAX_TIME_DIGITS = 6;
+
+/**
+ * Seconds to a display string — `MM:SS`, widening to `H:MM:SS` past an hour.
+ *
+ * Minutes stay zero-padded because that is the shape already stored on existing
+ * items. The hour component is the important part: the previous implementation
+ * computed minutes as `(total % 3600) / 60`, so an hour-long lecture trimmed to
+ * 1:01:01 was written to the database as "01:01" — a little over a minute. Any
+ * video past the hour mark silently lost its hours.
+ */
+export function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '00:00';
+
+  const total = Math.floor(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+
+  const mm = String(minutes).padStart(2, '0');
+  const ss = String(secs).padStart(2, '0');
+
+  return hours > 0 ? `${hours}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+/**
+ * A stored or pasted timestamp to seconds.
+ *
+ * Accepts `H:MM:SS`, `MM:SS`, and a bare number of seconds. Components are not
+ * clamped to 59 — `0:90` means ninety seconds, which is what makes typing raw
+ * seconds into a timestamp field work.
+ */
+export function parseTimeToSeconds(
+  value?: string | number | null,
+): number {
+  if (value === null || value === undefined) return 0;
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+  }
+
+  const raw = String(value).trim();
+  if (!raw) return 0;
+
+  if (!raw.includes(':')) {
+    const asNumber = Number(raw);
+    return Number.isFinite(asNumber) && asNumber > 0 ? Math.floor(asNumber) : 0;
+  }
+
+  const parts = raw.split(':');
+  if (parts.length > 3) return 0;
+
+  let total = 0;
+  for (const part of parts) {
+    const n = Number(part.trim());
+    if (!Number.isFinite(n) || n < 0) return 0;
+    total = total * 60 + Math.floor(n);
+  }
+  return total;
+}
+
+/**
+ * Keep only the digits that matter, newest-last.
+ *
+ * Leading zeros are dropped so the field does not creep into showing an hours
+ * component the teacher never typed, but a lone "0" survives — otherwise
+ * pressing 0 as the first keystroke blanks the field.
+ */
+export function normalizeDigits(input: string): string {
+  const digits = String(input ?? '')
+    .replace(/\D/g, '')
+    .replace(/^0+(?=\d)/, '');
+  return digits.slice(-MAX_TIME_DIGITS);
+}
+
+/**
+ * Digits to the masked display string, filled right to left like a stopwatch:
+ * `8` → `00:08`, `840` → `08:40`, `12345` → `01:23:45`.
+ *
+ * This is what removes the colon from the typing burden — the teacher types
+ * only digits, never a separator and never a modifier key.
+ */
+export function groupDigits(input: string): string {
+  const digits = normalizeDigits(input);
+  if (!digits) return '';
+
+  if (digits.length <= 4) {
+    const padded = digits.padStart(4, '0');
+    return `${padded.slice(0, 2)}:${padded.slice(2)}`;
+  }
+
+  const padded = digits.padStart(6, '0');
+  return `${padded.slice(0, 2)}:${padded.slice(2, 4)}:${padded.slice(4)}`;
+}
+
+/**
+ * Digits to seconds, using the same right-to-left reading as `groupDigits`.
+ *
+ * Components carry rather than clamp, so `084` is 84 seconds and normalises to
+ * 1:24 on commit. That is what lets someone who thinks in raw seconds type
+ * `90` and get 1:30 — the two mental models converge instead of one being wrong.
+ */
+export function digitsToSeconds(input: string): number {
+  const digits = normalizeDigits(input);
+  if (!digits) return 0;
+
+  const padded = digits.length <= 4 ? digits.padStart(4, '0') : digits.padStart(6, '0');
+
+  if (padded.length === 4) {
+    return Number(padded.slice(0, 2)) * 60 + Number(padded.slice(2));
+  }
+  return (
+    Number(padded.slice(0, 2)) * 3600 +
+    Number(padded.slice(2, 4)) * 60 +
+    Number(padded.slice(4))
+  );
+}
+
+/**
+ * Pull a timestamp out of pasted text.
+ *
+ * Teachers paste from a lot of places — a YouTube share link with `?t=`, a
+ * comment reading `1m30s`, a bare `90`, or a plain `1:30`. Returning null when
+ * nothing is recognisable lets the caller fall back to digit entry.
+ */
+export function parsePastedTime(text: string): number | null {
+  const raw = String(text ?? '').trim();
+  if (!raw) return null;
+
+  // A YouTube url or query fragment carrying ?t= / &start=
+  const urlMatch = raw.match(/[?&](?:t|start)=(\d+)/);
+  if (urlMatch) return Number(urlMatch[1]);
+
+  // 1h2m3s / 1m30s / 90s
+  const unitMatch = raw.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (unitMatch && (unitMatch[1] || unitMatch[2] || unitMatch[3])) {
+    return (
+      Number(unitMatch[1] ?? 0) * 3600 +
+      Number(unitMatch[2] ?? 0) * 60 +
+      Number(unitMatch[3] ?? 0)
+    );
+  }
+
+  if (/^\d{1,2}(:\d{1,2}){1,2}$/.test(raw)) return parseTimeToSeconds(raw);
+  if (/^\d+$/.test(raw)) return Number(raw);
+
+  return null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -841,6 +841,9 @@ importers:
       vite:
         specifier: ^6.2.6
         version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.2(@types/node@22.19.1)(typescript@5.9.3))(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)
 
 packages:
 


### PR DESCRIPTION
Addresses #499 and the input half of #1245.

## The reported problem

The start/end fields couldn't be selected and overwritten. The container around them set `user-select: none`, which inherits — so double-clicking the value selected nothing, and every edit meant deleting characters one at a time. That style is gone, and both fields now select their contents on focus, so tab-in-and-retype is one gesture.

## Typing

Entry is right-to-left like a stopwatch — `840` becomes 08:40 — so no colon and no modifier key is ever needed, and `inputMode="numeric"` brings up the keypad on a tablet.

Digits carry rather than clamp, so someone thinking in raw seconds can type `90` and land on 1:30 instead of being silently clamped to 0:59. A preview line under the field shows the normalised reading whenever it differs from the raw digits (`00:84` → `= 01:24`), so there's never doubt about what the digits mean.

Arrow keys nudge ±1s, Shift ±10s, Page Up/Down ±60s. Paste understands `1:30`, `90`, `90s`, `1m30s`, and a YouTube `?t=` link.

## Two real bugs fixed along the way

**Hours were being dropped on save.** `formatTime` computed minutes as `(total % 3600) / 60` and never emitted an hours component, so an hour-long lecture trimmed to 1:01:01 was written to the database as `"01:01"` — a little over a minute. It now widens to `H:MM:SS`, which the backend validator (`/^(\d{1,2}:)?\d{1,2}:\d{2}$/`) has always accepted.

**Three length limits on one field disagreed** — the change handler allowed 6 digits, the formatter bailed out above 4, and the input carried `maxLength={5}`. So `HH:MM:SS` was unreachable despite being parsed, and 5 digits fell through to being read as raw seconds.

## Structure

Timestamps are now held once, in seconds. `range`, `timeInputs` and `errors` were three copies of the same fact reconciled by hand across six effects — which is why range validation needed a `setTimeout(…, 0)` to read around its own stale closure. Errors are derived now, that workaround is gone, and so is a clamp that produced `-1` when the end time hadn't loaded yet.

New files: `utils/time.ts` (pure formatting/parsing), `hooks/useTimeRange.ts` (draft + derived validation), `components/TimeRangePicker.tsx`. Net −271 lines in `Video-modal.tsx`.

## Test plan

- Frontend had **no test runner**; this adds vitest and a `test` script.
- 19 tests over the parsing/formatting logic, including the hour-dropping regression and the `groupDigits`/`digitsToSeconds`/`parseTimeToSeconds` agreement.
- `tsc --noEmit` shows 1201 errors both before and after, with the same three in `Video-modal.tsx` — no new type errors introduced, none fixed.
- `vite build` succeeds (needs `NODE_OPTIONS=--max-old-space-size=8192`; the 18MB bundle OOMs the default heap on `main` too).
- `gts lint` reports nothing on the three new files.

**Not verified in a browser** — the logic is unit-tested and it builds, but I haven't clicked through the modal. Worth a manual pass on: focus/select behaviour, the preview line, and the arrow-key nudge.
