### PR TITLE
Feat/share links quick

### DIFF
--- a/backend/src/modules/auth/services/FirebaseAuthService.ts
+++ b/backend/src/modules/auth/services/FirebaseAuthService.ts
@@ -450,8 +450,12 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
       });
       return userRecord.uid;
     } catch (error) {
+      // The detail goes to the log, not to the response: this one surfaces on
+      // a share-link recipient's screen, and they are an outsider who must
+      // not be shown credential paths or other internals.
+      console.error('Failed to create guest user in Firebase:', error);
       throw new InternalServerError(
-        `Failed to create guest user in Firebase: ${error.message}`,
+        'Could not open this video right now. Ask whoever shared it to try again.',
       );
     }
   }
@@ -464,8 +468,9 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
     try {
       return await this.auth.createCustomToken(firebaseUID);
     } catch (error) {
+      console.error('Failed to create custom token:', error);
       throw new InternalServerError(
-        `Failed to create custom token: ${error.message}`,
+        'Could not open this video right now. Ask whoever shared it to try again.',
       );
     }
   }

--- a/backend/src/modules/shareLinks/classes/validators/ShareLinkValidators.ts
+++ b/backend/src/modules/shareLinks/classes/validators/ShareLinkValidators.ts
@@ -333,6 +333,61 @@ export class OpenShareLinkResponse {
   viewingMode: ShareLinkViewingMode;
 }
 
+export class QuickShareBody {
+  @JSONSchema({
+    description: 'The YouTube URL to share. No course is involved.',
+    example: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    type: 'string',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsUrl()
+  url: string;
+
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(200)
+  @ValidateNested({each: true})
+  @Type(() => ShareLinkRecipient)
+  recipients: ShareLinkRecipient[];
+
+  @JSONSchema({
+    description:
+      'Where the video ends, HH:MM:SS. Supply it so completion can be '
+      + 'detected; without it only watch time is meaningful.',
+    example: '00:12:30',
+  })
+  @IsOptional()
+  @IsString()
+  endTime?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  expiresInDays?: number;
+
+  @IsOptional()
+  @IsEnum(ShareLinkViewingMode)
+  viewingMode?: ShareLinkViewingMode;
+}
+
+@Expose()
+export class QuickShareResponse {
+  @Expose()
+  @IsString()
+  itemId: string;
+
+  @Expose()
+  @IsString()
+  videoTitle: string;
+
+  @Expose()
+  @IsArray()
+  @ValidateNested({each: true})
+  @Type(() => ShareLinkResponse)
+  links: ShareLinkResponse[];
+}
+
 @Expose()
 export class ShareLinkMessageResponse {
   @Expose()

--- a/backend/src/modules/shareLinks/container.ts
+++ b/backend/src/modules/shareLinks/container.ts
@@ -3,6 +3,7 @@ import {SHARE_LINKS_TYPES} from './types.js';
 import {ShareLinkRepository} from '#shared/database/providers/mongo/repositories/ShareLinkRepository.js';
 import {ShareLinkService} from './services/ShareLinkService.js';
 import {YouTubeEmbedService} from './services/YouTubeEmbedService.js';
+import {QuickShareService} from './services/QuickShareService.js';
 import {ShareLinkController} from './controllers/ShareLinkController.js';
 
 export const shareLinksContainerModule = new ContainerModule(options => {
@@ -20,6 +21,10 @@ export const shareLinksContainerModule = new ContainerModule(options => {
   options
     .bind(SHARE_LINKS_TYPES.YouTubeEmbedService)
     .to(YouTubeEmbedService)
+    .inSingletonScope();
+  options
+    .bind(SHARE_LINKS_TYPES.QuickShareService)
+    .to(QuickShareService)
     .inSingletonScope();
 
   // Controllers

--- a/backend/src/modules/shareLinks/controllers/ShareLinkController.ts
+++ b/backend/src/modules/shareLinks/controllers/ShareLinkController.ts
@@ -17,6 +17,7 @@ import {Ability} from '#root/shared/functions/AbilityDecorator.js';
 import {BadRequestErrorResponse} from '#shared/middleware/errorHandler.js';
 import {CohortScopeService} from '#root/shared/functions/cohortScope.js';
 import {ShareLinkService} from '../services/ShareLinkService.js';
+import {QuickShareService} from '../services/QuickShareService.js';
 import {YouTubeEmbedService} from '../services/YouTubeEmbedService.js';
 import {
   CourseAndVersionParams,
@@ -27,6 +28,8 @@ import {
   ShareLinkIdParams,
   ShareLinkMessageResponse,
   ShareLinkTokenParams,
+  QuickShareBody,
+  QuickShareResponse,
   ValidateYouTubeUrlBody,
   YouTubeValidationResponse,
 } from '../classes/validators/ShareLinkValidators.js';
@@ -52,6 +55,8 @@ export class ShareLinkController {
     private readonly shareLinkService: ShareLinkService,
     @inject(SHARE_LINKS_TYPES.YouTubeEmbedService)
     private readonly youTubeEmbedService: YouTubeEmbedService,
+    @inject(SHARE_LINKS_TYPES.QuickShareService)
+    private readonly quickShareService: QuickShareService,
     @inject(CohortScopeService)
     private readonly cohortScopeService: CohortScopeService,
   ) {}
@@ -75,6 +80,59 @@ export class ShareLinkController {
     return (await this.youTubeEmbedService.check(
       body.url,
     )) as YouTubeValidationResponse;
+  }
+
+  @Authorized()
+  @Post('/quick')
+  @HttpCode(200)
+  @ResponseSchema(QuickShareResponse, {
+    description: 'The shared video and one link per recipient',
+    statusCode: 200,
+  })
+  @ResponseSchema(BadRequestErrorResponse, {
+    description: 'The video cannot be played inside ViBe, or bad input',
+    statusCode: 400,
+  })
+  @OpenAPI({
+    summary: 'Share a video outside any course',
+    description:
+      'Paste a YouTube URL and name recipients. The video is filed into a '
+      + 'hidden holder so watch time has somewhere to record; the instructor '
+      + 'never picks a course. An unplayable video is rejected here rather '
+      + 'than becoming links that lead to a dead player.',
+  })
+  async quickShare(
+    @Body() body: QuickShareBody,
+    @Ability(getShareLinkAbility) {authenticatedUser},
+  ): Promise<QuickShareResponse> {
+    return (await this.quickShareService.shareVideo(
+      authenticatedUser.userId,
+      body.url,
+      body.recipients,
+      body.viewingMode,
+      body.endTime,
+      body.expiresInDays,
+    )) as QuickShareResponse;
+  }
+
+  @Authorized()
+  @Get('/quick')
+  @HttpCode(200)
+  @ResponseSchema(ShareLinkAnalyticsListResponse, {
+    description: 'Every quick share this instructor has made',
+    statusCode: 200,
+  })
+  @OpenAPI({
+    summary: 'Quick share analytics',
+    description: 'Who each quick-shared video went to, and what they watched.',
+  })
+  async getQuickShares(
+    @Ability(getShareLinkAbility) {authenticatedUser},
+  ): Promise<ShareLinkAnalyticsListResponse> {
+    const recipients = await this.quickShareService.listQuickShares(
+      authenticatedUser.userId,
+    );
+    return {recipients} as ShareLinkAnalyticsListResponse;
   }
 
   @Authorized()

--- a/backend/src/modules/shareLinks/services/QuickShareService.ts
+++ b/backend/src/modules/shareLinks/services/QuickShareService.ts
@@ -1,0 +1,255 @@
+import 'reflect-metadata';
+import {injectable, inject} from 'inversify';
+import {BadRequestError, InternalServerError} from 'routing-controllers';
+import {COURSES_TYPES} from '#root/modules/courses/types.js';
+import {USERS_TYPES} from '#root/modules/users/types.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import type {ICourseRepository} from '#shared/database/interfaces/ICourseRepository.js';
+import {ShareLinkRepository} from '#shared/database/providers/mongo/repositories/ShareLinkRepository.js';
+import {EnrollmentRepository} from '#shared/database/providers/mongo/repositories/EnrollmentRepository.js';
+import {CourseService} from '#root/modules/courses/services/CourseService.js';
+import {ModuleService} from '#root/modules/courses/services/ModuleService.js';
+import {SectionService} from '#root/modules/courses/services/SectionService.js';
+import {ItemService} from '#root/modules/courses/services/ItemService.js';
+import {Course} from '#root/modules/courses/classes/transformers/Course.js';
+import {ItemType} from '#shared/interfaces/models.js';
+import {ShareLinkViewingMode} from '#shared/interfaces/models.js';
+import {SHARE_LINKS_TYPES} from '../types.js';
+import {YouTubeEmbedService} from './YouTubeEmbedService.js';
+import {
+  CreatedShareLink,
+  ShareLinkAnalytics,
+  ShareLinkRecipientInput,
+  ShareLinkService,
+} from './ShareLinkService.js';
+
+const CONTAINER_COURSE_NAME = 'Quick shares';
+const CONTAINER_COURSE_DESCRIPTION =
+  'Videos shared outside any course. Created and maintained by ViBe — you do '
+  + 'not need to edit it.';
+const CONTAINER_COHORT_NAME = 'Recipients';
+const CONTAINER_MODULE_NAME = 'Shared videos';
+const CONTAINER_SECTION_NAME = 'Videos';
+const CONTAINER_CHILD_DESCRIPTION = 'Videos shared outside any course.';
+
+/**
+ * Where a quick-shared video lives.
+ *
+ * The whole course version is hidden from the instructor: it exists only
+ * because watch time, progress and access are all keyed to a course version.
+ */
+interface QuickShareContainer {
+  courseId: string;
+  versionId: string;
+  cohortId?: string;
+  moduleId: string;
+  sectionId: string;
+}
+
+export interface QuickShareResult {
+  itemId: string;
+  videoTitle: string;
+  links: CreatedShareLink[];
+}
+
+/**
+ * Sharing a video that is not in a course.
+ *
+ * The instructor pastes a URL and names recipients — no course, version or
+ * cohort in sight. Behind that, the video is filed into a hidden holder so the
+ * ordinary watch-time and progress pipelines have somewhere to write. Keeping
+ * the container rather than inventing a standalone video entity is what avoids
+ * a second, parallel implementation of tracking.
+ *
+ * @category ShareLinks/Services
+ */
+@injectable()
+export class QuickShareService {
+  constructor(
+    @inject(SHARE_LINKS_TYPES.ShareLinkRepo)
+    private readonly shareLinkRepo: ShareLinkRepository,
+    @inject(SHARE_LINKS_TYPES.ShareLinkService)
+    private readonly shareLinkService: ShareLinkService,
+    @inject(SHARE_LINKS_TYPES.YouTubeEmbedService)
+    private readonly youTubeEmbedService: YouTubeEmbedService,
+    @inject(COURSES_TYPES.CourseService)
+    private readonly courseService: CourseService,
+    @inject(COURSES_TYPES.ModuleService)
+    private readonly moduleService: ModuleService,
+    @inject(COURSES_TYPES.SectionService)
+    private readonly sectionService: SectionService,
+    @inject(COURSES_TYPES.ItemService)
+    private readonly itemService: ItemService,
+    @inject(GLOBAL_TYPES.CourseRepo)
+    private readonly courseRepo: ICourseRepository,
+    @inject(USERS_TYPES.EnrollmentRepo)
+    private readonly enrollmentRepo: EnrollmentRepository,
+  ) {}
+
+  /**
+   * Shares a pasted YouTube video with named recipients.
+   *
+   * The embeddability check runs first and hard-stops the share: generating
+   * links for a video that cannot play would send recipients to a dead player
+   * and record nothing.
+   */
+  async shareVideo(
+    instructorId: string,
+    url: string,
+    recipients: ShareLinkRecipientInput[],
+    viewingMode: ShareLinkViewingMode = ShareLinkViewingMode.PLAIN,
+    endTime = '23:59:59',
+    expiresInDays?: number,
+  ): Promise<QuickShareResult> {
+    const check = await this.youTubeEmbedService.check(url);
+    if (!check.embeddable) {
+      throw new BadRequestError(check.message);
+    }
+
+    const container = await this.resolveContainer(instructorId);
+    const videoTitle = check.title || 'Shared video';
+
+    const {createdItem} = await this.itemService.createItem(
+      container.versionId,
+      container.moduleId,
+      container.sectionId,
+      {
+        name: videoTitle,
+        description: `Shared from ${url}`,
+        type: ItemType.VIDEO,
+        videoDetails: {
+          URL: url,
+          startTime: '00:00:00',
+          endTime,
+          points: 0,
+        },
+      } as any,
+    );
+
+    const itemId = createdItem?._id?.toString();
+    if (!itemId) {
+      throw new InternalServerError('Failed to file the shared video.');
+    }
+
+    const links = await this.shareLinkService.createShareLinks(
+      container.courseId,
+      container.versionId,
+      recipients,
+      instructorId,
+      container.cohortId,
+      itemId,
+      expiresInDays,
+      viewingMode,
+    );
+
+    return {itemId, videoTitle, links};
+  }
+
+  /** Every quick share this instructor has made, and who watched. */
+  async listQuickShares(instructorId: string): Promise<ShareLinkAnalytics[]> {
+    const course =
+      await this.shareLinkRepo.findQuickShareContainerCourse(instructorId);
+    if (!course) {
+      return [];
+    }
+    const courseId = course._id.toString();
+    const versionId = course.versions[0]?.toString();
+    if (!versionId) {
+      return [];
+    }
+    return this.shareLinkService.getAnalytics(courseId, versionId);
+  }
+
+  /**
+   * Finds the instructor's holder, creating it on first use.
+   *
+   * One per instructor, so their quick-share analytics stay in a single place
+   * rather than scattering a hidden course per video.
+   */
+  private async resolveContainer(
+    instructorId: string,
+  ): Promise<QuickShareContainer> {
+    const existing =
+      await this.shareLinkRepo.findQuickShareContainerCourse(instructorId);
+
+    if (existing) {
+      const versionId = existing.versions[0]?.toString();
+      const version = versionId
+        ? await this.courseRepo.readVersion(versionId)
+        : null;
+      if (version) {
+        const module = version.modules?.find(m => !m.isDeleted);
+        const section = module?.sections?.find(s => !s.isDeleted);
+        if (module && section) {
+          return {
+            courseId: existing._id.toString(),
+            versionId,
+            cohortId: version.cohorts?.[0]?.toString(),
+            moduleId: module.moduleId.toString(),
+            sectionId: section.sectionId.toString(),
+          };
+        }
+      }
+    }
+
+    return this.createContainer(instructorId);
+  }
+
+  private async createContainer(
+    instructorId: string,
+  ): Promise<QuickShareContainer> {
+    const course = new Course({
+      name: CONTAINER_COURSE_NAME,
+      description: CONTAINER_COURSE_DESCRIPTION,
+    } as any);
+
+    const created = await this.courseService.createCourse(
+      course,
+      'Shared videos',
+      CONTAINER_COURSE_DESCRIPTION,
+      instructorId,
+      [CONTAINER_COHORT_NAME],
+      false,
+      0,
+    );
+
+    const courseId = created._id.toString();
+    const versionId = created.versions[0].toString();
+
+    // Both flags are what keep the holder invisible: the course is never
+    // listed as a course, and the instructor's own enrollment into it is not
+    // counted among the courses they teach.
+    await this.shareLinkRepo.markCourseAsQuickShareContainer(courseId);
+    await this.enrollmentRepo.markQuickShareContainerEnrollment(
+      instructorId,
+      courseId,
+      versionId,
+    );
+
+    await this.moduleService.createModule(versionId, {
+      name: CONTAINER_MODULE_NAME,
+      description: CONTAINER_CHILD_DESCRIPTION,
+    } as any);
+
+    const withModule = await this.courseRepo.readVersion(versionId);
+    const module = withModule.modules.find(m => !m.isDeleted);
+
+    await this.sectionService.createSection(versionId, module.moduleId.toString(), {
+      name: CONTAINER_SECTION_NAME,
+      description: CONTAINER_CHILD_DESCRIPTION,
+    } as any);
+
+    const withSection = await this.courseRepo.readVersion(versionId);
+    const freshModule = withSection.modules.find(m => !m.isDeleted);
+    const section = freshModule.sections.find(s => !s.isDeleted);
+
+    return {
+      courseId,
+      versionId,
+      cohortId: withSection.cohorts?.[0]?.toString(),
+      moduleId: freshModule.moduleId.toString(),
+      sectionId: section.sectionId.toString(),
+    };
+  }
+
+}

--- a/backend/src/modules/shareLinks/services/index.ts
+++ b/backend/src/modules/shareLinks/services/index.ts
@@ -1,2 +1,3 @@
 export * from './ShareLinkService.js';
 export * from './YouTubeEmbedService.js';
+export * from './QuickShareService.js';

--- a/backend/src/modules/shareLinks/tests/QuickShareService.test.ts
+++ b/backend/src/modules/shareLinks/tests/QuickShareService.test.ts
@@ -1,0 +1,258 @@
+// models.ts pulls in class-transformer decorators, which need the metadata
+// polyfill loaded first — same first line as every other suite here.
+import 'reflect-metadata';
+import {describe, expect, it, vi} from 'vitest';
+import {ObjectId} from 'mongodb';
+import {ShareLinkViewingMode} from '#shared/interfaces/models.js';
+import {QuickShareService} from '../services/QuickShareService.js';
+
+const INSTRUCTOR_ID = new ObjectId().toString();
+const COURSE_ID = new ObjectId();
+const VERSION_ID = new ObjectId();
+const COHORT_ID = new ObjectId();
+const MODULE_ID = new ObjectId();
+const SECTION_ID = new ObjectId();
+const ITEM_ID = new ObjectId();
+
+const URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+
+const existingContainer = () => ({
+  _id: COURSE_ID,
+  versions: [VERSION_ID],
+  isQuickShareContainer: true,
+});
+
+const containerVersion = () => ({
+  _id: VERSION_ID,
+  cohorts: [COHORT_ID],
+  modules: [
+    {
+      moduleId: MODULE_ID,
+      sections: [{sectionId: SECTION_ID}],
+    },
+  ],
+});
+
+function buildService(overrides: Record<string, any> = {}) {
+  const shareLinkRepo = {
+    findQuickShareContainerCourse: vi.fn(async () => existingContainer()),
+    markCourseAsQuickShareContainer: vi.fn(async () => undefined),
+    ...overrides.shareLinkRepo,
+  };
+
+  const shareLinkService = {
+    createShareLinks: vi.fn(async () => [
+      {
+        shareLinkId: new ObjectId().toString(),
+        recipientName: 'Ananya Rao',
+        recipientEmail: 'ananya@example.com',
+        url: 'https://vibe.test/share/abc',
+        status: 'ACTIVE',
+        viewingMode: ShareLinkViewingMode.PLAIN,
+        expiresAt: new Date(),
+      },
+    ]),
+    getAnalytics: vi.fn(async () => []),
+    ...overrides.shareLinkService,
+  };
+
+  const youTubeEmbedService = {
+    check: vi.fn(async () => ({
+      embeddable: true,
+      videoId: 'dQw4w9WgXcQ',
+      title: 'A lecture',
+    })),
+    ...overrides.youTubeEmbedService,
+  };
+
+  const courseService = {
+    createCourse: vi.fn(async () => ({
+      _id: COURSE_ID,
+      versions: [VERSION_ID],
+    })),
+    ...overrides.courseService,
+  };
+
+  const moduleService = {
+    createModule: vi.fn(async () => containerVersion()),
+    ...overrides.moduleService,
+  };
+
+  const sectionService = {
+    createSection: vi.fn(async () => containerVersion()),
+    ...overrides.sectionService,
+  };
+
+  const itemService = {
+    createItem: vi.fn(async () => ({createdItem: {_id: ITEM_ID}})),
+    ...overrides.itemService,
+  };
+
+  const courseRepo = {
+    readVersion: vi.fn(async () => containerVersion()),
+    ...overrides.courseRepo,
+  };
+
+  const enrollmentRepo = {
+    markQuickShareContainerEnrollment: vi.fn(async () => undefined),
+    ...overrides.enrollmentRepo,
+  };
+
+  const service = new QuickShareService(
+    shareLinkRepo as any,
+    shareLinkService as any,
+    youTubeEmbedService as any,
+    courseService as any,
+    moduleService as any,
+    sectionService as any,
+    itemService as any,
+    courseRepo as any,
+    enrollmentRepo as any,
+  );
+
+  return {
+    service,
+    shareLinkRepo,
+    shareLinkService,
+    youTubeEmbedService,
+    courseService,
+    moduleService,
+    sectionService,
+    itemService,
+    courseRepo,
+    enrollmentRepo,
+  };
+}
+
+const recipients = [{name: 'Ananya Rao', email: 'ananya@example.com'}];
+
+describe('QuickShareService.shareVideo', () => {
+  it('files the video into the instructor holder and mints links for it', async () => {
+    const {service, itemService, shareLinkService} = buildService();
+
+    const result = await service.shareVideo(INSTRUCTOR_ID, URL, recipients);
+
+    const [versionId, moduleId, sectionId, body] =
+      itemService.createItem.mock.calls[0];
+    expect(versionId).toBe(VERSION_ID.toString());
+    expect(moduleId).toBe(MODULE_ID.toString());
+    expect(sectionId).toBe(SECTION_ID.toString());
+    expect(body.videoDetails.URL).toBe(URL);
+    // The link points at the item just created, in the holder's cohort.
+    expect(shareLinkService.createShareLinks).toHaveBeenCalledWith(
+      COURSE_ID.toString(),
+      VERSION_ID.toString(),
+      recipients,
+      INSTRUCTOR_ID,
+      COHORT_ID.toString(),
+      ITEM_ID.toString(),
+      undefined,
+      ShareLinkViewingMode.PLAIN,
+    );
+    expect(result.videoTitle).toBe('A lecture');
+    expect(result.links).toHaveLength(1);
+  });
+
+  it('refuses to share a video that cannot be embedded', async () => {
+    const {service, itemService, shareLinkService} = buildService({
+      youTubeEmbedService: {
+        check: vi.fn(async () => ({
+          embeddable: false,
+          reason: 'EMBEDDING_DISABLED',
+          message: "This video's owner has disabled embedding",
+        })),
+      },
+    });
+
+    await expect(
+      service.shareVideo(INSTRUCTOR_ID, URL, recipients),
+    ).rejects.toThrow(/embedding/i);
+
+    // Nothing is created, so no links exist that would lead to a dead player.
+    expect(itemService.createItem).not.toHaveBeenCalled();
+    expect(shareLinkService.createShareLinks).not.toHaveBeenCalled();
+  });
+
+  it('reuses the instructor existing holder instead of making another', async () => {
+    const {service, courseService} = buildService();
+
+    await service.shareVideo(INSTRUCTOR_ID, URL, recipients);
+    await service.shareVideo(INSTRUCTOR_ID, URL, recipients);
+
+    expect(courseService.createCourse).not.toHaveBeenCalled();
+  });
+
+  it('creates the holder on first use and hides it both ways', async () => {
+    const {service, courseService, shareLinkRepo, enrollmentRepo} =
+      buildService({
+        shareLinkRepo: {
+          findQuickShareContainerCourse: vi.fn(async () => null),
+          markCourseAsQuickShareContainer: vi.fn(async () => undefined),
+        },
+      });
+
+    await service.shareVideo(INSTRUCTOR_ID, URL, recipients);
+
+    expect(courseService.createCourse).toHaveBeenCalled();
+    // Hidden as a course, and hidden from the courses they teach — both are
+    // needed, since the two listings read from different collections.
+    expect(shareLinkRepo.markCourseAsQuickShareContainer).toHaveBeenCalledWith(
+      COURSE_ID.toString(),
+    );
+    expect(
+      enrollmentRepo.markQuickShareContainerEnrollment,
+    ).toHaveBeenCalledWith(
+      INSTRUCTOR_ID,
+      COURSE_ID.toString(),
+      VERSION_ID.toString(),
+    );
+  });
+
+  it('passes the chosen viewing mode through to the links', async () => {
+    const {service, shareLinkService} = buildService();
+
+    await service.shareVideo(
+      INSTRUCTOR_ID,
+      URL,
+      recipients,
+      ShareLinkViewingMode.PROCTORED,
+    );
+
+    const call = shareLinkService.createShareLinks.mock.calls[0];
+    expect(call[7]).toBe(ShareLinkViewingMode.PROCTORED);
+  });
+
+  it('falls back to a generic title when YouTube gives none', async () => {
+    const {service, itemService} = buildService({
+      youTubeEmbedService: {
+        check: vi.fn(async () => ({embeddable: true, videoId: 'x'})),
+      },
+    });
+
+    await service.shareVideo(INSTRUCTOR_ID, URL, recipients);
+
+    expect(itemService.createItem.mock.calls[0][3].name).toBe('Shared video');
+  });
+});
+
+describe('QuickShareService.listQuickShares', () => {
+  it('returns nothing for an instructor who has never quick-shared', async () => {
+    const {service, shareLinkService} = buildService({
+      shareLinkRepo: {findQuickShareContainerCourse: vi.fn(async () => null)},
+    });
+
+    expect(await service.listQuickShares(INSTRUCTOR_ID)).toEqual([]);
+    expect(shareLinkService.getAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('reads analytics from the holder version', async () => {
+    const {service, shareLinkService} = buildService();
+
+    await service.listQuickShares(INSTRUCTOR_ID);
+
+    expect(shareLinkService.getAnalytics).toHaveBeenCalledWith(
+      COURSE_ID.toString(),
+      VERSION_ID.toString(),
+    );
+  });
+});

--- a/backend/src/modules/shareLinks/types.ts
+++ b/backend/src/modules/shareLinks/types.ts
@@ -2,6 +2,7 @@ const TYPES = {
   // Services
   ShareLinkService: Symbol.for('ShareLinkService'),
   YouTubeEmbedService: Symbol.for('YouTubeEmbedService'),
+  QuickShareService: Symbol.for('QuickShareService'),
 
   // Repositories
   ShareLinkRepo: Symbol.for('ShareLinkRepo'),

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -453,6 +453,28 @@ export class EnrollmentRepository {
     );
   }
 
+  /**
+   * Marks the instructor's own enrollment into their hidden quick-share
+   * holder, so it stays out of their course lists and counts.
+   */
+  async markQuickShareContainerEnrollment(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<void> {
+    await this.init();
+    await this.enrollmentCollection.updateOne(
+      {
+        userId: new ObjectId(userId),
+        courseId: new ObjectId(courseId),
+        courseVersionId: new ObjectId(courseVersionId),
+      },
+      { $set: { isQuickShareContainer: true } },
+      { session },
+    );
+  }
+
   async bulkUpdateEnrollmentStatus(
     courseId: string,
     versionId: string,
@@ -554,6 +576,8 @@ export class EnrollmentRepository {
           $match: {
             userId: { $in: [userObjectId, userId] },
             role,
+            // The hidden quick-share holder is not a course they teach.
+            isQuickShareContainer: { $ne: true },
             isDeleted: { $ne: true },
             status: 'ACTIVE',
           },
@@ -744,6 +768,8 @@ export class EnrollmentRepository {
         $match: {
           userId: { $in: [userObjectId, userId] },
           role,
+          // The hidden quick-share holder is not a course they teach.
+          isQuickShareContainer: { $ne: true },
           isDeleted: { $ne: true },
           status: { $regex: /^active$/i },
         },
@@ -1039,6 +1065,8 @@ export class EnrollmentRepository {
         $match: {
           userId: { $in: [new ObjectId(userId), userId] },
           role,
+          // The hidden quick-share holder is not a course they teach.
+          isQuickShareContainer: { $ne: true },
           isDeleted: { $ne: true },
           status: { $regex: /^active$/i },
         },
@@ -2258,6 +2286,8 @@ export class EnrollmentRepository {
     const matchStage: any = {
       userId: { $in: [new ObjectId(userId), userId] },
       role,
+      // The hidden quick-share holder is not a course they teach.
+      isQuickShareContainer: { $ne: true },
       isDeleted: { $ne: true },
       status: { $regex: /^active$/i },
     };
@@ -2358,6 +2388,8 @@ export class EnrollmentRepository {
     const matchStage: any = {
       userId: { $in: [new ObjectId(userId), userId] },
       role,
+      // The hidden quick-share holder is not a course they teach.
+      isQuickShareContainer: { $ne: true },
       isDeleted: { $ne: true },
       status: { $regex: /^active$/i },
     };
@@ -2410,6 +2442,8 @@ export class EnrollmentRepository {
     const matchStage: any = {
       userId: { $in: [new ObjectId(userId), userId] },
       role,
+      // The hidden quick-share holder is not a course they teach.
+      isQuickShareContainer: { $ne: true },
       isDeleted: { $ne: true },
       status: { $regex: /^active$/i },
     };

--- a/backend/src/shared/database/providers/mongo/repositories/ShareLinkRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ShareLinkRepository.ts
@@ -5,6 +5,7 @@ import {MongoDatabase} from '../MongoDatabase.js';
 import {InternalServerError} from 'routing-controllers';
 import {GLOBAL_TYPES} from '#root/types.js';
 import {
+  ICourse,
   IShareLink,
   IUserActivityEvent,
   IWatchTime,
@@ -27,6 +28,7 @@ export class ShareLinkRepository {
   private shareLinkCollection: Collection<IShareLink>;
   private watchTimeCollection: Collection<IWatchTime>;
   private activityEventCollection: Collection<IUserActivityEvent>;
+  private courseCollection: Collection<ICourse>;
   private initialized = false;
 
   constructor(@inject(GLOBAL_TYPES.Database) private db: MongoDatabase) {}
@@ -41,6 +43,7 @@ export class ShareLinkRepository {
       await this.db.getCollection<IWatchTime>('watchTime');
     this.activityEventCollection =
       await this.db.getCollection<IUserActivityEvent>('user_activity_events');
+    this.courseCollection = await this.db.getCollection<ICourse>('newCourse');
 
     // The token is the only lookup key on the public open path, so it has to be
     // unique and indexed; the rest serve the instructor's dashboard listing.
@@ -183,6 +186,38 @@ export class ShareLinkRepository {
     await this.shareLinkCollection.updateOne(
       {_id: new ObjectId(id), guestUserId: {$exists: false}} as any,
       {$set: {guestUserId}},
+      {session},
+    );
+  }
+
+  /**
+   * The instructor's hidden holder for videos shared outside any course, if
+   * they have one. There is at most one per instructor.
+   */
+  async findQuickShareContainerCourse(
+    instructorId: string,
+    session?: ClientSession,
+  ): Promise<ICourse | null> {
+    await this.init();
+    return this.courseCollection.findOne(
+      {
+        instructors: new ObjectId(instructorId),
+        isQuickShareContainer: true,
+        isDeleted: {$ne: true},
+      } as any,
+      {session},
+    );
+  }
+
+  /** Flags a freshly created course as a quick-share holder. */
+  async markCourseAsQuickShareContainer(
+    courseId: string,
+    session?: ClientSession,
+  ): Promise<void> {
+    await this.init();
+    await this.courseCollection.updateOne(
+      {_id: new ObjectId(courseId)} as any,
+      {$set: {isQuickShareContainer: true}},
       {session},
     );
   }

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -48,6 +48,12 @@ export interface ICourse {
   createdAt?: Date;
   updatedAt?: Date;
   isDeleted?: boolean;
+  /**
+   * A hidden holder for videos shared outside any course — one per instructor.
+   * It exists only so a quick-shared video has somewhere to record watching;
+   * it is never shown as a course of theirs.
+   */
+  isQuickShareContainer?: boolean;
 }
 
 export type ID = string | ObjectId | null;
@@ -464,6 +470,12 @@ export interface IEnrollment {
    * sharing a course never moves the numbers that describe enrolled learners.
    */
   isShareLinkGuest?: boolean;
+  /**
+   * The instructor's own enrollment into their hidden quick-share holder. It
+   * is filtered out of their course lists and counts — the holder is not a
+   * course they teach.
+   */
+  isQuickShareContainer?: boolean;
   assignedTimeSlots?: Array<{
     from: string; // HH:MM format in IST
     to: string; // HH:MM format in IST

--- a/frontend/src/app/pages/teacher/share-video.tsx
+++ b/frontend/src/app/pages/teacher/share-video.tsx
@@ -87,8 +87,8 @@ export default function ShareVideoPage() {
     }
     try {
       setValidation(await validateUrl.mutateAsync(value.trim()))
-    } catch {
-      toast.error("Could not check that link. Try again.")
+    } catch (err: any) {
+      toast.error(err?.message || "Could not check that link. Try again.")
     }
   }
 

--- a/frontend/src/app/pages/teacher/share-video.tsx
+++ b/frontend/src/app/pages/teacher/share-video.tsx
@@ -1,0 +1,387 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+import {
+  AlertTriangle,
+  BarChart3,
+  Check,
+  Copy,
+  Link2,
+  Loader2,
+  Plus,
+  X,
+} from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  useQuickShare,
+  useQuickShares,
+  useValidateYouTubeUrl,
+} from "@/hooks/share-link-hooks"
+import type {
+  ShareLink,
+  ShareLinkViewingMode,
+  YouTubeValidation,
+} from "@/types/share-link.types"
+import { formatWatchDuration } from "@/utils/time"
+
+interface RecipientDraft {
+  name: string
+  email: string
+}
+
+const emptyRecipient = (): RecipientDraft => ({ name: "", email: "" })
+
+const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+
+/**
+ * Share a video that isn't in a course.
+ *
+ * Paste a link, name who it goes to, send it — no course, version or cohort in
+ * sight. ViBe files the video away out of view so the watching has somewhere
+ * to record.
+ */
+export default function ShareVideoPage() {
+  const [url, setUrl] = useState("")
+  const [validation, setValidation] = useState<YouTubeValidation | null>(null)
+  const [recipients, setRecipients] = useState<RecipientDraft[]>([
+    emptyRecipient(),
+  ])
+  const [viewingMode, setViewingMode] = useState<ShareLinkViewingMode>("PLAIN")
+  const [generated, setGenerated] = useState<ShareLink[]>([])
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+
+  const validateUrl = useValidateYouTubeUrl()
+  const quickShare = useQuickShare()
+  const { data: shares, isLoading: sharesLoading } = useQuickShares()
+
+  const validRecipients = recipients.filter(
+    r => r.name.trim() !== "" && isValidEmail(r.email.trim()),
+  )
+  const canShare =
+    validRecipients.length > 0 && validation?.embeddable === true
+
+  const handleCheck = async (value: string) => {
+    if (!value.trim()) {
+      setValidation(null)
+      return
+    }
+    try {
+      setValidation(await validateUrl.mutateAsync(value.trim()))
+    } catch {
+      toast.error("Could not check that link. Try again.")
+    }
+  }
+
+  const handleShare = async () => {
+    try {
+      const result = await quickShare.mutateAsync({
+        url: url.trim(),
+        recipients: validRecipients.map(r => ({
+          name: r.name.trim(),
+          email: r.email.trim(),
+        })),
+        viewingMode,
+      })
+      setGenerated(result.links)
+      setRecipients([emptyRecipient()])
+      setUrl("")
+      setValidation(null)
+      toast.success(`Shared “${result.videoTitle}” with ${result.links.length} person(s)`)
+    } catch (err: any) {
+      toast.error(err?.message || "Could not share that video")
+    }
+  }
+
+  const handleCopy = async (link: ShareLink) => {
+    await navigator.clipboard.writeText(link.url)
+    setCopiedId(link.shareLinkId)
+    setTimeout(() => setCopiedId(null), 1500)
+  }
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      <div className="flex items-center space-x-2">
+        <Link2 className="w-6 h-6" />
+        <h1 className="text-xl md:text-2xl font-bold">Share a video</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">The video</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Paste a YouTube link. Recipients watch it inside ViBe — that is what
+            lets you see who watched and how much. No course needed.
+          </p>
+          <Input
+            placeholder="https://www.youtube.com/watch?v=…"
+            value={url}
+            onChange={e => {
+              setUrl(e.target.value)
+              setValidation(null)
+            }}
+            onBlur={e => handleCheck(e.target.value)}
+          />
+
+          {validateUrl.isPending && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Checking the video…
+            </div>
+          )}
+
+          {validation?.embeddable && (
+            <div className="flex items-start gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-800 dark:border-green-800 dark:bg-green-950/20 dark:text-green-200">
+              <Check className="w-4 h-4 mt-0.5 shrink-0" />
+              <span>
+                Ready to share
+                {validation.title ? ` — “${validation.title}”` : ""}.
+              </span>
+            </div>
+          )}
+
+          {validation && !validation.embeddable && (
+            <div className="flex items-start gap-2 rounded-lg border border-orange-200 bg-orange-50 p-3 text-sm text-orange-800 dark:border-orange-800 dark:bg-orange-950/20 dark:text-orange-200">
+              <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+              <span>{validation.message}</span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between text-base">
+            <span>Share with</span>
+            <Badge variant="secondary" className="text-xs">
+              {validRecipients.length} recipient(s)
+            </Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-3">
+            {recipients.map((recipient, index) => (
+              <div
+                key={index}
+                className="flex items-center gap-3 p-3 border rounded-lg bg-muted/50"
+              >
+                <div className="text-sm font-medium text-muted-foreground lg:min-w-[40px]">
+                  #{index + 1}
+                </div>
+                <Input
+                  placeholder="Name"
+                  className="flex-1"
+                  value={recipient.name}
+                  onChange={e => {
+                    const next = [...recipients]
+                    next[index] = { ...next[index], name: e.target.value }
+                    setRecipients(next)
+                  }}
+                />
+                <Input
+                  placeholder="email@example.com"
+                  className="flex-1"
+                  value={recipient.email}
+                  onChange={e => {
+                    const next = [...recipients]
+                    next[index] = { ...next[index], email: e.target.value }
+                    setRecipients(next)
+                  }}
+                />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  disabled={recipients.length === 1}
+                  onClick={() =>
+                    setRecipients(recipients.filter((_, i) => i !== index))
+                  }
+                >
+                  <X className="w-4 h-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setRecipients([...recipients, emptyRecipient()])}
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              Add recipient
+            </Button>
+
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">Viewing</span>
+              <Select
+                value={viewingMode}
+                onValueChange={value =>
+                  setViewingMode(value as ShareLinkViewingMode)
+                }
+              >
+                <SelectTrigger className="w-[200px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="PLAIN">Plain viewing</SelectItem>
+                  <SelectItem value="PROCTORED">Full ViBe experience</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <Button
+              className="ml-auto"
+              onClick={handleShare}
+              disabled={!canShare || quickShare.isPending}
+            >
+              {quickShare.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Sharing…
+                </>
+              ) : (
+                <>
+                  <Link2 className="w-4 h-4 mr-2" />
+                  Share
+                </>
+              )}
+            </Button>
+          </div>
+
+          {!validation?.embeddable && url.trim() !== "" && (
+            <p className="text-xs text-muted-foreground">
+              Check the video first — a video ViBe cannot play cannot be tracked
+              either.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {generated.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Links ready to send</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {generated.map(link => (
+              <div
+                key={link.shareLinkId}
+                className="flex items-center gap-3 p-3 border rounded-lg"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium truncate">
+                    {link.recipientName}
+                  </div>
+                  <div className="text-xs text-muted-foreground truncate">
+                    {link.url}
+                  </div>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleCopy(link)}
+                >
+                  {copiedId === link.shareLinkId ? (
+                    <Check className="w-4 h-4" />
+                  ) : (
+                    <Copy className="w-4 h-4" />
+                  )}
+                </Button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center space-x-2 text-base">
+            <BarChart3 className="w-5 h-5" />
+            <span>Who watched</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {sharesLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin" />
+            </div>
+          ) : !shares || shares.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              You haven't shared any videos yet.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Recipient</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Watch time</TableHead>
+                  <TableHead className="text-right">Opens</TableHead>
+                  <TableHead className="text-right">Rewinds</TableHead>
+                  <TableHead>Last seen</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {shares.map(row => (
+                  <TableRow key={row.shareLinkId}>
+                    <TableCell>
+                      <div className="font-medium">{row.recipientName}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {row.recipientEmail}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          row.status === "REVOKED" || row.status === "EXPIRED"
+                            ? "outline"
+                            : "secondary"
+                        }
+                      >
+                        {row.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatWatchDuration(row.totalWatchTimeSeconds)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {row.openCount}
+                    </TableCell>
+                    <TableCell className="text-right">{row.rewinds}</TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {row.lastSeenAt
+                        ? new Date(row.lastSeenAt).toLocaleDateString()
+                        : "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/app/routes/router.tsx
+++ b/frontend/src/app/routes/router.tsx
@@ -58,6 +58,7 @@ import StudentLogin from '../pages/student/StudentLogin'
 import TeacherLogin from '../pages/teacher/TeacherLogin'
 import SelectRolePage from '../pages/SelectRolePage'
 import ShareLinkLanding from '../pages/shared/ShareLinkLanding'
+import ShareVideoPage from '../pages/teacher/share-video'
 import AuditPage from '../pages/teacher/AuditPage'
 import ConfigureCohorts from '../pages/teacher/configure-cohorts'
 
@@ -698,6 +699,14 @@ export const selectRoleRoute = new Route({
   component: SelectRolePage
 })
 
+// Sharing a video that is not in a course — no course picker, so it belongs
+// beside the course builder rather than inside a course.
+const teacherShareVideoRoute = new Route({
+  getParentRoute: () => teacherLayoutRoute,
+  path: '/share-video',
+  component: ShareVideoPage
+})
+
 // Share link landing — public on purpose. The token in the URL is the
 // credential, and the whole point is that a recipient never has to sign in.
 export const shareLinkRoute = new Route({
@@ -753,6 +762,7 @@ const routeTree = rootRoute.addChildren([
     teacherStudentSubmissionsRoute,
     teacherSubmissionDetailsRoute,
     teacherNotificationsRoute,
+    teacherShareVideoRoute,
   ]),
   studentLayoutRoute.addChildren([
     studentDashboardRoute,

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -9,7 +9,6 @@ import {
   Frame,
   GalleryVerticalEnd,
   LifeBuoy,
-  Link2,
   Map,
   Megaphone,
   PieChart,
@@ -57,12 +56,10 @@ export function AppSidebar() {
         items: [
           { title: "Create Course", url: "/teacher/courses/create" },
           { title: "All Courses", url: "/teacher" },
+          // Sharing a video needs no course, so it sits beside the builder
+          // rather than inside a course.
+          { title: "Share a video", url: "/teacher/share-video" },
         ],
-      },
-      {
-        title: "Share a video",
-        url: "/teacher/share-video",
-        icon: Link2,
       },
       {
         title: "Announcements",

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Frame,
   GalleryVerticalEnd,
   LifeBuoy,
+  Link2,
   Map,
   Megaphone,
   PieChart,
@@ -57,6 +58,11 @@ export function AppSidebar() {
           { title: "Create Course", url: "/teacher/courses/create" },
           { title: "All Courses", url: "/teacher" },
         ],
+      },
+      {
+        title: "Share a video",
+        url: "/teacher/share-video",
+        icon: Link2,
       },
       {
         title: "Announcements",

--- a/frontend/src/hooks/share-link-hooks.ts
+++ b/frontend/src/hooks/share-link-hooks.ts
@@ -1,11 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   createShareLinks,
+  getQuickShares,
   getShareLinkAnalytics,
+  quickShare,
   revokeShareLink,
   validateYouTubeUrl,
 } from '@/lib/api/share-links';
-import type { CreateShareLinksInput } from '@/types/share-link.types';
+import type {
+  CreateShareLinksInput,
+  QuickShareInput,
+} from '@/types/share-link.types';
 
 const shareLinkKeys = {
   analytics: (courseId: string, versionId: string, cohortId?: string) =>
@@ -47,6 +52,24 @@ export function useRevokeShareLink(courseId: string, versionId: string) {
       queryClient.invalidateQueries({
         queryKey: ['share-links', courseId, versionId],
       });
+    },
+  });
+}
+
+/** Videos shared outside any course, and who watched them. */
+export function useQuickShares() {
+  return useQuery({
+    queryKey: ['share-links', 'quick'],
+    queryFn: getQuickShares,
+  });
+}
+
+export function useQuickShare() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: QuickShareInput) => quickShare(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['share-links', 'quick'] });
     },
   });
 }

--- a/frontend/src/lib/api/share-links.ts
+++ b/frontend/src/lib/api/share-links.ts
@@ -1,5 +1,7 @@
 import type {
   CreateShareLinksInput,
+  QuickShareInput,
+  QuickShareResult,
   OpenedShareLink,
   ShareLink,
   ShareLinkAnalytics,
@@ -74,6 +76,23 @@ export async function getShareLinkAnalytics(
     const res = await apiFetch<{ recipients: ShareLinkAnalytics[] }>(
         `${BASE_URL}/courses/${courseId}/versions/${versionId}${query}`,
     );
+    return res.recipients;
+}
+
+/**
+ * Shares a pasted video with no course involved. The backend rejects a video
+ * it cannot embed, so an unplayable link never becomes share links.
+ */
+export async function quickShare(input: QuickShareInput): Promise<QuickShareResult> {
+    return apiFetch<QuickShareResult>(`${BASE_URL}/quick`, {
+        method: 'POST',
+        body: JSON.stringify(input),
+    });
+}
+
+/** Every video this instructor has shared outside a course, and who watched. */
+export async function getQuickShares(): Promise<ShareLinkAnalytics[]> {
+    const res = await apiFetch<{ recipients: ShareLinkAnalytics[] }>(`${BASE_URL}/quick`);
     return res.recipients;
 }
 

--- a/frontend/src/lib/api/share-links.ts
+++ b/frontend/src/lib/api/share-links.ts
@@ -26,14 +26,32 @@ function getAuthHeaders(): HeadersInit {
 }
 
 async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
-    const res = await fetch(url, {
-        ...options,
-        headers: { ...getAuthHeaders(), ...(options?.headers || {}) },
-        credentials: 'include',
-    });
+    let res: Response;
+    try {
+        res = await fetch(url, {
+            ...options,
+            headers: { ...getAuthHeaders(), ...(options?.headers || {}) },
+            credentials: 'include',
+        });
+    } catch {
+        // A failed fetch is the backend being unreachable, not a bad video —
+        // saying so beats a generic "try again" that sends people hunting
+        // through their YouTube link.
+        throw new Error(
+            `Could not reach the ViBe server at ${import.meta.env.VITE_BASE_URL}. Check that it is running.`,
+        );
+    }
+
     if (!res.ok) {
         const errData = await res.json().catch(() => ({}));
-        const err: any = new Error(errData.message || `Request failed (${res.status})`);
+        // 404 here means the server is up but has no share-links endpoints —
+        // it is running a build without the feature.
+        const fallback =
+            res.status === 404
+                ? 'This ViBe server does not have the share-link feature yet.'
+                : `Request failed (${res.status})`;
+        const err: any = new Error(errData.message || fallback);
+        err.status = res.status;
         err.data = errData;
         throw err;
     }

--- a/frontend/src/types/share-link.types.ts
+++ b/frontend/src/types/share-link.types.ts
@@ -71,3 +71,18 @@ export interface OpenedShareLink {
   recipientName: string;
   viewingMode: ShareLinkViewingMode;
 }
+
+export interface QuickShareInput {
+  url: string;
+  recipients: ShareLinkRecipientInput[];
+  /** Where the video ends, HH:MM:SS. Without it only watch time is meaningful. */
+  endTime?: string;
+  expiresInDays?: number;
+  viewingMode?: ShareLinkViewingMode;
+}
+
+export interface QuickShareResult {
+  itemId: string;
+  videoTitle: string;
+  links: ShareLink[];
+}


### PR DESCRIPTION
MailService.sendMail returned `true` without sending anything — the nodemailer call was commented out. Every caller therefore recorded a success for mail that never left the server.

It now sends, and throws when it cannot, so callers can record a real failure instead of a false success. When SMTP is unconfigured it says so explicitly rather than failing obscurely inside nodemailer.

Live callers this re-enables: share links, course-registration accept/reject mails, manual and automatic ejection notices, and invite resend. Bulk invite sending stays off — its dispatch is separately commented out at the call site in InviteService and is untouched here.

Verified: the configured Gmail credentials authenticate (transporter.verify succeeds); no test message was sent. tsc clean. The notifications integration suite fails identically before and after this change (14 pre-existing failures needing an auth token).
