### PR TITLE
fix: automatic retry for database write conflicts doesn't actually work

### DIFF
--- a/backend/src/modules/users/tests/EnrollmentRepository.concurrentProgressUpdates.test.ts
+++ b/backend/src/modules/users/tests/EnrollmentRepository.concurrentProgressUpdates.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { MongoDatabase } from '#shared/database/providers/mongo/MongoDatabase.js';
+import { EnrollmentRepository } from '#shared/database/providers/mongo/repositories/EnrollmentRepository.js';
+import { BaseService } from '#shared/classes/BaseService.js';
+
+/**
+ * Forces real MongoDB write conflicts by hammering the same enrollment
+ * document with concurrent transactional updates, to prove
+ * BaseService._withTransaction's retry actually recovers from them now
+ * that EnrollmentRepository preserves the TransientTransactionError label
+ * instead of discarding it when wrapping the error (see
+ * TRANSACTION_RETRY_GAP.md). Before that fix, a meaningful fraction of
+ * these concurrent calls would fail outright instead of retrying.
+ */
+class ConcurrencyTestService extends BaseService {
+  constructor(
+    db: MongoDatabase,
+    private enrollmentRepo: EnrollmentRepository,
+  ) {
+    super(db);
+  }
+
+  async bumpProgress(enrollmentId: string, percentCompleted: number) {
+    return this._withTransaction(session =>
+      this.enrollmentRepo.updateProgressPercentById(
+        enrollmentId,
+        percentCompleted,
+        undefined,
+        undefined,
+        session,
+      ),
+    );
+  }
+}
+
+describe('BaseService._withTransaction retry under real concurrent contention', () => {
+  let db: MongoDatabase;
+  let service: ConcurrencyTestService;
+  const enrollmentId = new ObjectId();
+
+  beforeAll(async () => {
+    db = new MongoDatabase(process.env.DB_URL, 'enrollment_concurrency_test');
+    await db.connect();
+    const enrollmentRepo = new EnrollmentRepository(db);
+    service = new ConcurrencyTestService(db, enrollmentRepo);
+
+    const enrollments = await db.getCollection('enrollment');
+    await enrollments.insertOne({
+      _id: enrollmentId,
+      userId: new ObjectId(),
+      courseId: new ObjectId(),
+      courseVersionId: new ObjectId(),
+      role: 'STUDENT',
+      status: 'ACTIVE',
+      enrollmentDate: new Date(),
+      percentCompleted: 0,
+      isDeleted: false,
+    } as any);
+  });
+
+  afterAll(async () => {
+    await db.disconnect();
+  });
+
+  it('retries transient write conflicts instead of surfacing them, under 15 concurrent updates to the same document', async () => {
+    const CONCURRENT_UPDATES = 15;
+
+    const results = await Promise.allSettled(
+      Array.from({ length: CONCURRENT_UPDATES }, (_, i) =>
+        service.bumpProgress(enrollmentId.toString(), i + 1),
+      ),
+    );
+
+    const rejected = results.filter(r => r.status === 'rejected');
+    if (rejected.length > 0) {
+      // Surface what actually failed, rather than just a count, if this
+      // ever regresses.
+      console.error(
+        'Concurrent progress updates that failed instead of retrying:',
+        rejected.map(r => (r as PromiseRejectedResult).reason?.message ?? r),
+      );
+    }
+
+    expect(rejected).toHaveLength(0);
+  });
+});

--- a/backend/src/shared/classes/BaseService.ts
+++ b/backend/src/shared/classes/BaseService.ts
@@ -13,7 +13,7 @@ export abstract class BaseService {
     operation: (session: ClientSession) => Promise<T>,
   ): Promise<T> {
     const client = await this.db.getClient();
-    const MAX_RETRIES = 3;
+    const MAX_RETRIES = 5;
     const txOptions = {
       readPreference: ReadPreference.primary,
       readConcern: new ReadConcern('snapshot'),
@@ -35,6 +35,11 @@ export abstract class BaseService {
           Array.isArray(error?.errorLabels) &&
           error.errorLabels.includes('TransientTransactionError');
         if (isTransient && attempt < MAX_RETRIES - 1) {
+          // Retrying immediately makes competing writers collide again in
+          // lockstep under high contention. Exponential backoff with
+          // jitter spreads retries out so they stop re-colliding.
+          const backoffMs = 2 ** attempt * 15 + Math.random() * 30;
+          await new Promise(resolve => setTimeout(resolve, backoffMs));
           continue;
         }
         throw error;

--- a/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
@@ -49,18 +49,7 @@ import { IQuestionBank } from '#root/shared/interfaces/quiz.js';
 import { IProjectSubmissionRepository } from '#root/modules/projects/interfaces/IProjectSubmissionRepository.js';
 import { ISettingRepository } from '#root/shared/database/interfaces/ISettingRepository.js';
 import { NOTIFICATIONS_TYPES } from '#root/modules/notifications/types.js';
-
-/**
- * Transient transaction errors (e.g. write conflicts with concurrent watch-time
- * heartbeats) must reach BaseService._withTransaction unwrapped, with their
- * errorLabels intact, so the transaction is retried instead of surfacing a 500.
- */
-function isTransientTransactionError(error: unknown): boolean {
-  return (
-    Array.isArray((error as any)?.errorLabels) &&
-    (error as any).errorLabels.includes('TransientTransactionError')
-  );
-}
+import { isTransientTransactionError } from '#root/shared/functions/isTransientTransactionError.js';
 
 @injectable()
 export class CourseRepository implements ICourseRepository {

--- a/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
@@ -477,6 +477,9 @@ export class CourseRepository implements ICourseRepository {
         throw new InternalServerError('Failed to create course version');
       }
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to create course version.\n More Details: ' + error,
       );
@@ -499,6 +502,9 @@ export class CourseRepository implements ICourseRepository {
         { session },
       );
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to add module to course version.\n More Details: ' + error,
       );
@@ -537,6 +543,9 @@ export class CourseRepository implements ICourseRepository {
       ) as CourseVersion;
     } catch (error) {
       if (error instanceof NotFoundError) {
+        throw error;
+      }
+      if (isTransientTransactionError(error)) {
         throw error;
       }
       throw new InternalServerError(
@@ -945,6 +954,9 @@ export class CourseRepository implements ICourseRepository {
       if (error instanceof NotFoundError) {
         throw error;
       }
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to delete course version.\n More Details: ' + error,
       );
@@ -1238,6 +1250,9 @@ export class CourseRepository implements ICourseRepository {
       );
       return await query.toArray();
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         `Failed to fetch courses: ${(error as Error).message}`,
       );
@@ -1256,6 +1271,9 @@ export class CourseRepository implements ICourseRepository {
       );
       console.log(`Bulk update result: ${JSON.stringify(result)}`);
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to bulk update course versions.\n More Details: ' + error,
       );
@@ -1280,6 +1298,9 @@ export class CourseRepository implements ICourseRepository {
 
       return true;
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       console.error('Failed to add new course version:', error);
       throw new InternalServerError(`Failed to add new course version`);
     }
@@ -1398,6 +1419,9 @@ export class CourseRepository implements ICourseRepository {
         );
       }
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to cascade delete versions.\n More Details: ' + error,
       );
@@ -1428,6 +1452,9 @@ export class CourseRepository implements ICourseRepository {
       )
       return result;
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to update course version.\n More Details: ' + error,
       );
@@ -1465,6 +1492,9 @@ export class CourseRepository implements ICourseRepository {
 
       return result.insertedId.toString();
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to create cohort settings.\n More Details: ' + error,
       );
@@ -1489,6 +1519,9 @@ export class CourseRepository implements ICourseRepository {
       }
       return setting;
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to get cohort setting by ID.\n More Details: ' + error,
       );
@@ -1515,6 +1548,9 @@ export class CourseRepository implements ICourseRepository {
       }
       return setting._id.toString();
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to get cohort setting.\n More Details: ' + error,
       );
@@ -1543,6 +1579,9 @@ export class CourseRepository implements ICourseRepository {
 
       return result.modifiedCount === 1;
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to update cohort settings.\n More Details: ' + error,
       );

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -43,6 +43,7 @@ import {
   buildGuruSetuWatchAggPipeline,
   buildGuruSetuFeedbackAggPipeline,
 } from './queries/guruSetuFeedbackExportPipeline.js';
+import { isTransientTransactionError } from '#root/shared/functions/isTransientTransactionError.js';
 
 @injectable()
 export class EnrollmentRepository {
@@ -313,6 +314,9 @@ export class EnrollmentRepository {
         { session },
       );
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         `Failed to update progress in enrollment. More/${error}`,
       );
@@ -332,6 +336,9 @@ export class EnrollmentRepository {
         { session },
       );
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         `Failed to update completed items count in enrollment. More/${error}`,
       );
@@ -365,6 +372,9 @@ export class EnrollmentRepository {
       }
       return newEnrollment;
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         `Failed to create enrollment: ${error.message}`,
       );
@@ -535,6 +545,9 @@ export class EnrollmentRepository {
 
       return newProgress;
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         `Failed to create progress tracking: ${error.message}`,
       );
@@ -749,6 +762,9 @@ export class EnrollmentRepository {
         .aggregate(aggregationPipeline, { session })
         .toArray();
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       console.error(error);
       throw new InternalServerError(`Failed to get enrollments /More ${error}`);
     }
@@ -2499,6 +2515,9 @@ export class EnrollmentRepository {
       });
       console.log(`Enrollment bulk update result: ${JSON.stringify(result)}`);
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         'Failed to bulk update enrollments.\n More Details: ' + error,
       );
@@ -3775,6 +3794,9 @@ export class EnrollmentRepository {
 
       return enrollments;
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       console.error('Failed to get enrollments:', error);
       throw new Error('Failed to fetch enrollments for the course version');
     }
@@ -3809,6 +3831,9 @@ export class EnrollmentRepository {
 
       return enrollments;
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       console.error('Failed to get student enrollments:', error);
       throw new Error(
         'Failed to fetch student enrollments for the course version',
@@ -3889,6 +3914,9 @@ export class EnrollmentRepository {
 
       return result.modifiedCount;
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       console.error('Failed to delete enrollments:', error);
       throw new Error('Failed to delete enrollments for the course version');
     }

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -6,6 +6,7 @@ import { MongoDatabase } from '../MongoDatabase.js';
 import { GLOBAL_TYPES } from '#root/types.js';
 import { BadRequestError, InternalServerError } from 'routing-controllers';
 import { ActiveUserDto, Course, CourseVersion, VideoUserAnalytics, VideoUserAnalyticsResponse } from '#root/modules/courses/classes/index.js';
+import { isTransientTransactionError } from '#root/shared/functions/isTransientTransactionError.js';
 
 type CurrentProgress = Pick<
   IProgress,
@@ -473,6 +474,9 @@ class ProgressRepository {
 
       return docsToDelete.map(doc => doc._id.toString());
     } catch (error) {
+      if (isTransientTransactionError(error)) {
+        throw error;
+      }
       throw new InternalServerError(
         `Failed to delete quiz attempts /More ${error}`,
       );

--- a/backend/src/shared/functions/isTransientTransactionError.ts
+++ b/backend/src/shared/functions/isTransientTransactionError.ts
@@ -1,0 +1,12 @@
+/**
+ * Transient transaction errors (e.g. write conflicts between concurrent
+ * operations touching the same document) must reach BaseService._withTransaction
+ * unwrapped, with their errorLabels intact, so the transaction is retried
+ * instead of surfacing as a failure.
+ */
+export function isTransientTransactionError(error: unknown): boolean {
+  return (
+    Array.isArray((error as any)?.errorLabels) &&
+    (error as any).errorLabels.includes('TransientTransactionError')
+  );
+}


### PR DESCRIPTION
Fixes #1284.

**The bug**: course creation, enrollment, and progress updates could fail on nothing more than bad timing (two writes hitting the same document at once) - even though the app already has retry logic built for exactly that. The retry silently never fired, because most repository methods discarded the signal it needs before it ever reached the retry logic.

**The fix**:
- Extracted the one correct existing implementation (`isTransientTransactionError()`, previously only in `CourseRepository.ts`) into a shared helper
- Applied it everywhere it was missing - 23 spots across `CourseRepository.ts` (13), `EnrollmentRepository.ts` (9), `ProgressRepository.ts` (1) - including `createVersion`, the exact method causing the intermittent `CrowdQuestion.e2e.test.ts` failure in CI
- Added a stress test (15 simultaneous writes to the same document) as permanent regression coverage for this
- That stress test found a second bug: retries fired instantly with no delay, so competing writers kept colliding with each other under real contention. Added a short randomized delay between attempts and gave it more attempts (3 → 5)

