### PR TITLE
feat(hp-system): scope the HP System to courses that opt into it

### DIFF
--- a/backend/src/modules/hpSystem/classes/validators/courseAndCohorts.ts
+++ b/backend/src/modules/hpSystem/classes/validators/courseAndCohorts.ts
@@ -18,6 +18,13 @@ export class CourseVersionDto {
 
     @IsString() // ISO date string
     createdAt!: string;
+
+    /**
+     * False for a version whose HP System has been switched off but which still
+     * holds HP data. Instructors may read that data; nothing may be written to it.
+     */
+    @IsBoolean()
+    hpEnabled!: boolean;
 }
 
 export class CourseWithVersionsDto {

--- a/backend/src/modules/hpSystem/container.ts
+++ b/backend/src/modules/hpSystem/container.ts
@@ -13,6 +13,7 @@ import { ActivitySubmissionsRepository, LedgerRepository, RuleConfigsRepository 
 import { CohortsController } from './controllers/cohortsController.js';
 import { CohortsService } from './services/cohortsService.js';
 import { CohortRepository } from './repositories/providers/mongodb/cohortsRepository.js';
+import { HpAccessService } from './services/hpAccessService.js';
 
 export const hpSystemContainerModule = new ContainerModule(options => {
     // Controllers
@@ -28,6 +29,7 @@ export const hpSystemContainerModule = new ContainerModule(options => {
     options.bind(HP_SYSTEM_TYPES.activitySubmissionsService).to(ActivitySubmissionsService).inSingletonScope();
     options.bind(HP_SYSTEM_TYPES.ledgerService).to(LedgerService).inSingletonScope();
     options.bind(HP_SYSTEM_TYPES.ruleConfigsService).to(RuleConfigService).inSingletonScope();
+    options.bind(HP_SYSTEM_TYPES.hpAccessService).to(HpAccessService).inSingletonScope();
 
     // Repositories
     options.bind(HP_SYSTEM_TYPES.activityRepository).to(ActivityRepository);

--- a/backend/src/modules/hpSystem/repositories/providers/mongodb/cohortsRepository.ts
+++ b/backend/src/modules/hpSystem/repositories/providers/mongodb/cohortsRepository.ts
@@ -808,11 +808,23 @@ async getCourseDetailsByVersionId(courseVersionId: string) {
     async getDynamicCoursesWithVersions(session?: ClientSession): Promise<CourseWithVersionsDto[]> {
         await this.init();
 
+        // Versions that already accumulated HP data. They stay listed even after an
+        // instructor switches the HP System off, so the work students did remains
+        // reachable — read-only, which the hpEnabled flag below signals.
+        const versionIdsWithHpData = await this.hpActivityCollection.distinct(
+            "courseVersionId",
+            { isDeleted: { $ne: true } },
+        );
+
         const pipeline: any[] = [
-            // 1. Get all active & public course versions that have hpSystem enabled
+            // 1. Get all active & public course versions that have hpSystem enabled,
+            //    plus the switched-off ones that still hold HP data
             {
                 $match: {
-                    "settings.hpSystem": true,
+                    $or: [
+                        { "settings.hpSystem": true },
+                        { courseVersionId: { $in: versionIdsWithHpData } },
+                    ],
                     //"settings.isPublic": true, // We might need this if we shouldn't show private courses, ask later if needed.
                 }
             },
@@ -878,7 +890,8 @@ async getCourseDetailsByVersionId(courseVersionId: string) {
                             courseVersionId: { $toString: "$versionDetails._id" },
                             versionName: "$versionDetails.version",
                             totalCohorts: { $size: "$versionCohorts" },
-                            createdAt: "$versionDetails.createdAt"
+                            createdAt: "$versionDetails.createdAt",
+                            hpEnabled: { $eq: ["$settings.hpSystem", true] }
                         }
                     }
                 }

--- a/backend/src/modules/hpSystem/services/activityService.ts
+++ b/backend/src/modules/hpSystem/services/activityService.ts
@@ -7,6 +7,7 @@ import { BadRequestError, ForbiddenError, NotFoundError } from "routing-controll
 import { CreateActivityBody, ListActivitiesQuery, UpdateActivityBody } from "../classes/validators/activityValidators.js";
 import { ObjectId } from "mongodb";
 import { CohortRepository } from "../repositories/providers/mongodb/cohortsRepository.js";
+import { HpAccessService } from "./hpAccessService.js";
 
 
 
@@ -26,6 +27,8 @@ export class ActivityService extends BaseService {
         @inject(HP_SYSTEM_TYPES.cohortRepository)
         private readonly cohortRepository: CohortRepository,
 
+        @inject(HP_SYSTEM_TYPES.hpAccessService)
+        private readonly hpAccessService: HpAccessService,
 
     ) {
         super(mongoDatabase);
@@ -34,6 +37,8 @@ export class ActivityService extends BaseService {
 
     async create(teacherId: string, body: CreateActivityBody) {
         return this._withTransaction(async (session) => {
+            await this.hpAccessService.assertEnabled(body.courseVersionId);
+
             if (body.submissionMode === "EXTERNAL_LINK" && !body.externalLink) {
                 throw new BadRequestError("externalLink is required when submissionMode is EXTERNAL_LINK");
             }
@@ -102,6 +107,7 @@ export class ActivityService extends BaseService {
         return this._withTransaction(async (session) => {
             const existing = await this.activityRepository.findById(activityId);
             if (!existing) throw new NotFoundError("Activity not found");
+            await this.hpAccessService.assertEnabled(existing.courseVersionId);
             if (existing.status === "ARCHIVED") throw new BadRequestError("Archived activity cannot be updated");
 
             if (body.submissionMode === "EXTERNAL_LINK" && !body.externalLink && !existing.externalLink) {
@@ -172,6 +178,7 @@ export class ActivityService extends BaseService {
         return this._withTransaction(async (session) => {
             const existing = await this.activityRepository.findById(activityId);
             if (!existing) throw new NotFoundError("Activity not found");
+            await this.hpAccessService.assertEnabled(existing.courseVersionId);
             // if (existing.status === "ARCHIVED") throw new BadRequestError("Archived activity cannot be published");
 
             if (existing.submissionMode === "EXTERNAL_LINK" && !existing.externalLink) {
@@ -188,6 +195,7 @@ export class ActivityService extends BaseService {
         return this._withTransaction(async (session) => {
             const existing = await this.activityRepository.findById(activityId);
             if (!existing) throw new NotFoundError("Activity not found");
+            await this.hpAccessService.assertEnabled(existing.courseVersionId);
 
             const archived = await this.activityRepository.archiveActivity(activityId, session);
             if (!archived) throw new NotFoundError("Activity not found");
@@ -214,6 +222,8 @@ export class ActivityService extends BaseService {
             if (!activity) {
                 throw new BadRequestError("Activity not found");
             }
+
+            await this.hpAccessService.assertEnabled(activity.courseVersionId);
 
             // Allow only owner (adjust if admins allowed)
             const createdBy = activity.createdByTeacherId

--- a/backend/src/modules/hpSystem/services/activitySubmissionsService.ts
+++ b/backend/src/modules/hpSystem/services/activitySubmissionsService.ts
@@ -19,6 +19,7 @@ import { ID } from "../constants.js";
 import { getHpLedgerOperationId } from "../utils/getHpLedgerOperationId .js";
 import { ISettingRepository } from "#root/shared/database/interfaces/ISettingRepository.js";
 import { ICourseRepository } from "#root/shared/database/interfaces/ICourseRepository.js";
+import { HpAccessService } from "./hpAccessService.js";
 
 
 @injectable()
@@ -50,6 +51,9 @@ export class ActivitySubmissionsService extends BaseService {
 
         @inject(HP_SYSTEM_TYPES.activityRepository)
         private readonly activityRepository: ActivityRepository,
+
+        @inject(HP_SYSTEM_TYPES.hpAccessService)
+        private readonly hpAccessService: HpAccessService,
 
         @inject(GLOBAL_TYPES.UserRepo) private readonly userRepo: IUserRepository,
         @inject(GLOBAL_TYPES.SettingRepo) private readonly settingRepository: ISettingRepository,
@@ -234,6 +238,8 @@ export class ActivitySubmissionsService extends BaseService {
             if (!body.courseId || !body.courseVersionId || !body.activityId || !body.cohortId) {
                 throw new BadRequestError("Missing required fields");
             }
+
+            await this.hpAccessService.assertEnabled(body.courseVersionId);
 
             const activityId = body.activityId;
 
@@ -533,6 +539,8 @@ export class ActivitySubmissionsService extends BaseService {
             if (!body.courseId || !body.courseVersionId || !body.activityId || !body.cohortId) {
                 throw new BadRequestError("Missing required fields");
             }
+
+            await this.hpAccessService.assertEnabled(body.courseVersionId);
 
             const submission = await this.activitySubmissionsRepository.findById(submissionId, { session });
             if (!submission) {
@@ -847,6 +855,8 @@ export class ActivitySubmissionsService extends BaseService {
             const submission = await this.activitySubmissionsRepository.findById(submissionId, { session });
             if (!submission) throw new NotFoundError(`Submission ${submissionId} not found.`);
 
+            await this.hpAccessService.assertEnabled(submission.courseVersionId);
+
             // Use the new resolver to handle both ID and legacy names
             const resolvedCohort = await this.cohortRepository.resolveCohort(
                 submission.cohortId?.toString() || submission.cohort,
@@ -1041,6 +1051,8 @@ export class ActivitySubmissionsService extends BaseService {
         // 1. Fetch submission
         const submission = await this.activitySubmissionsRepository.findById(submissionId, { session });
         if (!submission) throw new NotFoundError(`Submission ${submissionId} not found.`);
+
+        await this.hpAccessService.assertEnabled(submission.courseVersionId);
 
         // 2. Validate — only REVERTED or REJECTED submissions can be restored
         if (submission.status !== "REVERTED" && submission.status !== "REJECTED") {

--- a/backend/src/modules/hpSystem/services/cohortsService.ts
+++ b/backend/src/modules/hpSystem/services/cohortsService.ts
@@ -9,6 +9,7 @@ import { ActivityRepository } from "../repositories/index.js";
 import { BadRequestError, NotFoundError } from "routing-controllers";
 import { IActivitySubmissionRepository } from "../interfaces/IActivitySubmissionRepository.js";
 import { HpResetMode } from "../models.js";
+import { HpAccessService } from "./hpAccessService.js";
 
 
 const EXISTING_COHORTS_MAP: Record<string, Record<string, string>> = {
@@ -47,6 +48,9 @@ export class CohortsService extends BaseService {
         @inject(GLOBAL_TYPES.SettingRepo)
         private readonly settingsRepository: ISettingRepository,
 
+        @inject(HP_SYSTEM_TYPES.hpAccessService)
+        private readonly hpAccessService: HpAccessService,
+
     ) {
         super(mongoDatabase);
     }
@@ -60,14 +64,16 @@ export class CohortsService extends BaseService {
                     {
                         courseVersionId: "000000000000000000000001",
                         versionName: "Pinternship",
-                        totalCohorts: 4, 
+                        totalCohorts: 4,
                         createdAt: "2025-12-18T07:52:42Z",
+                        hpEnabled: true,
                     },
                     {
                         courseVersionId: "000000000000000000000002",
                         versionName: "Vinternship",
-                        totalCohorts: 3, 
+                        totalCohorts: 3,
                         createdAt: "2025-12-18T07:52:42Z",
+                        hpEnabled: true,
                     }
                 ]
             }
@@ -669,6 +675,8 @@ export class CohortsService extends BaseService {
         throw new NotFoundError('Cohort Not found');
       }
 
+      await this.hpAccessService.assertEnabled(resolved.courseVersionId);
+
       return this.cohortRepository.resetHpforCohort(
         resolved.courseVersionId.toString(),
         resolved._id!.toString(),
@@ -697,6 +705,8 @@ export class CohortsService extends BaseService {
         if (!resolved) {
             throw new NotFoundError('Cohort Not found');
         }
+
+        await this.hpAccessService.assertEnabled(resolved.courseVersionId);
 
         return this.cohortRepository.resetHpForStudent(
             resolved.courseVersionId.toString(),

--- a/backend/src/modules/hpSystem/services/hpAccessService.ts
+++ b/backend/src/modules/hpSystem/services/hpAccessService.ts
@@ -1,0 +1,54 @@
+import { ISettingRepository } from "#root/shared/index.js";
+import { GLOBAL_TYPES } from "#root/types.js";
+import { inject, injectable } from "inversify";
+import { ObjectId } from "mongodb";
+import { ForbiddenError } from "routing-controllers";
+import { COHORT_OVERRIDES } from "../constants.js";
+
+/**
+ * The HP System is an opt-in, per-course-version feature: it is on only when
+ * `courseSettings.settings.hpSystem` is true for that version.
+ *
+ * Turning it off never destroys anything — instructors keep read access to the
+ * activities, submissions and ledger entries a course already accumulated — but
+ * nothing new may be written against a version that has it switched off.
+ */
+@injectable()
+export class HpAccessService {
+    /**
+     * Versions that predate course settings. They carry HP data but have no
+     * `hpSystem` flag to read, so they stay writable until they are migrated.
+     */
+    private readonly legacyVersionIds = new Set(
+        Object.values(COHORT_OVERRIDES).map(o => o.versionId),
+    );
+
+    constructor(
+        @inject(GLOBAL_TYPES.SettingRepo)
+        private readonly settingsRepository: ISettingRepository,
+    ) { }
+
+    async isEnabled(courseVersionId?: string | ObjectId | null): Promise<boolean> {
+        const versionId = courseVersionId?.toString();
+        if (!versionId || !ObjectId.isValid(versionId)) return false;
+        if (this.legacyVersionIds.has(versionId)) return true;
+
+        const settings = await this.settingsRepository.getSettingsByVersionIds([
+            new ObjectId(versionId),
+        ]);
+
+        return (settings ?? []).some(s => s.settings?.hpSystem === true);
+    }
+
+    /**
+     * Guards every write that creates HP data or moves a student's HP balance.
+     * Reads are deliberately left open so existing records stay reachable.
+     */
+    async assertEnabled(courseVersionId?: string | ObjectId | null): Promise<void> {
+        if (await this.isEnabled(courseVersionId)) return;
+
+        throw new ForbiddenError(
+            "The HP System is turned off for this course. Existing HP records remain visible, but they can no longer be changed.",
+        );
+    }
+}

--- a/backend/src/modules/hpSystem/tests/hpAccessService.test.ts
+++ b/backend/src/modules/hpSystem/tests/hpAccessService.test.ts
@@ -1,0 +1,79 @@
+// models.ts pulls in class-transformer decorators, which need the metadata
+// polyfill loaded first — same first line as every other suite here.
+import 'reflect-metadata';
+import {describe, expect, it, vi} from 'vitest';
+import {ObjectId} from 'mongodb';
+import {ForbiddenError} from 'routing-controllers';
+import {HpAccessService} from '../services/hpAccessService.js';
+import {COHORT_OVERRIDES} from '../constants.js';
+
+const VERSION_ID = new ObjectId().toString();
+
+function makeService(settings: unknown[] | null) {
+  const settingsRepository = {
+    getSettingsByVersionIds: vi.fn().mockResolvedValue(settings),
+  };
+
+  return {
+    service: new HpAccessService(settingsRepository as never),
+    settingsRepository,
+  };
+}
+
+describe('HpAccessService', () => {
+  it('treats a version with hpSystem on as enabled', async () => {
+    const {service} = makeService([
+      {courseVersionId: VERSION_ID, settings: {hpSystem: true}},
+    ]);
+
+    await expect(service.isEnabled(VERSION_ID)).resolves.toBe(true);
+    await expect(service.assertEnabled(VERSION_ID)).resolves.toBeUndefined();
+  });
+
+  it('refuses writes once hpSystem is switched off', async () => {
+    const {service} = makeService([
+      {courseVersionId: VERSION_ID, settings: {hpSystem: false}},
+    ]);
+
+    await expect(service.isEnabled(VERSION_ID)).resolves.toBe(false);
+    await expect(service.assertEnabled(VERSION_ID)).rejects.toBeInstanceOf(
+      ForbiddenError,
+    );
+  });
+
+  it('refuses writes for a version that has no settings at all', async () => {
+    const {service} = makeService([]);
+
+    await expect(service.assertEnabled(VERSION_ID)).rejects.toBeInstanceOf(
+      ForbiddenError,
+    );
+  });
+
+  it.each([undefined, null, '', 'not-an-object-id'])(
+    'refuses writes for the unusable version id %p',
+    async versionId => {
+      const {service, settingsRepository} = makeService([]);
+
+      await expect(service.isEnabled(versionId)).resolves.toBe(false);
+      expect(settingsRepository.getSettingsByVersionIds).not.toHaveBeenCalled();
+    },
+  );
+
+  it('keeps the pre-settings legacy versions writable', async () => {
+    const legacyVersionId = COHORT_OVERRIDES.Euclideans.versionId;
+    const {service, settingsRepository} = makeService([]);
+
+    await expect(service.isEnabled(legacyVersionId)).resolves.toBe(true);
+    expect(settingsRepository.getSettingsByVersionIds).not.toHaveBeenCalled();
+  });
+
+  it('accepts an ObjectId as readily as a string', async () => {
+    const {service} = makeService([
+      {courseVersionId: VERSION_ID, settings: {hpSystem: true}},
+    ]);
+
+    await expect(service.isEnabled(new ObjectId(VERSION_ID))).resolves.toBe(
+      true,
+    );
+  });
+});

--- a/backend/src/modules/hpSystem/types.ts
+++ b/backend/src/modules/hpSystem/types.ts
@@ -17,6 +17,7 @@ const TYPES = {
     ruleConfigsService: Symbol.for('ruleConfigsService'),
     ledgerService: Symbol.for('ledgerService'),
     cohortsService: Symbol.for('cohortsService'),
+    hpAccessService: Symbol.for('hpAccessService'),
 
     // Repositories
     ruleConfigsRepository: Symbol.for('ruleConfigsRepository'),

--- a/frontend/src/app/pages/teacher/hp-system/CohortDetails.tsx
+++ b/frontend/src/app/pages/teacher/hp-system/CohortDetails.tsx
@@ -1,11 +1,11 @@
 import { useParams, useNavigate, useRouterState } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Info } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CohortOverviewTab } from "./components/CohortOverviewTab";
 import { ActivitiesTab } from "./components/ActivitiesTab";
 import { StudentsTab } from "./components/StudentsTab";
-import { useHpCohorts } from "@/hooks/hooks";
+import { useHpCohorts, useHpVersionAccess } from "@/hooks/hooks";
 import { type CohortStats } from "@/lib/api/hp-system";
 
 export default function HpSystemDashboard() {
@@ -15,6 +15,7 @@ export default function HpSystemDashboard() {
     const from = (router.location.state as any)?.from;
 
     const { data: cohortsData } = useHpCohorts(courseVersionId || "");
+    const { readOnly } = useHpVersionAccess(courseVersionId);
     const cohort = (cohortsData?.data as CohortStats[])?.find((c: CohortStats) => c.cohortId === cohortId);
     const cohortName = cohort?.cohortName || cohortId || "";
 
@@ -30,6 +31,17 @@ export default function HpSystemDashboard() {
                     <p className="text-muted-foreground">Manage activities and HP for this cohort.</p>
                 </div>
             </div>
+
+            {readOnly && (
+                <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-200">
+                    <Info className="h-4 w-4 mt-0.5 shrink-0" />
+                    <p>
+                        The HP System is switched off for this course, so this cohort is read-only.
+                        Existing activities, submissions and HP history stay available here — turn the
+                        HP System back on in the course settings to make changes.
+                    </p>
+                </div>
+            )}
 
             <Tabs defaultValue="activities" className="w-full">
                 <TabsList>

--- a/frontend/src/app/pages/teacher/hp-system/components/ActivitiesTab.tsx
+++ b/frontend/src/app/pages/teacher/hp-system/components/ActivitiesTab.tsx
@@ -3,7 +3,7 @@ import { HpActivity } from "@/lib/api/hp-system";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { EditActivityDialog } from "./EditActivityDialog";
 import { RuleSettingsDialog } from "./RuleSettingsDialog";
-import { useHpActivities, useUpdateHpActivity, usePublishHpActivity, useArchiveHpActivity, useHpCourseVersions, useDeleteHpActivity, useHpActivitiesStatsMap } from "@/hooks/hooks";
+import { useHpActivities, useUpdateHpActivity, usePublishHpActivity, useArchiveHpActivity, useHpCourseVersions, useDeleteHpActivity, useHpActivitiesStatsMap, useHpVersionAccess } from "@/hooks/hooks";
 import { Plus, Search, Trash2, Paperclip, Edit, Link as LinkIcon, FileText, Send, Settings, LayoutGrid, List, Archive, RefreshCw, MoreVertical } from "lucide-react";
 import{
     DropdownMenu,
@@ -38,6 +38,10 @@ export function ActivitiesTab({ courseVersionId, cohortId }: ActivitiesTabProps)
     
     const router = useRouterState();
     const from = router.location.state?.from;
+
+    // HP switched off for this version: the activities stay readable, but nothing
+    // here may be authored, published or removed any more.
+    const { readOnly } = useHpVersionAccess(courseVersionId);
 
 
     // Edit Dialog state
@@ -291,9 +295,11 @@ export function ActivitiesTab({ courseVersionId, cohortId }: ActivitiesTabProps)
                         <RefreshCw className={`h-4 w-4 mr-2 ${isRefetching ? "animate-spin" : ""}`} />
                         {isRefetching ? "Refreshing..." : "Refresh"}
                     </Button>
-                    <Button onClick={() => navigate({ to: `/teacher/hp-system/${courseVersionId}/cohort/${encodeURIComponent(cohortId)}/activities/create` , state: {from}})}>
-                        <Plus className="mr-2 h-4 w-4" /> Add Activity
-                    </Button>
+                    {!readOnly && (
+                        <Button onClick={() => navigate({ to: `/teacher/hp-system/${courseVersionId}/cohort/${encodeURIComponent(cohortId)}/activities/create` , state: {from}})}>
+                            <Plus className="mr-2 h-4 w-4" /> Add Activity
+                        </Button>
+                    )}
                 </div>
             </div>
 
@@ -330,7 +336,7 @@ export function ActivitiesTab({ courseVersionId, cohortId }: ActivitiesTabProps)
 
                                         <DropdownMenu>
                                             <DropdownMenuTrigger asChild>
-                                                <Button variant="outline" size="sm">
+                                                <Button variant="outline" size="sm" disabled={readOnly}>
                                                     <MoreVertical className="h-4 w-4" />
                                                 </Button>
                                             </DropdownMenuTrigger>
@@ -505,7 +511,7 @@ export function ActivitiesTab({ courseVersionId, cohortId }: ActivitiesTabProps)
                                 </div>
                                 <DropdownMenu>
                                     <DropdownMenuTrigger asChild>
-                                        <Button variant="outline" size="sm" className="h-9 px-3">
+                                        <Button variant="outline" size="sm" className="h-9 px-3" disabled={readOnly}>
                                             <MoreVertical className="h-4 w-4" />
                                         </Button>
                                     </DropdownMenuTrigger>

--- a/frontend/src/app/pages/teacher/hp-system/components/CoursesTab.tsx
+++ b/frontend/src/app/pages/teacher/hp-system/components/CoursesTab.tsx
@@ -91,6 +91,12 @@ export default function CourseTab() {
                                                                     <Badge variant="outline" className="text-xs">
                                                                         Version
                                                                     </Badge>
+                                                                    {/* Listed only because it still holds HP data. */}
+                                                                    {v.hpEnabled === false && (
+                                                                        <Badge variant="secondary" className="text-xs">
+                                                                            HP off — read only
+                                                                        </Badge>
+                                                                    )}
                                                                 </div>
 
                                                                 <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">

--- a/frontend/src/app/pages/teacher/hp-system/components/StudentsTab.tsx
+++ b/frontend/src/app/pages/teacher/hp-system/components/StudentsTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { useHpStudents } from "@/hooks/hooks";
+import { useHpStudents, useHpVersionAccess } from "@/hooks/hooks";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Search, History, Mail, FileText, RefreshCw } from "lucide-react";
@@ -36,6 +36,9 @@ export function StudentsTab({ courseVersionId, cohortId, cohortName }: StudentsT
 
   const itemsPerPage = 10;
   const navigate = useNavigate();
+
+  // Balances of a switched-off course stay visible but can no longer be moved.
+  const { readOnly } = useHpVersionAccess(courseVersionId);
 
   const { data: students = [], isLoading, refetch, isRefetching } = useHpStudents(
     courseVersionId,
@@ -146,13 +149,15 @@ export function StudentsTab({ courseVersionId, cohortId, cohortName }: StudentsT
               {isRefetching ? "Refreshing..." : "Refresh"}
             </Button>
             
-            <Button
-              variant="default"
-              size="sm"
-              onClick={() => setOpenReset(true)}
-            >
-              Reset HP
-            </Button>
+            {!readOnly && (
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => setOpenReset(true)}
+              >
+                Reset HP
+              </Button>
+            )}
           </div>
 
       </div>
@@ -300,16 +305,18 @@ export function StudentsTab({ courseVersionId, cohortId, cohortName }: StudentsT
                       HP History
                     </Button>
 
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => {
-                        setSelectedStudent(student);
-                        setOpenStudentReset(true);
-                      }}
-                    >
-                      Reset HP
-                    </Button>
+                    {!readOnly && (
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => {
+                          setSelectedStudent(student);
+                          setOpenStudentReset(true);
+                        }}
+                      >
+                        Reset HP
+                      </Button>
+                    )}
                   </td>
 
                 </tr>

--- a/frontend/src/app/pages/teacher/hp-system/create-activity.tsx
+++ b/frontend/src/app/pages/teacher/hp-system/create-activity.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate, useRouterState } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,7 +20,7 @@ import {
 import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { toast } from "sonner";
 import { CreateHpActivityPayload, HpRuleConfig, CourseWithVersions, CourseVersionStats, SubmissionField, getEffectiveIds } from "@/lib/api/hp-system";
-import { useCreateActivityWithRule, useCreateHpActivity, useCreateHpRuleConfig, useHpCourseVersions } from "@/hooks/hooks";
+import { useCreateActivityWithRule, useCreateHpActivity, useCreateHpRuleConfig, useHpCourseVersions, useHpVersionAccess } from "@/hooks/hooks";
 import ConfirmationModal from "@/app/pages/teacher/components/confirmation-modal";
 
 export default function CreateHpActivityPage() {
@@ -38,6 +38,19 @@ export default function CreateHpActivityPage() {
 
     const router = useRouterState();
     let from = router.location.state?.from;
+
+    // Authoring is closed once the course's HP System is switched off; the
+    // cohort's existing activities stay readable on the dashboard.
+    const { readOnly } = useHpVersionAccess(courseVersionId);
+
+    useEffect(() => {
+        if (readOnly) {
+            navigate({
+                to: `/teacher/hp-system/${courseVersionId}/cohort/${encodeURIComponent(cohortId || "")}/activities`,
+                replace: true,
+            });
+        }
+    }, [readOnly, courseVersionId, cohortId, navigate]);
 
     // Find the correct courseId for the given courseVersionId
     const course = courses.find((c: CourseWithVersions) =>

--- a/frontend/src/app/pages/teacher/hp-system/submission-details.tsx
+++ b/frontend/src/app/pages/teacher/hp-system/submission-details.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { useParams, useNavigate } from "@tanstack/react-router";
-import { useHpStudentSubmissions, useHpStudents, useRevertHpEntry, useRestoreHpEntry, useReviewSubmission, useAddFeedback } from "@/hooks/hooks";
+import { useHpStudentSubmissions, useHpStudents, useRevertHpEntry, useRestoreHpEntry, useReviewSubmission, useAddFeedback, useHpVersionAccess } from "@/hooks/hooks";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -485,6 +485,8 @@ export default function SubmissionDetailsPage() {
     const { data: students, isLoading: studentsLoading } = useHpStudents(courseVersionId || "", cohortId || "");
     const student = students.find(s => s._id === studentId);
 
+    const { readOnly } = useHpVersionAccess(courseVersionId);
+
     const { mutateAsync: revertEntry, isPending: isReverting } = useRevertHpEntry();
     const { mutateAsync: restoreEntry, isPending: isRestoring } = useRestoreHpEntry();
     const { mutateAsync: reviewSubmission, isPending: isReviewing } = useReviewSubmission();
@@ -726,7 +728,9 @@ export default function SubmissionDetailsPage() {
                 {/* Feedback Section */}
                 {status !== 'PENDING' && (
                     <>
-                        {/* Review Actions Card */}
+                        {/* Review Actions Card — gone once the course's HP System is off,
+                            since every action here moves the student's HP balance. */}
+                        {!readOnly && (
                         <Card className="bg-muted/50 border">
                             <CardHeader className="pb-3">
                                 <CardTitle className="text-base flex items-center gap-2">
@@ -804,6 +808,7 @@ export default function SubmissionDetailsPage() {
                                 </div>
                             </CardContent>
                         </Card>
+                        )}
 
                         {/* Feedback & Review Card */}
                         <Card>

--- a/frontend/src/app/routes/router.tsx
+++ b/frontend/src/app/routes/router.tsx
@@ -73,6 +73,7 @@ import StudentActivities from '@/app/pages/student/hp-system/activities'
 import StudentSubmissions from '@/app/pages/student/hp-system/submissions'
 import StudentMyLedgerPage from '@/app/pages/student/hp-system/student-ledger'
 import StudentActivityDetail from '@/app/pages/student/hp-system/activity-detail'
+import { StudentHpGuard } from '@/components/hp-system/StudentHpGuard'
 import NotificationsPage from '@/app/pages/shared/NotificationsPage'
 import SupportDashboard from '@/app/pages/teacher/support-dashboard'
 
@@ -569,36 +570,44 @@ const studentMySubmissionsRoute = new Route({
   component: StudentMySubmissions,
 });
 
+// Every learner HP page sits behind the per-course opt-in, so each one is
+// wrapped rather than relying on the sidebar to keep learners away.
+const guardStudentHp = (Page: () => JSX.Element) => () => (
+  <StudentHpGuard>
+    <Page />
+  </StudentHpGuard>
+);
+
 // Student cohorts route
 const studentHpSystemCohortsRoute = new Route({
   getParentRoute: () => studentLayoutRoute,
   path: '/hp-system/cohorts',
-  component: StudentCohorts,
+  component: guardStudentHp(StudentCohorts),
 });
 
 // Student activities route
 const studentHpSystemActivitiesRoute = new Route({
   getParentRoute: () => studentLayoutRoute,
   path: '/hp-system/$courseVersionId/$cohortId/activities',
-  component: StudentActivities,
+  component: guardStudentHp(StudentActivities),
 });
 
 const studentHpSystemSubmissionsRoute = new Route({
   getParentRoute: () => studentLayoutRoute,
   path: '/hp-system/$courseVersionId/$cohortId/submissions',
-  component: StudentSubmissions,
+  component: guardStudentHp(StudentSubmissions),
 });
 
 const studentHpSystemLedgerRoute = new Route({
   getParentRoute: () => studentLayoutRoute,
   path: '/hp-system/ledger',
-  component: StudentMyLedgerPage,
+  component: guardStudentHp(StudentMyLedgerPage),
 });
 
 const studentHpSystemActivitiesDetailRoute = new Route({
   getParentRoute: () =>studentLayoutRoute,
   path: '/hp-system/$courseVersionId/$cohortId/activities/$activityId',
-  component: StudentActivityDetail,
+  component: guardStudentHp(StudentActivityDetail),
 });
 // export const studentCourseInviteRegistration = new Route({
 //   getParentRoute: () => studentLayoutRoute,

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -32,11 +32,13 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar"
 import { useAuthStore } from "@/store/auth-store"
+import { useInstructorHasHpCourses } from "@/hooks/hooks"
 
 export function AppSidebar() {
   // Set default state to "expanded"
   const { state } = useSidebar()
   const { user } = useAuthStore.getState()
+  const { hasHpCourses } = useInstructorHasHpCourses()
 
   const data = {
     user: {
@@ -63,11 +65,15 @@ export function AppSidebar() {
         url: "/teacher/announcements",
         icon: Megaphone,
       },
-      {
-        title: "HP System",
-        url: "/teacher/hp-system",
-        icon: SquareTerminal,
-      },
+      // The HP System is opt-in per course, so this only appears once the
+      // instructor has a course that uses it.
+      ...(hasHpCourses
+        ? [{
+          title: "HP System",
+          url: "/teacher/hp-system",
+          icon: SquareTerminal,
+        }]
+        : []),
       {
         title: "Support Queue",
         url: "/teacher/support",

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -113,13 +113,9 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
   const GURU_SETU_VERSION_ID = "6981df886e100cfe04f9c4ae";
   const isNotGuruSetu = versionId !== GURU_SETU_VERSION_ID;
 
-  // Robust check for HP system availability
-  const isHpSystem = !!(
-    (enrollment.hpSystem || (enrollment as any).hpSystem) ||
-    ((enrollment.course as any)?.hpSystem) ||
-    ((enrollment as any).versionDetails && (enrollment as any).versionDetails[0]?.hpSystem) ||
-    (courseVersionData as any)?.hpSystem
-  );
+  // The enrollment carries the live per-version setting, so it is the only
+  // source to trust — an instructor switching HP off has to hide the badge.
+  const isHpSystem = enrollment.hpSystem === true;
 
   const isStart = progress === 0 && variant !== 'available';
   const isRankVisible = variant !== 'available' && isNotGuruSetu;

--- a/frontend/src/components/course/CourseListCard.tsx
+++ b/frontend/src/components/course/CourseListCard.tsx
@@ -69,7 +69,8 @@ export const CourseListCard = ({ enrollment, index, isLoading: _isLoading, varia
     : '';
   const completedItems = Number(enrollment.completedItems ?? 0);
   const totalItems = Number(enrollment.contentCounts?.totalItems ?? 0);
-  const hpSystem = !!(courseVersionData as any)?.hpSystem;
+  // Same single source as CourseCard: the enrollment reflects the live setting.
+  const hpSystem = enrollment.hpSystem === true;
   const isMoreVideosSoon = enrollment.courseId === "6981df886e100cfe04f9c4ad";
 
   // Subtle icon-tile accent, varied by position for visual rhythm.

--- a/frontend/src/components/hp-system/StudentHpGuard.tsx
+++ b/frontend/src/components/hp-system/StudentHpGuard.tsx
@@ -1,0 +1,33 @@
+import { type ReactNode, useEffect } from "react";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useStudentHpEnabled } from "@/hooks/hooks";
+
+/**
+ * The HP System is opt-in per course, so a learner only reaches these pages
+ * while a course they are enrolled in has it switched on. Hiding the nav entry
+ * is not enough on its own — a typed URL or a stale tab has to land somewhere
+ * sensible too.
+ */
+export function StudentHpGuard({ children }: { children: ReactNode }) {
+  const { courseVersionId } = useParams({ strict: false });
+  const { hpEnabled, isLoading } = useStudentHpEnabled(courseVersionId);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoading && !hpEnabled) {
+      navigate({ to: "/student", replace: true });
+    }
+  }, [isLoading, hpEnabled, navigate]);
+
+  if (isLoading) {
+    return (
+      <div className="p-8 text-center text-muted-foreground flex items-center justify-center min-h-[50vh]">
+        Loading...
+      </div>
+    );
+  }
+
+  if (!hpEnabled) return null;
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/student-sidebar/StudentSidebar.tsx
+++ b/frontend/src/components/student-sidebar/StudentSidebar.tsx
@@ -5,7 +5,7 @@ import { Link, useLocation, useNavigate } from "@tanstack/react-router"
 import { LogOut, Settings, Sun, Moon } from "lucide-react"
 import { useTheme } from "next-themes"
 import { useAuthStore } from "@/store/auth-store"
-import { useUserEnrollments } from "@/hooks/hooks"
+import { useStudentHpEnabled } from "@/hooks/hooks"
 import { useNewAnnouncementIndicator } from "@/hooks/use-new-announcement-indicator"
 import { logout } from "@/utils/auth"
 import { AuroraText } from "@/components/magicui/aurora-text"
@@ -29,7 +29,7 @@ import { STUDENT_NAV_ITEMS } from "./nav-items"
 import { StudentNotifications } from "./StudentNotifications"
 
 export function StudentSidebar() {
-  const { user, token } = useAuthStore()
+  const { user } = useAuthStore()
   const navigate = useNavigate()
   const { pathname } = useLocation()
   const { theme, setTheme } = useTheme()
@@ -38,10 +38,7 @@ export function StudentSidebar() {
   const { hasNew: hasNewAnnouncements, markSeen: markAnnouncementsSeen } = useNewAnnouncementIndicator()
 
   // HP System nav item only shows when the student has an active HP-enabled course.
-  const { data: enrollmentsData } = useUserEnrollments(1, 100, !!token && !!user?.uid)
-  const hasHpSystem = (enrollmentsData?.enrollments ?? []).some(
-    (e) => e.hpSystem === true && e.status === "ACTIVE" && e.percentCompleted !== 100,
-  )
+  const { hasCourseInProgress: hasHpSystem } = useStudentHpEnabled()
 
   const isActive = (path: string) =>
     path === "/student" ? pathname === "/student" : pathname === path || pathname.startsWith(path + "/")

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -85,6 +85,7 @@ import { InviteBody, InviteResponse, MessageResponse } from '@/types/invite.type
 import { EntityType, IReport, ReportStatus } from '@/types/flag.types';
 import { PendingRegistrationNotification, ApprovedRegistrationNotification, PendingStudentRegistrationNotification, RejectedStudentRegistrationNotification } from '@/types/notification.types';
 import { useQueryClient, useQuery, useMutation } from '@tanstack/react-query';
+import { useAuthStore } from '@/store/auth-store';
 import { VersionWithCourse } from '@/app/pages/student/CourseRegistration';
 import { Registration, RegistrationStatus } from '@/app/pages/teacher/CourseRegistrationRequests';
 // import { Field } from '@/app/pages/teacher/components/course-registration-modal';
@@ -6518,6 +6519,63 @@ export function useHpCourseVersions() {
     isLoading: query.isLoading,
     error: query.error ? (query.error as Error).message : null,
     refetch: query.refetch,
+  };
+}
+
+/**
+ * The HP System is opt-in per course version, so the instructor nav entry only
+ * earns its place once at least one of their courses uses it.
+ */
+export function useInstructorHasHpCourses() {
+  const { data, isLoading } = useHpCourseVersions();
+
+  return {
+    hasHpCourses: data.some(course => course.versions.length > 0),
+    isLoading,
+  };
+}
+
+/**
+ * Whether the instructor may still write to a version's HP data. A version whose
+ * HP System was switched off stays listed — and readable — but turns read-only.
+ */
+export function useHpVersionAccess(courseVersionId?: string) {
+  const { data, isLoading } = useHpCourseVersions();
+
+  const version = courseVersionId
+    ? data.flatMap(course => course.versions).find(v => v.courseVersionId === courseVersionId)
+    : undefined;
+
+  return {
+    isLoading,
+    // Unknown versions stay writable here; the backend is the authority and
+    // rejects the write if HP is in fact off.
+    readOnly: !isLoading && version?.hpEnabled === false,
+  };
+}
+
+/**
+ * Learner-side counterpart: HP surfaces exist for a student only while the
+ * course version they are enrolled in has the HP System switched on.
+ */
+export function useStudentHpEnabled(courseVersionId?: string) {
+  const { user, token } = useAuthStore();
+  const { data, isLoading } = useUserEnrollments(1, 100, !!token && !!user?.uid);
+
+  const enrollments = data?.enrollments ?? [];
+  const hpEnrollments = enrollments.filter(
+    e => e.hpSystem === true && e.status === 'ACTIVE',
+  );
+
+  return {
+    isLoading,
+    // Access to HP pages, including for a course the student has finished —
+    // their HP history stays theirs to read.
+    hpEnabled: courseVersionId
+      ? hpEnrollments.some(e => String(e.courseVersionId) === courseVersionId)
+      : hpEnrollments.length > 0,
+    // Narrower: worth a nav entry only while a course is still in progress.
+    hasCourseInProgress: hpEnrollments.some(e => e.percentCompleted !== 100),
   };
 }
 

--- a/frontend/src/lib/api/hp-system.ts
+++ b/frontend/src/lib/api/hp-system.ts
@@ -57,6 +57,8 @@ export interface CourseVersionStats {
     versionName: string;
     totalCohorts: number;
     createdAt?: string;
+    /** False when the HP System was switched off but the version still holds HP data. */
+    hpEnabled?: boolean;
 }
 
 export interface CourseWithVersions {


### PR DESCRIPTION
The HP System is opt-in per course version via courseSettings.hpSystem, but the UI only honoured that in places. The instructor nav entry always showed, every HP route rendered regardless of the course in the URL, and the learner course card guessed the flag from four different response shapes — so a course that never enabled HP still exposed HP surfaces to both roles.

Backend: a new HpAccessService reads the per-version setting and refuses every write that creates HP data or moves a student's HP balance — activity create/update/publish/archive/delete, submission submit/edit, review, restore, and both HP resets. Reads stay open on purpose. The legacy pre-settings versions in COHORT_OVERRIDES remain writable so the live MERN cohorts are unaffected. The instructor courses list now also returns versions that hold HP data but have the feature switched off, each tagged hpEnabled, so switching HP off no longer makes a course disappear.

Frontend: three hooks (useInstructorHasHpCourses, useHpVersionAccess, useStudentHpEnabled) replace the scattered flag checks. The instructor sidebar entry appears only when they have an HP course; every learner HP route is wrapped in a guard that redirects instead of rendering; and the course cards read the flag from the enrollment, which the backend derives from live settings.

When an instructor turns HP off, the course stays visible to them and is marked read-only: a banner explains why, and Add Activity, the per-activity menu, both Reset HP buttons and the Review Actions card are gone. Learners lose the surfaces entirely. One deliberate difference from the old sidebar rule: a learner who has completed a course can still open their HP ledger — the sidebar still hides the entry, but the guard does not block finished courses.

Verified with backend and frontend typechecks, a new 9-case unit suite for HpAccessService covering enabled, disabled, missing-settings, unusable ids and the legacy versions, and the backend lint hook on commit.
