### PR TITLE
fix(support-chat): make the bot answer from the FAQ set

### DIFF
--- a/SUPPORT_CHAT_SETUP.md
+++ b/SUPPORT_CHAT_SETUP.md
@@ -51,32 +51,14 @@ frontend/src/
 
 ## Integration Steps
 
-### Step 1: Add Module to Container
+### Steps 1 & 2: Container and controllers — already done
 
-In your main application container setup (e.g., `backend/src/container.ts`):
+`loadAppModules` walks `backend/src/modules/*` and picks up each module's
+`<name>ContainerModules` and `<name>ModuleControllers` exports, both of which
+`supportChat/index.ts` provides. Nothing has to be registered by hand.
 
-```typescript
-import { supportChatContainerModule } from '@/modules/supportChat';
-
-// Add to container setup
-container.load(supportChatContainerModule);
-```
-
-### Step 2: Register Controllers
-
-If using routing-controllers:
-
-```typescript
-import { useContainer, useControllers } from 'routing-controllers';
-import { ChatController, AdminController } from '@/modules/supportChat';
-
-useContainer(container);
-useControllers([
-  // ... other controllers
-  ChatController,
-  AdminController,
-]);
-```
+Controller paths must **not** include `/api`: the app mounts
+routing-controllers with `routePrefix: '/api'` already.
 
 ### Step 3: Initialize Database Indexes
 
@@ -103,19 +85,21 @@ await initializeSupportChat();
 
 Add to your `.env` file:
 
+Every one of these is optional. With none of them set the bot still answers from
+the FAQ set by lexical matching; embeddings only sharpen the ranking.
+
 ```env
-# Minimax API Configuration
+# Minimax embeddings (optional layer)
 MINIMAX_API_KEY=your-minimax-api-key
-MINIMAX_API_URL=https://api.minimax.chat/v1      # Optional, defaults to this
+MINIMAX_GROUP_ID=your-minimax-group-id
+MINIMAX_API_URL=https://api.minimax.io/v1        # Optional, defaults to this
 MINIMAX_EMBEDDING_MODEL=embo-01                   # Optional, defaults to this
 
 # Support Chat Configuration
-FAQ_CONFIDENCE_THRESHOLD=0.75
+FAQ_CONFIDENCE_THRESHOLD=0.75                     # Bar when embeddings are available
+FAQ_LEXICAL_CONFIDENCE_THRESHOLD=0.45             # Bar when they are not
 MONGODB_FAQ_COLLECTION=supportFaqs
 MONGODB_QUESTIONS_COLLECTION=supportQuestions
-
-# Frontend API (if separate from main app)
-REACT_APP_API_URL=http://localhost:3001
 ```
 
 ### Step 5: Seed Initial FAQs
@@ -361,15 +345,19 @@ Visit: `http://localhost:3000/teacher/support`
 ## Troubleshooting
 
 ### Embeddings not generating
-- Verify `MINIMAX_API_KEY` is set and valid
-- Check Minimax API quota and rate limits
-- Verify `MINIMAX_API_URL` is correct (defaults to `https://api.minimax.chat/v1`)
-- Embeddings are cached in FAQ documents after first creation
+- Verify `MINIMAX_API_KEY` is set and valid. Minimax answers a bad key with
+  HTTP 200 and `base_resp.status_code: 2049`, so a green status code proves
+  nothing — the service logs the decoded error
+- After a failure the service stops calling the provider for
+  `SUPPORT_CHAT_EMBEDDING_COOLDOWN_MS` (default 10 min) and matches lexically
+- Verify `MINIMAX_API_URL` is correct (defaults to `https://api.minimax.io/v1`)
+- Embeddings are generated lazily for the best-matching FAQs and stored on the
+  FAQ document, a few per chat turn
 
-### Questions not escalating to admin
-- Check confidence threshold (default 0.75)
-- Verify FAQ embeddings exist (`faq.embedding` field populated)
-- Check `SUPPORT_CHAT_EMBEDDING_MODEL` is set correctly
+### Every question escalates to admin
+- Confirm the FAQ set is seeded and the documents have `isActive: true`
+- Lower `FAQ_LEXICAL_CONFIDENCE_THRESHOLD` (default 0.45) to inspect near-misses
+- With embeddings configured the bar is `FAQ_CONFIDENCE_THRESHOLD` (default 0.75)
 
 ### Admin dashboard not loading questions
 - Verify admin has correct role (`admin` or `staff`)

--- a/backend/src/modules/supportChat/README.md
+++ b/backend/src/modules/supportChat/README.md
@@ -58,10 +58,11 @@ supportChat/
 
 ## Key Features
 
-### 1. Semantic FAQ Retrieval
-- Uses Anthropic Claude embeddings for intelligent question matching
-- Confidence-based filtering (threshold: 0.75)
-- Combines similarity score, keyword overlap, recency, and popularity
+### 1. FAQ Retrieval
+- Lexical (IDF-weighted term coverage) matching that works with no external service
+- Optional MiniMax embeddings layered on top when a key is configured, generated
+  lazily per FAQ and stored, so the provider is never on the critical path
+- Confidence-based filtering, with a separate lower bar for lexical-only matching
 - No hallucinations - returns only FAQ content
 
 ### 2. Admin Fallback Workflow
@@ -158,13 +159,16 @@ All types are defined in `types.ts`:
 
 ## Environment Configuration
 
-Required `.env` variables:
+All of these are optional — with none of them set the bot still answers from the
+FAQ set using lexical matching.
 
 ```env
-MINIMAX_API_KEY=your-minimax-api-key    # Minimax API key
-MINIMAX_API_URL=https://api.minimax.chat/v1  # Minimax API endpoint (optional)
-MINIMAX_EMBEDDING_MODEL=embo-01         # Minimax embedding model (optional)
-FAQ_CONFIDENCE_THRESHOLD=0.75           # Minimum confidence for auto-response
+MINIMAX_API_KEY=your-minimax-api-key         # enables the embedding layer
+MINIMAX_GROUP_ID=your-minimax-group-id       # MiniMax sends this as a query param
+MINIMAX_API_URL=https://api.minimax.io/v1    # embedding endpoint host
+MINIMAX_EMBEDDING_MODEL=embo-01
+FAQ_CONFIDENCE_THRESHOLD=0.75                # bar when embeddings are available
+FAQ_LEXICAL_CONFIDENCE_THRESHOLD=0.45        # bar when they are not
 MONGODB_FAQ_COLLECTION=supportFaqs
 MONGODB_QUESTIONS_COLLECTION=supportQuestions
 ```
@@ -216,14 +220,24 @@ for (const faqData of initialFAQs) {
 
 ## Retrieval Algorithm
 
-The FAQ retrieval uses a multi-factor scoring system:
+Every question is scored lexically first, because that path has no external
+dependency and works on FAQs that have never been embedded:
 
-1. **Semantic Similarity (70%)**: Cosine similarity between question and FAQ embeddings via Claude
-2. **Keyword Overlap (20%)**: Percentage of query words appearing in FAQ
-3. **Recency (-10%)**: Penalty for FAQs not updated in 365+ days
-4. **Popularity (+0.0001 per use)**: Boost for frequently helpful FAQs
+**Lexical score**: the share of the question's information — each term weighted
+by its inverse document frequency across the FAQ set — that the FAQ covers,
+discounted by where the term was found (its own question 1.0, tags 0.8,
+answer 0.5). Terms no FAQ contains still count against coverage, so a question
+about something unknown cannot score a confident match.
 
-Result is escalated to admin if top score < 0.75 threshold.
+If an embedding provider is reachable, the question is embedded, the top lexical
+candidates have their own embeddings generated and stored (bounded per request),
+and the final score becomes `0.7 × cosine similarity + 0.3 × lexical`. Popularity
+adds a tiebreak of at most 0.01. Recency is reported but no longer penalises.
+
+The bar depends on which signal was available: `FAQ_CONFIDENCE_THRESHOLD` (0.75)
+with embeddings, `FAQ_LEXICAL_CONFIDENCE_THRESHOLD` (0.45) without. Anything
+below it, or any retrieval failure, escalates to the admin queue rather than
+erroring the chat turn.
 
 ## Security & Access Control
 
@@ -273,12 +287,17 @@ Track metrics from `supportAnalytics`:
 - `inversify`: Dependency injection
 - `routing-controllers`: Express decorators
 - `mongodb`: Database access
-- `@anthropic-ai/sdk`: Claude embeddings & API
 - `class-validator`: Input validation
+
+Embeddings are fetched over `fetch` from MiniMax; no vendor SDK is required.
 
 ## Support & Debugging
 
 **Check logs**: Look for "ChatService", "FAQRetrievalService", "AdminService" logger outputs
 **Test retrieval**: Use ChatService.handleUserQuestion() with test questions
-**Verify embeddings**: Ensure Anthropic API key is set and API is accessible
+**Everything escalates**: check the FAQ set is non-empty and `isActive`, then
+lower `FAQ_LEXICAL_CONFIDENCE_THRESHOLD` to see the near-misses
+**Embeddings look inert**: the service logs once and stops calling the provider
+for `SUPPORT_CHAT_EMBEDDING_COOLDOWN_MS` after a failure — MiniMax reports a bad
+key as HTTP 200 with a non-zero `base_resp.status_code`
 **Monitor queue**: Admin dashboard shows pending questions count

--- a/backend/src/modules/supportChat/container.ts
+++ b/backend/src/modules/supportChat/container.ts
@@ -4,23 +4,33 @@ import { FAQRepository, SupportQuestionRepository } from './repositories/provide
 import { ChatService, FAQRetrievalService, AdminService } from './services/index.js';
 import { ChatController, AdminController } from './controllers/index.js';
 
+// Everything here is injected by symbol, and the symbol bindings carry the
+// singleton scope: without it each injection site gets its own instance, so
+// per-service state (the retrieval service's embedding-provider cooldown) would
+// never be shared between the learner and admin controllers.
 export const supportChatContainerModule = new ContainerModule(options => {
   // Repositories
   options.bind(FAQRepository).toSelf().inSingletonScope();
-  options.bind(SUPPORT_CHAT_TYPES.FAQRepo).to(FAQRepository);
+  options.bind(SUPPORT_CHAT_TYPES.FAQRepo).to(FAQRepository).inSingletonScope();
 
   options.bind(SupportQuestionRepository).toSelf().inSingletonScope();
-  options.bind(SUPPORT_CHAT_TYPES.SupportQuestionRepo).to(SupportQuestionRepository);
+  options
+    .bind(SUPPORT_CHAT_TYPES.SupportQuestionRepo)
+    .to(SupportQuestionRepository)
+    .inSingletonScope();
 
   // Services
   options.bind(FAQRetrievalService).toSelf().inSingletonScope();
-  options.bind(SUPPORT_CHAT_TYPES.FAQRetrievalService).to(FAQRetrievalService);
+  options
+    .bind(SUPPORT_CHAT_TYPES.FAQRetrievalService)
+    .to(FAQRetrievalService)
+    .inSingletonScope();
 
   options.bind(ChatService).toSelf().inSingletonScope();
-  options.bind(SUPPORT_CHAT_TYPES.ChatService).to(ChatService);
+  options.bind(SUPPORT_CHAT_TYPES.ChatService).to(ChatService).inSingletonScope();
 
   options.bind(AdminService).toSelf().inSingletonScope();
-  options.bind(SUPPORT_CHAT_TYPES.AdminService).to(AdminService);
+  options.bind(SUPPORT_CHAT_TYPES.AdminService).to(AdminService).inSingletonScope();
 
   // Controllers
   options.bind(ChatController).toSelf().inSingletonScope();

--- a/backend/src/modules/supportChat/controllers/AdminController.ts
+++ b/backend/src/modules/supportChat/controllers/AdminController.ts
@@ -25,7 +25,8 @@ import {
   UpdateFAQBody,
 } from '../classes/validators/SupportChatValidators.js';
 
-@JsonController('/api/admin/support')
+// '/api' comes from the app-level routePrefix; see ChatController.
+@JsonController('/admin/support')
 @injectable()
 export class AdminController {
   constructor(@inject(SUPPORT_CHAT_TYPES.AdminService) private adminService: AdminService) {}

--- a/backend/src/modules/supportChat/controllers/ChatController.ts
+++ b/backend/src/modules/supportChat/controllers/ChatController.ts
@@ -24,7 +24,9 @@ import {
   SupportQuestionPathParams,
 } from '../classes/validators/SupportChatValidators.js';
 
-@JsonController('/api/support/chat')
+// The app mounts routing-controllers with routePrefix '/api', so the prefix is
+// omitted here — declaring it would serve the routes at /api/api/support/chat.
+@JsonController('/support/chat')
 @injectable()
 export class ChatController {
   constructor(@inject(SUPPORT_CHAT_TYPES.ChatService) private chatService: ChatService) {}

--- a/backend/src/modules/supportChat/repositories/providers/mongodb/FAQRepository.ts
+++ b/backend/src/modules/supportChat/repositories/providers/mongodb/FAQRepository.ts
@@ -2,17 +2,18 @@ import { inject, injectable } from 'inversify';
 import { Collection, ObjectId } from 'mongodb';
 import { IFAQ, SUPPORT_CHAT_CONFIG, FAQCategory } from '../../../types.js';
 import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
 
 @injectable()
 export class FAQRepository {
-  constructor(@inject(GLOBAL_TYPES.Database) private db: any) {}
+  constructor(@inject(GLOBAL_TYPES.Database) private db: MongoDatabase) {}
 
-  private getCollection(): Collection<IFAQ> {
-    return this.db.collection(SUPPORT_CHAT_CONFIG.collectionsNames.faq);
+  private async getCollection(): Promise<Collection<IFAQ>> {
+    return this.db.getCollection<IFAQ>(SUPPORT_CHAT_CONFIG.collectionsNames.faq);
   }
 
   async create(faq: Omit<IFAQ, '_id' | 'createdAt' | 'updatedAt'>): Promise<IFAQ> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     const now = new Date();
     const document = {
       ...faq,
@@ -29,12 +30,12 @@ export class FAQRepository {
   }
 
   async findById(id: ObjectId): Promise<IFAQ | null> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     return collection.findOne({ _id: id });
   }
 
   async findAll(filters?: { isActive?: boolean; category?: FAQCategory }): Promise<IFAQ[]> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     const query: any = {};
 
     if (filters?.isActive !== undefined) {
@@ -48,7 +49,7 @@ export class FAQRepository {
   }
 
   async updateById(id: ObjectId, updates: Partial<IFAQ>): Promise<IFAQ | null> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     const result = await collection.findOneAndUpdate(
       { _id: id },
       {
@@ -63,19 +64,29 @@ export class FAQRepository {
     return result as IFAQ | null;
   }
 
+  /**
+   * Persists a generated embedding so it is computed once per FAQ rather than
+   * on every retrieval. Seeded FAQs arrive without one; the retrieval service
+   * backfills them lazily through here.
+   */
+  async setEmbedding(id: ObjectId, embedding: number[]): Promise<void> {
+    const collection = await this.getCollection();
+    await collection.updateOne({ _id: id }, { $set: { embedding } });
+  }
+
   async incrementUsageCount(id: ObjectId): Promise<void> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     await collection.updateOne({ _id: id }, { $inc: { usageCount: 1 } });
   }
 
   async deleteById(id: ObjectId): Promise<boolean> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     const result = await collection.deleteOne({ _id: id });
     return result.deletedCount === 1;
   }
 
   async search(query: string, limit: number = 10): Promise<IFAQ[]> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     return collection
       .find({
         isActive: true,
@@ -86,17 +97,17 @@ export class FAQRepository {
   }
 
   async findByCategory(category: FAQCategory): Promise<IFAQ[]> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     return collection.find({ category, isActive: true }).toArray();
   }
 
   async findByTag(tag: string): Promise<IFAQ[]> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     return collection.find({ tags: tag, isActive: true }).toArray();
   }
 
   async findRelated(faqId: ObjectId): Promise<IFAQ[]> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     const faq = await this.findById(faqId);
     if (!faq?.relatedFaqIds || faq.relatedFaqIds.length === 0) {
       return [];
@@ -111,7 +122,7 @@ export class FAQRepository {
   }
 
   async createIndex(): Promise<void> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     await collection.createIndex({ category: 1, isActive: 1 });
     await collection.createIndex({ tags: 1 });
     await collection.createIndex({ createdAt: -1 });

--- a/backend/src/modules/supportChat/repositories/providers/mongodb/SupportQuestionRepository.ts
+++ b/backend/src/modules/supportChat/repositories/providers/mongodb/SupportQuestionRepository.ts
@@ -2,17 +2,20 @@ import { inject, injectable } from 'inversify';
 import { Collection, ObjectId } from 'mongodb';
 import { ISupportQuestion, SUPPORT_CHAT_CONFIG, SupportQuestionStatus, ResolutionRating } from '../../../types.js';
 import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
 
 @injectable()
 export class SupportQuestionRepository {
-  constructor(@inject(GLOBAL_TYPES.Database) private db: any) {}
+  constructor(@inject(GLOBAL_TYPES.Database) private db: MongoDatabase) {}
 
-  private getCollection(): Collection<ISupportQuestion> {
-    return this.db.collection(SUPPORT_CHAT_CONFIG.collectionsNames.questions);
+  private async getCollection(): Promise<Collection<ISupportQuestion>> {
+    return this.db.getCollection<ISupportQuestion>(
+      SUPPORT_CHAT_CONFIG.collectionsNames.questions,
+    );
   }
 
   async create(question: Omit<ISupportQuestion, '_id' | 'createdAt' | 'updatedAt'>): Promise<ISupportQuestion> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     const now = new Date();
     const document = {
       ...question,
@@ -29,12 +32,12 @@ export class SupportQuestionRepository {
   }
 
   async findById(id: ObjectId): Promise<ISupportQuestion | null> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     return collection.findOne({ _id: id });
   }
 
   async findByUserId(userId: ObjectId, limit: number = 50): Promise<ISupportQuestion[]> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     return collection
       .find({ userId })
       .sort({ createdAt: -1 })
@@ -43,7 +46,7 @@ export class SupportQuestionRepository {
   }
 
   async findByCourseId(courseId: ObjectId, filters?: { status?: SupportQuestionStatus }): Promise<ISupportQuestion[]> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     const query: any = { courseId };
 
     if (filters?.status) {
@@ -54,7 +57,7 @@ export class SupportQuestionRepository {
   }
 
   async findByStatus(status: SupportQuestionStatus, limit: number = 50): Promise<ISupportQuestion[]> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     return collection
       .find({ status })
       .sort({ createdAt: -1 })
@@ -67,7 +70,7 @@ export class SupportQuestionRepository {
   }
 
   async updateById(id: ObjectId, updates: Partial<ISupportQuestion>): Promise<ISupportQuestion | null> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     const result = await collection.findOneAndUpdate(
       { _id: id },
       {
@@ -91,7 +94,7 @@ export class SupportQuestionRepository {
     response: string,
     respondedByUserId: ObjectId
   ): Promise<ISupportQuestion | null> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     const result = await collection.findOneAndUpdate(
       { _id: id },
       {
@@ -138,7 +141,7 @@ export class SupportQuestionRepository {
     byStatus: Record<string, number>;
     avgResolutionTime: number;
   }> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
 
     const matchStage: any = {};
     if (courseId) {
@@ -207,7 +210,7 @@ export class SupportQuestionRepository {
   }
 
   async createIndex(): Promise<void> {
-    const collection = this.getCollection();
+    const collection = await this.getCollection();
     await collection.createIndex({ userId: 1, createdAt: -1 });
     await collection.createIndex({ status: 1, createdAt: -1 });
     await collection.createIndex({ courseId: 1, status: 1 });

--- a/backend/src/modules/supportChat/seeds/seedFAQs.ts
+++ b/backend/src/modules/supportChat/seeds/seedFAQs.ts
@@ -1,5 +1,6 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import * as dotenv from 'dotenv';
+import { FAQCategory, FAQSource } from '../types.js';
 
 dotenv.config({ path: '.env' });
 
@@ -296,6 +297,25 @@ This is the fastest way to get a ViBe issue resolved. Please attempt the self-tr
   },
 ];
 
+/**
+ * The copy above is grouped by the headings used on the internship FAQ page;
+ * the collection stores the module's own `FAQCategory` values, so map on the
+ * way in rather than writing categories nothing else in the module understands.
+ */
+const CATEGORY_MAP: Record<string, FAQCategory> = {
+  'getting-started': FAQCategory.LOGIN,
+  troubleshooting: FAQCategory.TECHNICAL,
+  setup: FAQCategory.TECHNICAL,
+  proctoring: FAQCategory.PROCTORING,
+  privacy: FAQCategory.PROCTORING,
+  progress: FAQCategory.FEATURES,
+  evaluation: FAQCategory.FEATURES,
+  learning: FAQCategory.FEATURES,
+  quiz: FAQCategory.FEATURES,
+  scoring: FAQCategory.FEATURES,
+  support: FAQCategory.OTHER,
+};
+
 async function seedFAQs() {
   // Use the same connection string as the app
   const uri = process.env.DB_URL || process.env.MONGODB_URI || 'mongodb://localhost:27017';
@@ -313,14 +333,18 @@ async function seedFAQs() {
     const db = client.db(dbName);
     const collection = db.collection(FAQ_COLLECTION_NAME);
 
-    // Clear existing FAQs
-    await collection.deleteMany({});
-    console.log('Cleared existing FAQs');
+    // Only clear previously seeded FAQs — FAQs an admin wrote from a learner
+    // question live in the same collection and must survive a re-seed.
+    const cleared = await collection.deleteMany({ source: FAQSource.IMPORTED });
+    console.log(`Cleared ${cleared.deletedCount} previously seeded FAQs`);
 
-    // Insert FAQs without embeddings (they will be generated on first use)
+    // Inserted without embeddings: FAQRetrievalService matches these lexically
+    // and backfills the vectors once an embedding provider is reachable.
     const result = await collection.insertMany(
       FAQS.map((faq) => ({
         ...faq,
+        category: CATEGORY_MAP[faq.category] ?? FAQCategory.OTHER,
+        source: FAQSource.IMPORTED,
         isActive: true,
         upvotes: 0,
         downvotes: 0,

--- a/backend/src/modules/supportChat/services/AdminService.ts
+++ b/backend/src/modules/supportChat/services/AdminService.ts
@@ -58,7 +58,7 @@ export class AdminService {
           embedding: await this.faqRetrieval.generateEmbeddingForFAQ({
             question: question.question,
             answer: request.response,
-          } as IFAQ),
+          }),
           upvotes: 0,
           downvotes: 0,
           usageCount: 0,
@@ -134,7 +134,9 @@ export class AdminService {
     adminUserId: ObjectId
   ): Promise<IFAQ> {
     try {
-      const embedding = await this.faqRetrieval.generateEmbeddingForFAQ(faq as IFAQ);
+      // undefined when the embedding provider is down; retrieval still matches
+      // the FAQ lexically and backfills the vector on a later chat turn.
+      const embedding = await this.faqRetrieval.generateEmbeddingForFAQ(faq);
 
       return await this.faqRepo.create({
         ...faq,

--- a/backend/src/modules/supportChat/services/FAQRetrievalService.ts
+++ b/backend/src/modules/supportChat/services/FAQRetrievalService.ts
@@ -64,12 +64,43 @@ export class FAQRetrievalService {
     return dotProduct / (magnitudeA * magnitudeB);
   }
 
+  /**
+   * Conservative suffix stripping, applied to questions and FAQs alike so both
+   * sides land on the same form. Without it a learner asking about "completing"
+   * videos misses an FAQ that says "completed", which is exactly the kind of
+   * near-miss that pushes a real match below the threshold.
+   */
+  private stem(word: string): string {
+    let stemmed = word;
+
+    if (stemmed.length > 4 && stemmed.endsWith('ies')) {
+      stemmed = `${stemmed.slice(0, -3)}i`;
+    } else if (stemmed.length > 4 && stemmed.endsWith('ses')) {
+      stemmed = stemmed.slice(0, -2);
+    } else if (stemmed.length > 3 && stemmed.endsWith('s') && !stemmed.endsWith('ss')) {
+      stemmed = stemmed.slice(0, -1);
+    }
+
+    if (stemmed.length > 5 && stemmed.endsWith('ing')) {
+      stemmed = stemmed.slice(0, -3);
+    } else if (stemmed.length > 4 && stemmed.endsWith('ed')) {
+      stemmed = stemmed.slice(0, -2);
+    }
+
+    // Collapses "update"/"updating" onto one form once 'ing' has gone.
+    if (stemmed.length > 4 && stemmed.endsWith('e')) {
+      stemmed = stemmed.slice(0, -1);
+    }
+
+    return stemmed;
+  }
+
   private tokenize(text: string): string[] {
     return text
       .toLowerCase()
       .split(/[^a-z0-9]+/)
-      .map((word) => (word.length > 3 && word.endsWith('s') ? word.slice(0, -1) : word))
-      .filter((word) => word.length > 1 && !STOP_WORDS.has(word));
+      .filter((word) => word.length > 1 && !STOP_WORDS.has(word))
+      .map((word) => this.stem(word));
   }
 
   /**

--- a/backend/src/modules/supportChat/services/FAQRetrievalService.ts
+++ b/backend/src/modules/supportChat/services/FAQRetrievalService.ts
@@ -6,16 +6,40 @@ import {
   SUPPORT_CHAT_TYPES,
 } from '../types.js';
 import { FAQRepository } from '../repositories/providers/mongodb/index.js';
+
+/**
+ * Words carrying no retrieval signal in support questions. Kept deliberately
+ * short: over-stripping hurts more than it helps on questions this brief.
+ */
+const STOP_WORDS = new Set([
+  'a', 'about', 'after', 'all', 'am', 'an', 'and', 'any', 'are', 'as', 'at',
+  'be', 'been', 'but', 'by', 'can', 'cant', 'do', 'does', 'doing', 'dont', 'for',
+  'from', 'get', 'getting', 'had', 'has', 'have', 'how', 'i', 'if', 'im', 'in',
+  'into', 'is', 'it', 'its', 'me', 'my', 'no', 'not', 'of', 'on', 'or', 'please',
+  'so', 'some', 'that', 'the', 'their', 'them', 'then', 'there', 'these', 'they',
+  'this', 'to', 'up', 'use', 'want', 'was', 'we', 'what', 'when', 'where', 'which',
+  'why', 'will', 'with', 'would', 'you', 'your',
+]);
+
+/** Per-field weight for a query term found in an FAQ. */
+const FIELD_WEIGHTS = { question: 1, tags: 0.8, answer: 0.5 };
+
 @injectable()
 export class FAQRetrievalService {
   private minimaxApiKey = process.env.MINIMAX_API_KEY;
-  private minimaxApiUrl = process.env.MINIMAX_API_URL || 'https://api.minimax.chat/v1';
-  private minimaxEmbeddingModel =
-    process.env.MINIMAX_EMBEDDING_MODEL || 'embo-01';
+
+  /**
+   * Epoch ms before which the embedding provider is not called again. Set after
+   * a failure so one bad key does not add a doomed HTTP round-trip to every
+   * chat turn; retrieval keeps working lexically in the meantime.
+   */
+  private embeddingCooldownUntil = 0;
 
   constructor(@inject(SUPPORT_CHAT_TYPES.FAQRepo) private faqRepo: FAQRepository) {
     if (!this.minimaxApiKey) {
-      console.warn('MINIMAX_API_KEY not set - embedding generation will fail');
+      console.warn(
+        'MINIMAX_API_KEY not set - support chat will match FAQs lexically only'
+      );
     }
   }
 
@@ -40,50 +64,171 @@ export class FAQRetrievalService {
     return dotProduct / (magnitudeA * magnitudeB);
   }
 
-  private calculateKeywordOverlap(query: string, text: string): number {
-    const queryWords = query.toLowerCase().split(/\s+/);
-    const textWords = text.toLowerCase().split(/\s+/);
-
-    const matches = queryWords.filter((word) => textWords.some((tw) => tw.includes(word)));
-
-    return matches.length / Math.max(queryWords.length, 1);
+  private tokenize(text: string): string[] {
+    return text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .map((word) => (word.length > 3 && word.endsWith('s') ? word.slice(0, -1) : word))
+      .filter((word) => word.length > 1 && !STOP_WORDS.has(word));
   }
 
-  async getEmbedding(text: string): Promise<number[]> {
+  /**
+   * Inverse document frequency over the FAQ set, so that a shared rare term
+   * ("proctoring") counts for far more than a shared common one ("course").
+   */
+  private buildIdf(faqs: IFAQ[]): Map<string, number> {
+    const documentFrequency = new Map<string, number>();
+
+    for (const faq of faqs) {
+      const terms = new Set(this.tokenize(`${faq.question} ${faq.answer} ${faq.tags.join(' ')}`));
+      for (const term of terms) {
+        documentFrequency.set(term, (documentFrequency.get(term) || 0) + 1);
+      }
+    }
+
+    const idf = new Map<string, number>();
+    for (const [term, frequency] of documentFrequency) {
+      idf.set(term, Math.log(1 + faqs.length / (1 + frequency)));
+    }
+
+    return idf;
+  }
+
+  /**
+   * Fraction of the query's information (IDF-weighted) that the FAQ covers,
+   * discounted by which field the match landed in. 1 means every meaningful
+   * query term appears in the FAQ's own question.
+   */
+  private lexicalScore(
+    queryTerms: string[],
+    idf: Map<string, number>,
+    unseenTermIdf: number,
+    faq: IFAQ
+  ): number {
+    if (queryTerms.length === 0) return 0;
+
+    const questionTerms = new Set(this.tokenize(faq.question));
+    const tagTerms = new Set(this.tokenize(faq.tags.join(' ')));
+    const answerTerms = new Set(this.tokenize(faq.answer));
+
+    let matched = 0;
+    let total = 0;
+
+    for (const term of new Set(queryTerms)) {
+      // Unseen terms still count against coverage, at a floor weight, so a
+      // question full of terms no FAQ knows cannot score a confident match.
+      const weight = idf.get(term) ?? unseenTermIdf;
+      total += weight;
+
+      if (questionTerms.has(term)) {
+        matched += weight * FIELD_WEIGHTS.question;
+      } else if (tagTerms.has(term)) {
+        matched += weight * FIELD_WEIGHTS.tags;
+      } else if (answerTerms.has(term)) {
+        matched += weight * FIELD_WEIGHTS.answer;
+      }
+    }
+
+    return total === 0 ? 0 : matched / total;
+  }
+
+  private embeddingProviderAvailable(): boolean {
+    return Boolean(this.minimaxApiKey) && Date.now() >= this.embeddingCooldownUntil;
+  }
+
+  private disableEmbeddingsTemporarily(reason: unknown): void {
+    this.embeddingCooldownUntil = Date.now() + SUPPORT_CHAT_CONFIG.embeddingCooldownMs;
+    console.warn(
+      'Support chat embedding provider unavailable, falling back to lexical matching',
+      reason
+    );
+  }
+
+  /**
+   * MiniMax embeddings. `type` is part of their contract: stored FAQ vectors
+   * are indexed as 'db', the incoming question as 'query'.
+   */
+  async getEmbedding(text: string, type: 'db' | 'query' = 'query'): Promise<number[]> {
+    if (!this.minimaxApiKey) {
+      throw new Error('MINIMAX_API_KEY is not configured');
+    }
+
+    const groupId = SUPPORT_CHAT_CONFIG.minimaxGroupId;
+    const url = `${SUPPORT_CHAT_CONFIG.minimaxApiUrl}/embeddings${
+      groupId ? `?GroupId=${groupId}` : ''
+    }`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.minimaxApiKey}`,
+      },
+      body: JSON.stringify({
+        model: SUPPORT_CHAT_CONFIG.embeddingModel,
+        texts: [text],
+        type,
+      }),
+      signal: AbortSignal.timeout(SUPPORT_CHAT_CONFIG.embeddingTimeoutMs),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Minimax API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as {
+      vectors?: number[][];
+      data?: Array<{ embedding: number[] }>;
+      base_resp?: { status_code?: number; status_msg?: string };
+    };
+
+    // MiniMax reports auth and quota failures with HTTP 200 and a non-zero
+    // base_resp.status_code, so response.ok alone proves nothing.
+    if (data?.base_resp && data.base_resp.status_code !== 0) {
+      throw new Error(
+        `Minimax API error ${data.base_resp.status_code}: ${data.base_resp.status_msg}`
+      );
+    }
+
+    const embedding = data?.vectors?.[0] ?? data?.data?.[0]?.embedding;
+    if (!Array.isArray(embedding) || embedding.length === 0) {
+      throw new Error('Invalid embedding response from Minimax');
+    }
+
+    return embedding;
+  }
+
+  /** Embedding, or null if the provider is unconfigured or failing. Never throws. */
+  private async tryGetEmbedding(
+    text: string,
+    type: 'db' | 'query'
+  ): Promise<number[] | null> {
+    if (!this.embeddingProviderAvailable()) return null;
+
     try {
-      if (!this.minimaxApiKey) {
-        throw new Error('MINIMAX_API_KEY is not configured');
-      }
-
-      const response = await fetch(`${this.minimaxApiUrl}/embeddings`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.minimaxApiKey}`,
-        },
-        body: JSON.stringify({
-          model: this.minimaxEmbeddingModel,
-          input: text,
-          encoding_format: 'float',
-        }),
-      });
-
-      if (!response.ok) {
-        const error = (await response.json()) as { message?: string };
-        throw new Error(`Minimax API error: ${error?.message || response.statusText}`);
-      }
-
-      const data = (await response.json()) as { data?: Array<{ embedding: number[] }> };
-
-      // Minimax returns embeddings in data.data array
-      if (!data?.data || !Array.isArray(data.data) || data.data.length === 0) {
-        throw new Error('Invalid embedding response from Minimax');
-      }
-
-      return data.data[0].embedding;
+      return await this.getEmbedding(text, type);
     } catch (error) {
-      console.error('Error getting embedding from Minimax', error);
-      throw error;
+      this.disableEmbeddingsTemporarily(error);
+      return null;
+    }
+  }
+
+  /**
+   * Generates and stores embeddings for the best lexical candidates that lack
+   * one. Bounded per request, so a cold FAQ set fills in over a few chat turns
+   * instead of firing one API call per FAQ on the first question.
+   */
+  private async backfillEmbeddings(faqs: IFAQ[]): Promise<void> {
+    const pending = faqs
+      .filter((faq) => !faq.embedding?.length && faq._id)
+      .slice(0, SUPPORT_CHAT_CONFIG.maxEmbeddingBackfillPerRequest);
+
+    for (const faq of pending) {
+      const embedding = await this.tryGetEmbedding(`${faq.question} ${faq.answer}`, 'db');
+      if (!embedding) return; // provider just went into cooldown
+
+      faq.embedding = embedding;
+      await this.faqRepo.setEmbedding(faq._id!, embedding);
     }
   }
 
@@ -92,10 +237,6 @@ export class FAQRetrievalService {
     maxResults: number = SUPPORT_CHAT_CONFIG.maxSearchResults
   ): Promise<FAQRetrievalResult | null> {
     try {
-      // Get question embedding
-      const queryEmbedding = await this.getEmbedding(question);
-
-      // Fetch all active FAQs
       const faqs = await this.faqRepo.findAll({ isActive: true });
 
       if (faqs.length === 0) {
@@ -103,59 +244,68 @@ export class FAQRetrievalService {
         return null;
       }
 
-      // Score each FAQ
-      const scored = faqs
-        .map((faq) => {
-          const similarity = faq.embedding ? this.cosineSimilarity(queryEmbedding, faq.embedding) : 0;
+      // Lexical first: it always works, and its ranking decides which FAQs are
+      // worth spending embedding calls on.
+      const queryTerms = this.tokenize(question);
+      const idf = this.buildIdf(faqs);
+      // A term no FAQ contains is as informative as one in a single FAQ.
+      const unseenTermIdf = Math.log(1 + faqs.length);
+      const byLexical = faqs
+        .map((faq) => ({
+          faq,
+          lexical: this.lexicalScore(queryTerms, idf, unseenTermIdf, faq),
+        }))
+        .sort((a, b) => b.lexical - a.lexical);
 
-          const keywordMatch = this.calculateKeywordOverlap(question, faq.question);
+      const queryEmbedding = await this.tryGetEmbedding(question, 'query');
+      if (queryEmbedding) {
+        await this.backfillEmbeddings(byLexical.map((candidate) => candidate.faq));
+      }
 
-          // Recency factor (newer = lower value = better score)
-          const daysSinceUpdate = (Date.now() - faq.updatedAt.getTime()) / (1000 * 60 * 60 * 24);
+      const semanticWeight = queryEmbedding ? 0.7 : 0;
+      const threshold = queryEmbedding
+        ? SUPPORT_CHAT_CONFIG.confidenceThreshold
+        : SUPPORT_CHAT_CONFIG.lexicalConfidenceThreshold;
+
+      const scored = byLexical
+        .map(({ faq, lexical }) => {
+          const similarity =
+            queryEmbedding && faq.embedding?.length
+              ? this.cosineSimilarity(queryEmbedding, faq.embedding)
+              : 0;
+
+          // Reported for observability; neither term is allowed to decide a
+          // match on its own.
+          const daysSinceUpdate =
+            (Date.now() - faq.updatedAt.getTime()) / (1000 * 60 * 60 * 24);
           const recency = Math.min(daysSinceUpdate / 365, 1);
-
-          // Popularity factor (more usage = higher score boost)
           const popularity = Math.min(faq.usageCount / 100, 0.5);
 
-          // Combined score: 70% semantic similarity + 20% keyword + 10% recency + popularity bonus
-          const score =
-            similarity * 0.7 + keywordMatch * 0.2 - recency * 0.1 + popularity * 0.0001;
+          const relevance =
+            semanticWeight * similarity + (1 - semanticWeight) * lexical;
+          const score = Math.min(relevance + popularity * 0.01, 1);
 
-          return {
-            faq,
-            similarity,
-            recency,
-            popularity,
-            score,
-          };
+          return { faq, similarity, recency, popularity, score };
         })
         .sort((a, b) => b.score - a.score)
         .slice(0, maxResults);
 
-      if (!scored[0]) {
-        return null;
-      }
-
       const topResult = scored[0];
-
-      if (topResult.score < SUPPORT_CHAT_CONFIG.confidenceThreshold) {
+      if (!topResult || topResult.score < threshold) {
         return null;
       }
 
       return topResult as FAQRetrievalResult;
     } catch (error) {
+      // A retrieval failure must escalate the question, not 500 the chat turn.
       console.error('Error retrieving FAQ', error);
-      throw error;
+      return null;
     }
   }
 
-  async generateEmbeddingForFAQ(faq: IFAQ): Promise<number[]> {
-    try {
-      const textToEmbed = `${faq.question} ${faq.answer}`;
-      return await this.getEmbedding(textToEmbed);
-    } catch (error) {
-      console.error('Error generating FAQ embedding', error);
-      throw error;
-    }
+  /** Embedding for a new FAQ, or undefined when the provider is unavailable. */
+  async generateEmbeddingForFAQ(faq: Pick<IFAQ, 'question' | 'answer'>): Promise<number[] | undefined> {
+    const embedding = await this.tryGetEmbedding(`${faq.question} ${faq.answer}`, 'db');
+    return embedding ?? undefined;
   }
 }

--- a/backend/src/modules/supportChat/tests/FAQRetrievalService.test.ts
+++ b/backend/src/modules/supportChat/tests/FAQRetrievalService.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { FAQRetrievalService } from '../services/FAQRetrievalService.js';
+import { FAQCategory, IFAQ } from '../types.js';
+
+/**
+ * Retrieval has to answer questions with no embedding provider at all: seeded
+ * FAQs are stored without vectors, and MINIMAX_API_KEY may be missing or
+ * rejected. These specs pin the lexical path — the one that used to score at
+ * most 0.2 against a 0.75 threshold, so the bot escalated every question.
+ */
+
+function faq(overrides: Partial<IFAQ>): IFAQ {
+  return {
+    _id: new ObjectId(),
+    question: '',
+    answer: '',
+    category: FAQCategory.OTHER,
+    tags: [],
+    upvotes: 0,
+    downvotes: 0,
+    usageCount: 0,
+    createdBy: new ObjectId(),
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    isActive: true,
+    ...overrides,
+  };
+}
+
+const LOGIN_FAQ = faq({
+  question: 'How do I log in to ViBe?',
+  answer: 'Sign up as a student with the registered mail ID, then accept the course invite.',
+  category: FAQCategory.LOGIN,
+  tags: ['login', 'authentication', 'signup'],
+});
+
+const VIDEO_FAQ = faq({
+  question: 'Why are videos stuck or repeating?',
+  answer: 'Videos must be watched fully and in sequence, with camera permissions enabled.',
+  category: FAQCategory.TECHNICAL,
+  tags: ['video', 'playback', 'stuck'],
+});
+
+const PROCTORING_FAQ = faq({
+  question: 'What proctoring does ViBe use during a lesson?',
+  answer: 'Your camera stays on for anomaly detection while a lesson is in progress.',
+  category: FAQCategory.PROCTORING,
+  tags: ['proctoring', 'camera', 'anomaly'],
+});
+
+const FAQS = [LOGIN_FAQ, VIDEO_FAQ, PROCTORING_FAQ];
+
+function makeService(faqs: IFAQ[] | Error) {
+  const repo = {
+    findAll: vi.fn(async () => {
+      if (faqs instanceof Error) throw faqs;
+      return faqs;
+    }),
+    setEmbedding: vi.fn(async () => undefined),
+  };
+
+  return {
+    repo,
+    service: new FAQRetrievalService(repo as never),
+  };
+}
+
+describe('FAQRetrievalService without an embedding provider', () => {
+  beforeEach(() => {
+    // No key configured: the service must match lexically instead of throwing.
+    vi.stubEnv('MINIMAX_API_KEY', '');
+  });
+
+  it('answers a question that restates a seeded FAQ', async () => {
+    const { service } = makeService(FAQS);
+
+    const result = await service.retrieveFAQ('How do I log in to ViBe?');
+
+    expect(result?.faq.question).toBe(LOGIN_FAQ.question);
+    expect(result?.score).toBeGreaterThanOrEqual(0.75);
+    expect(result?.similarity).toBe(0);
+  });
+
+  it('answers a paraphrase that shares the FAQ\'s distinctive terms', async () => {
+    const { service } = makeService(FAQS);
+
+    const result = await service.retrieveFAQ('my videos keep repeating and get stuck');
+
+    expect(result?.faq.question).toBe(VIDEO_FAQ.question);
+  });
+
+  it('matches on tags when the wording differs', async () => {
+    const { service } = makeService(FAQS);
+
+    const result = await service.retrieveFAQ('camera anomaly during proctoring');
+
+    expect(result?.faq.question).toBe(PROCTORING_FAQ.question);
+  });
+
+  it('escalates a question no FAQ covers', async () => {
+    const { service } = makeService(FAQS);
+
+    expect(await service.retrieveFAQ('what is the meaning of life')).toBeNull();
+  });
+
+  it('escalates rather than throwing when the FAQ lookup fails', async () => {
+    const { service } = makeService(new Error('mongo down'));
+
+    expect(await service.retrieveFAQ('How do I log in to ViBe?')).toBeNull();
+  });
+
+  it('returns null when no FAQ is active', async () => {
+    const { service } = makeService([]);
+
+    expect(await service.retrieveFAQ('How do I log in to ViBe?')).toBeNull();
+  });
+
+  it('does not call the embedding provider when no key is configured', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const { service, repo } = makeService(FAQS);
+
+    await service.retrieveFAQ('How do I log in to ViBe?');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(repo.setEmbedding).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/backend/src/modules/supportChat/tests/supportChatRoutes.test.ts
+++ b/backend/src/modules/supportChat/tests/supportChatRoutes.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import { useExpressServer } from 'routing-controllers';
+import { supportChatModuleControllers } from '../index.js';
+
+/**
+ * The app mounts routing-controllers with `routePrefix: '/api'`. Controllers
+ * that also declare '/api' in their @JsonController path end up served at
+ * /api/api/..., which is how the support chat widget silently 404'd against a
+ * backend that looked correctly wired. Pin the mounted paths.
+ */
+
+function mountedPaths(): string[] {
+  const app = express();
+  useExpressServer(app, {
+    controllers: supportChatModuleControllers as Function[],
+    routePrefix: '/api',
+    authorizationChecker: async () => true,
+  });
+
+  const stack = (app as any)._router?.stack ?? (app as any).router?.stack ?? [];
+  return stack
+    .filter((layer: any) => layer.route)
+    .map((layer: any) => layer.route.path);
+}
+
+describe('support chat route mounting', () => {
+  it('serves the learner chat under /api/support/chat', () => {
+    expect(mountedPaths()).toContain('/api/support/chat/message');
+  });
+
+  it('serves the admin dashboard under /api/admin/support', () => {
+    expect(mountedPaths()).toContain('/api/admin/support/dashboard');
+  });
+
+  it('never doubles the api prefix', () => {
+    expect(mountedPaths().filter((path) => path.startsWith('/api/api'))).toEqual([]);
+  });
+});

--- a/backend/src/modules/supportChat/types.ts
+++ b/backend/src/modules/supportChat/types.ts
@@ -136,11 +136,33 @@ export const FAQ_CONFIDENCE_THRESHOLD = parseFloat(
   process.env.FAQ_CONFIDENCE_THRESHOLD || '0.75'
 );
 
+/**
+ * Lexical matching is a weaker signal than embeddings, so it gets its own,
+ * lower bar. Retrieval falls back to it whenever the embedding provider is
+ * unconfigured or failing, which is the only way the bot answers at all when
+ * no FAQ has an embedding yet.
+ */
+export const FAQ_LEXICAL_CONFIDENCE_THRESHOLD = parseFloat(
+  process.env.FAQ_LEXICAL_CONFIDENCE_THRESHOLD || '0.45'
+);
+
 export const SUPPORT_CHAT_CONFIG = {
   confidenceThreshold: FAQ_CONFIDENCE_THRESHOLD,
+  lexicalConfidenceThreshold: FAQ_LEXICAL_CONFIDENCE_THRESHOLD,
   maxSearchResults: 5,
   embeddingModel: process.env.MINIMAX_EMBEDDING_MODEL || 'embo-01',
-  minimaxApiUrl: process.env.MINIMAX_API_URL || 'https://api.minimax.chat/v1',
+  minimaxApiUrl: process.env.MINIMAX_API_URL || 'https://api.minimax.io/v1',
+  minimaxGroupId: process.env.MINIMAX_GROUP_ID,
+  /** Hard deadline per embedding call — a slow provider must not hang a chat turn. */
+  embeddingTimeoutMs: Number(process.env.SUPPORT_CHAT_EMBEDDING_TIMEOUT_MS || '8000'),
+  /** FAQs whose embedding is generated and stored per chat turn, best-matching first. */
+  maxEmbeddingBackfillPerRequest: Number(
+    process.env.SUPPORT_CHAT_EMBEDDING_BACKFILL_LIMIT || '5'
+  ),
+  /** How long to stop calling the embedding provider after it fails. */
+  embeddingCooldownMs: Number(
+    process.env.SUPPORT_CHAT_EMBEDDING_COOLDOWN_MS || String(10 * 60 * 1000)
+  ),
   collectionsNames: {
     faq: process.env.MONGODB_FAQ_COLLECTION || 'supportFaqs',
     questions: process.env.MONGODB_QUESTIONS_COLLECTION || 'supportQuestions',

--- a/frontend/src/hooks/useAdminSupport.ts
+++ b/frontend/src/hooks/useAdminSupport.ts
@@ -1,6 +1,8 @@
 import { useCallback } from 'react';
 import { AdminResponseRequest, IFAQ, FAQCategory } from '@/modules/supportChat/types';
 
+// VITE_BASE_URL already ends in the API prefix (e.g. http://localhost:4001/api),
+// which is why paths below start at the resource, not at /api.
 const API_BASE = import.meta.env.VITE_BASE_URL ?? '';
 
 export default function useAdminSupport() {
@@ -13,7 +15,7 @@ export default function useAdminSupport() {
       if (startDate) params.append('startDate', startDate);
       if (endDate) params.append('endDate', endDate);
 
-      const response = await fetch(`${API_BASE}/api/admin/support/dashboard?${params}`, {
+      const response = await fetch(`${API_BASE}/admin/support/dashboard?${params}`, {
         headers: {
           Authorization: `Bearer ${getToken()}`,
         },
@@ -33,7 +35,7 @@ export default function useAdminSupport() {
       params.append('limit', limit.toString());
       if (courseId) params.append('courseId', courseId);
 
-      const response = await fetch(`${API_BASE}/api/admin/support/questions?${params}`, {
+      const response = await fetch(`${API_BASE}/admin/support/questions?${params}`, {
         headers: {
           Authorization: `Bearer ${getToken()}`,
         },
@@ -48,7 +50,7 @@ export default function useAdminSupport() {
   const respondToQuestion = useCallback(
     async (questionId: string, request: AdminResponseRequest) => {
       const response = await fetch(
-        `${API_BASE}/api/admin/support/questions/${questionId}/respond`,
+        `${API_BASE}/admin/support/questions/${questionId}/respond`,
         {
           method: 'POST',
           headers: {
@@ -68,7 +70,7 @@ export default function useAdminSupport() {
   const resolveQuestion = useCallback(
     async (questionId: string) => {
       const response = await fetch(
-        `${API_BASE}/api/admin/support/questions/${questionId}/resolve`,
+        `${API_BASE}/admin/support/questions/${questionId}/resolve`,
         {
           method: 'PUT',
           headers: {
@@ -88,7 +90,7 @@ export default function useAdminSupport() {
       const params = new URLSearchParams();
       if (category) params.append('category', category);
 
-      const response = await fetch(`${API_BASE}/api/admin/support/faqs?${params}`, {
+      const response = await fetch(`${API_BASE}/admin/support/faqs?${params}`, {
         headers: {
           Authorization: `Bearer ${getToken()}`,
         },
@@ -102,7 +104,7 @@ export default function useAdminSupport() {
 
   const createFAQ = useCallback(
     async (faq: Omit<IFAQ, '_id' | 'createdAt' | 'updatedAt' | 'embedding' | 'createdBy'>) => {
-      const response = await fetch(`${API_BASE}/api/admin/support/faqs`, {
+      const response = await fetch(`${API_BASE}/admin/support/faqs`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -119,7 +121,7 @@ export default function useAdminSupport() {
 
   const updateFAQ = useCallback(
     async (faqId: string, updates: Partial<IFAQ>) => {
-      const response = await fetch(`${API_BASE}/api/admin/support/faqs/${faqId}`, {
+      const response = await fetch(`${API_BASE}/admin/support/faqs/${faqId}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -136,7 +138,7 @@ export default function useAdminSupport() {
 
   const deleteFAQ = useCallback(
     async (faqId: string) => {
-      const response = await fetch(`${API_BASE}/api/admin/support/faqs/${faqId}`, {
+      const response = await fetch(`${API_BASE}/admin/support/faqs/${faqId}`, {
         method: 'DELETE',
         headers: {
           Authorization: `Bearer ${getToken()}`,

--- a/frontend/src/hooks/useSupportChat.ts
+++ b/frontend/src/hooks/useSupportChat.ts
@@ -1,6 +1,8 @@
 import { useCallback } from 'react';
 import { ChatMessageResponse } from '@/modules/supportChat/types';
 
+// VITE_BASE_URL already ends in the API prefix (e.g. http://localhost:4001/api),
+// which is why paths below start at the resource, not at /api.
 const API_BASE = import.meta.env.VITE_BASE_URL ?? '';
 
 const authHeaders = (): Record<string, string> => {
@@ -22,7 +24,7 @@ export default function useSupportChat() {
       if (cohortId) queryParams.append('cohortId', cohortId);
 
       const response = await fetch(
-        `${API_BASE}/api/support/chat/message?${queryParams.toString()}`,
+        `${API_BASE}/support/chat/message?${queryParams.toString()}`,
         {
           method: 'POST',
           headers: {
@@ -50,7 +52,7 @@ export default function useSupportChat() {
   const getHistory = useCallback(
     async (limit: number = 50) => {
       const response = await fetch(
-        `${API_BASE}/api/support/chat/history?limit=${limit}`,
+        `${API_BASE}/support/chat/history?limit=${limit}`,
         {
           headers: authHeaders(),
         }
@@ -67,7 +69,7 @@ export default function useSupportChat() {
 
   const getQuestion = useCallback(
     async (questionId: string) => {
-      const response = await fetch(`${API_BASE}/api/support/chat/${questionId}`, {
+      const response = await fetch(`${API_BASE}/support/chat/${questionId}`, {
         headers: authHeaders(),
       });
 
@@ -83,7 +85,7 @@ export default function useSupportChat() {
   const rateResolution = useCallback(
     async (questionId: string, rating: 'helpful' | 'not_helpful') => {
       const response = await fetch(
-        `${API_BASE}/api/support/chat/${questionId}/rate`,
+        `${API_BASE}/support/chat/${questionId}/rate`,
         {
           method: 'PATCH',
           headers: {


### PR DESCRIPTION
The learner chat widget never returned an FAQ answer. Five independent defects were involved, each enough on its own to break it, which is why fixing any one of them appeared to change nothing.

- Both controllers declared '/api' in their @JsonController path while the app already mounts routing-controllers with routePrefix '/api', so the endpoints were served at /api/api/... and the widget's calls 404'd.
- The frontend hooks made the mirror-image mistake, building `${VITE_BASE_URL}/api/...` when VITE_BASE_URL already ends in the API prefix. Localhost still 404'd after the backend was corrected.
- FAQRepository and SupportQuestionRepository injected the database as `any` and called `db.collection()`, which MongoDatabase does not have — the `any` hid it from tsc and every request threw at runtime.
- Retrieval embedded the question before doing anything else and rethrew on failure, so a missing, rejected or rate-limited MINIMAX_API_KEY turned every chat turn into a 500.
- No FAQ had an embedding and no code ever created one, so the similarity term was 0 for every FAQ and the old scoring formula topped out at 0.20 against a 0.75 threshold. Matching was arithmetically impossible.

Retrieval now scores lexically — IDF-weighted coverage of the question's terms across an FAQ's own question, tags and answer, with conservative stemming so "completing" reaches "completed" — and works with no external service. Embeddings are an optional layer on top: when a key is configured the question is embedded, the best lexical candidates have their vectors generated and stored a few per turn, and the score becomes 0.7 semantic + 0.3 lexical. A provider failure logs once, puts the provider on a cooldown and falls back rather than failing the turn. The lexical-only path gets its own lower bar, FAQ_LEXICAL_CONFIDENCE_THRESHOLD (0.45).

Also points the MiniMax host at api.minimax.io, decodes their HTTP-200-with-error-body envelope, maps the seeded FAQ categories onto FAQCategory, and stops the seed script from deleting admin-authored FAQs on re-seed.

Verified two ways. Ten new tests: seven pin the lexical retrieval path with the API key stubbed empty, three pin the mounted route paths through useExpressServer. All ten fail against the pre-fix code and pass after. And end to end against the real 20-FAQ collection, which has no embeddings at all: a verbatim question scores 1.00, "my video keeps getting stuck and repeating" 0.89, "progress not updating after completing videos" 0.62, and off-topic questions escalate. The live server returns 401 on /api/support/chat/message and 404 on the old doubled path. tsc is clean on both workspaces and lint passes.

Two related gaps found and deliberately left out of scope: nothing calls createIndex() during boot, so the /faqs/search $text query will fail; and the admin support dashboard has a useAdminSupport hook but no page or route in the frontend.

Fixes #1268
