### PR TITLE
fix(mail): actually send mail instead of reporting success and droppi…

### DIFF
--- a/backend/src/modules/notifications/services/MailService.ts
+++ b/backend/src/modules/notifications/services/MailService.ts
@@ -3,6 +3,10 @@ import { injectable } from 'inversify';
 import nodemailer from 'nodemailer';
 import { smtpConfig } from '#root/config/smtp.js';
 
+/** The values config falls back to when SMTP is not configured at all. */
+const PLACEHOLDER_USER = 'user@example.com';
+const PLACEHOLDER_PASS = 'password';
+
 /**
  * Service for sending emails related to course invitations and notifications.
  *
@@ -22,14 +26,38 @@ export class MailService {
     });
   }
 
-  async sendMail(options: Omit<nodemailer.SendMailOptions, 'from'>): Promise<nodemailer.SentMessageInfo> {
-    // const mailOptions: nodemailer.SendMailOptions = {
-    //   from: smtpConfig.auth.user,
-    //   ...options
-    // };
+  /** True when real credentials are configured, rather than the fallbacks. */
+  private isConfigured(): boolean {
+    return (
+      !!smtpConfig.auth.user &&
+      !!smtpConfig.auth.pass &&
+      smtpConfig.auth.user !== PLACEHOLDER_USER &&
+      smtpConfig.auth.pass !== PLACEHOLDER_PASS
+    );
+  }
 
-    // const info = await this.transporter.sendMail(mailOptions);
+  /**
+   * Sends a message, and throws if it could not be sent.
+   *
+   * This used to return `true` without sending anything, which meant every
+   * caller — invites included — recorded a success for mail that never left
+   * the server. Failing loudly is what lets callers mark a send as failed and
+   * tell someone about it.
+   */
+  async sendMail(
+    options: Omit<nodemailer.SendMailOptions, 'from'>,
+  ): Promise<nodemailer.SentMessageInfo> {
+    if (!this.isConfigured()) {
+      throw new Error(
+        'SMTP is not configured. Set SMTP_USER and SMTP_PASS to send mail.',
+      );
+    }
 
-    return true;
+    const mailOptions: nodemailer.SendMailOptions = {
+      from: smtpConfig.auth.user,
+      ...options,
+    };
+
+    return this.transporter.sendMail(mailOptions);
   }
 }


### PR DESCRIPTION
MailService.sendMail returned true without sending, with the nodemailer call commented out. Every caller recorded a success for mail that never left the server — share links, registration decisions, ejection notices and invite resends alike.

It now sends, and throws when it cannot, so callers can record a real failure instead of a false success. When SMTP is unconfigured it says so rather than failing obscurely inside nodemailer.

Verified the configured Gmail credentials authenticate (transporter.verify succeeds); no test message was sent.

Live callers this re-enables: share links, course-registration accept and reject mails, manual and automatic ejection notices, and invite resend. Bulk invite sending stays off — its dispatch is separately commented out at the call site in InviteService and is untouched here.

