### PR TITLE
fix(frontend): add forgot-password link to sign-in page

### DIFF
--- a/frontend/src/app/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/app/pages/ForgotPasswordPage.tsx
@@ -96,7 +96,7 @@ export default function ForgotPasswordPage() {
               <Button
                 variant="outline"
                 className="w-full"
-                onClick={() => navigate({ to: "/login" })}
+                onClick={() => navigate({ to: "/student/login" })}
               >
                 Back to Login
               </Button>
@@ -143,7 +143,7 @@ export default function ForgotPasswordPage() {
               variant="ghost" 
               size="sm" 
               className="absolute top-4 left-4 text-muted-foreground"
-              onClick={() => navigate({ to: "/login" })}
+              onClick={() => navigate({ to: "/student/login" })}
             >
               ← Back
             </Button>
@@ -196,7 +196,7 @@ export default function ForgotPasswordPage() {
               <Button
                 variant="link"
                 className="p-0 h-auto font-medium"
-                onClick={() => navigate({ to: "/login" })}
+                onClick={() => navigate({ to: "/student/login" })}
               >
                 Sign in
               </Button>

--- a/frontend/src/app/pages/ResetPasswordPage.tsx
+++ b/frontend/src/app/pages/ResetPasswordPage.tsx
@@ -148,7 +148,7 @@ export default function ResetPasswordPage() {
             <CardFooter>
               <Button
                 className="w-full"
-                onClick={() => navigate({ to: "/login" })}
+                onClick={() => navigate({ to: "/student/login" })}
               >
                 Go to Login
               </Button>

--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -1437,6 +1437,18 @@ export default function AuthPage({ role }: AuthPageProps) {
                         {formErrors.password && (
                           <p className="text-xs text-destructive">{formErrors.password}</p>
                         )}
+                        {!isSignUp && (
+                          <div className="text-right">
+                            <Button
+                              type="button"
+                              variant="link"
+                              className="h-auto p-0 text-xs"
+                              onClick={() => navigate({ to: "/forgot-password" })}
+                            >
+                              Forgot password?
+                            </Button>
+                          </div>
+                        )}
                       </div>
 
                       {/* reCAPTCHA */}


### PR DESCRIPTION
The sign-in form had no way to reach the forgot-password flow — `ForgotPasswordPage`/`ResetPasswordPage` and their routes already existed and work end-to-end through Firebase, but nothing linked to them from login.

Added a "Forgot password?" link under the password field, shown only in login mode. Also fixed both reset pages' "back to login"/"go to login" buttons, which pointed at `/login`, a route commented out of the router — they now go to `/student/login`, the live route.

Verified live on a deployed fork (Render): link appears on both `/student/login` and `/teacher/login`, `/forgot-password` renders and submits correctly, and a real Firebase password-reset email was received end-to-end after adding the deploy domain to Firebase's authorized domains.

(Supersedes #1282, which was cut from a fork branch carrying unrelated commits — this one is a single commit on top of upstream `main`.)

Closes #1281