### PR TITLE
fix(progress): recover orphaned watch-time records that lock students out

### DIFF
--- a/backend/src/bootstrap/jobs/index.ts
+++ b/backend/src/bootstrap/jobs/index.ts
@@ -2,6 +2,7 @@ import './backupDb.js';
 import './allocateHp.js'
 import './backfillFollowUpInvites.js';
 import './evaluateSlotFulfillment.js';
+import './recoverOrphanedWatchTimes.js';
 
 export const initJobs = () => {
   console.log('[CRON] Jobs initialized.');

--- a/backend/src/bootstrap/jobs/recoverOrphanedWatchTimes.ts
+++ b/backend/src/bootstrap/jobs/recoverOrphanedWatchTimes.ts
@@ -1,0 +1,58 @@
+import {appConfig} from '#root/config/app.js';
+import {getContainer} from '#root/bootstrap/loadModules.js';
+import {USERS_TYPES} from '#users/types.js';
+import type {ProgressService} from '#users/services/ProgressService.js';
+import cron from 'node-cron';
+
+// Safety net for lost stop calls.
+//
+// An item counts as complete only if its watchTime row has an endTime, and only
+// the stop API writes that field. When the stop call never lands — the network
+// drops as the video ends, the tab is closed, the request times out — the row
+// stays open, the item never completes, and linear progression locks the
+// student out of everything after it. Until this job existed the only remedy
+// was editing the database by hand, one student at a time.
+//
+// The sweep closes such a row at its lastSeenAt heartbeat, but only when the
+// resulting duration clears the same isValidWatchTime bar the live stop path
+// enforces. Someone who opened a video and walked away fails that check and
+// correctly stays incomplete, so no one is handed a completion they did not
+// earn and linear progression is not weakened.
+//
+// Runs every 30 minutes over sessions untouched for at least 30 minutes, which
+// is far longer than the 15s heartbeat interval, so a student who is simply
+// still watching is never swept. Idempotent, and safe to run concurrently
+// across instances: the close is guarded on the row still being open and the
+// pointer only moves while it is still parked on the recovered item. Gate with
+// ENABLE_WATCHTIME_RECOVERY_JOB=true.
+cron.schedule(
+  '*/30 * * * *',
+  async () => {
+    if (!appConfig.ENABLE_WATCHTIME_RECOVERY_JOB) {
+      console.log(
+        'Skipped orphaned watch-time recovery ENABLE_WATCHTIME_RECOVERY_JOB==',
+        appConfig.ENABLE_WATCHTIME_RECOVERY_JOB,
+      );
+      return;
+    }
+
+    console.log('🚀 Cron Job Started: orphaned watch-time recovery...');
+    try {
+      const progressService = getContainer().get<ProgressService>(
+        USERS_TYPES.ProgressService,
+      );
+      const summary = await progressService.recoverOrphanedWatchTimes();
+      console.log(
+        `[watchtime-recovery] scanned=${summary.scanned} ` +
+          `closed=${summary.closed} advanced=${summary.advanced} ` +
+          `rejected=${summary.rejected} skipped=${summary.skipped}`,
+      );
+      console.log('🎉 Orphaned watch-time recovery completed');
+    } catch (err) {
+      console.error('❌ Orphaned watch-time recovery failed:', err);
+    }
+  },
+  {
+    timezone: 'Asia/Kolkata',
+  },
+);

--- a/backend/src/config/app.ts
+++ b/backend/src/config/app.ts
@@ -29,6 +29,11 @@ export const appConfig = {
   // Default ON: the slot-booking fulfillment evaluator (Phase 3) annotates ended
   // windows as FULFILLED/UNFULFILLED. Set ENABLE_FULFILLMENT_JOB='false' to stop.
   ENABLE_FULFILLMENT_JOB: env('ENABLE_FULFILLMENT_JOB') !== 'false',
+  // Default OFF, unlike the jobs above: this one closes abandoned watch
+  // sessions and moves student progress forward, so it is switched on
+  // deliberately per environment after a dry run rather than on deploy.
+  ENABLE_WATCHTIME_RECOVERY_JOB:
+    env('ENABLE_WATCHTIME_RECOVERY_JOB') === 'true',
   GOOGLE_APPLICATION_CREDENTIALS: env('GOOGLE_APPLICATION_CREDENTIALS'),
   GCP_BACKUP_BUCKET: env('GCP_BACKUP_BUCKET'),
   GCP_BACKUP_ACTIVITY_BUCKET: env('GCP_BACKUP_ACTIVITY_BUCKET'),

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -74,6 +74,13 @@ export interface LeaderboardEntry {
 // threshold, without requiring every item to be marked complete.
 const FOLLOW_UP_INVITE_THRESHOLD = 98;
 
+// Item types whose completion can be judged from watch timestamps alone, and so
+// are the only ones the orphan recovery job will close. Mirrors the
+// WATCH_TIME_REQUIRED_ITEMS set the live stop path validates against. QUIZ and
+// PROJECT are excluded on purpose: their completion depends on a submission,
+// which a background sweep must never fabricate.
+const WATCH_TIME_RECOVERABLE_ITEMS = new Set<string>(['VIDEO', 'BLOG']);
+
 @injectable()
 class ProgressService extends BaseService {
   private getCourseSettingService(): CourseSettingService {
@@ -2548,8 +2555,6 @@ class ProgressService extends BaseService {
       // ----------------------------------------------------
       // 8. DERIVED PROGRESS CALCULATION
       // ----------------------------------------------------
-      let totalItems = totalCourseItems;
-
       const completedItemsArray =
         await this.progressRepository.getCompletedItems(
           userId,
@@ -2558,39 +2563,15 @@ class ProgressService extends BaseService {
           cohortId,
         );
 
-      let completedItemsSet = new Set(
-        completedItemsArray.map(id => id.toString()),
-      );
-
-      if (shouldCountCurrentItemAsCompleted) {
-        completedItemsSet.add(itemId);
-      }
-
-      const hiddenItems =
-        await this.progressRepository.getHiddenOrDeletedItems(
+      const {percentCompleted, completedCourseItemsCount} =
+        await this.computeCourseProgressPercent(
+          completedItemsArray,
+          allCourseItemIdSet,
+          totalCourseItems,
           courseVersionId,
+          shouldCountCurrentItemAsCompleted ? itemId : undefined,
           session,
         );
-
-      const hiddenSet = new Set(hiddenItems.map(i => i.itemId.toString()));
-
-      completedItemsSet = new Set(
-        Array.from(completedItemsSet).filter(id => !hiddenSet.has(id)),
-      );
-
-      totalItems = totalItems - hiddenSet.size;
-
-      const completedCourseItemsCount = Array.from(allCourseItemIdSet).filter(
-        id => completedItemsSet.has(id),
-      ).length;
-
-      const rawPercent =
-        totalItems > 0 ? (completedCourseItemsCount / totalItems) * 100 : 0;
-
-      const percentCompleted = Math.min(
-        100,
-        parseFloat(rawPercent.toFixed(2)),
-      );
 
       // ----------------------------------------------------
       // 9. GURU SETU OVERRIDE
@@ -2665,6 +2646,321 @@ class ProgressService extends BaseService {
     if (justCompleted || crossedFollowUpThreshold) {
       await this.triggerFollowUpInvite(userId, courseId, courseVersionId);
     }
+  }
+
+  /**
+   * Course completion percentage, with hidden and soft-deleted items removed
+   * from both sides of the fraction.
+   *
+   * Shared by the live stop path and the orphan recovery job so a recovered
+   * session produces exactly the same numbers a normal stop would have.
+   *
+   * @param extraCompletedItemId item to count as complete on top of what the
+   * watchTime records already show — the one being completed right now, whose
+   * row may not be visible to the read inside this transaction.
+   */
+  private async computeCourseProgressPercent(
+    completedItemsArray: string[],
+    allCourseItemIdSet: Set<string>,
+    totalCourseItems: number,
+    courseVersionId: string,
+    extraCompletedItemId?: string,
+    session?: ClientSession,
+  ): Promise<{percentCompleted: number; completedCourseItemsCount: number}> {
+    let completedItemsSet = new Set(
+      completedItemsArray.map(id => id.toString()),
+    );
+
+    if (extraCompletedItemId) {
+      completedItemsSet.add(extraCompletedItemId);
+    }
+
+    const hiddenItems = await this.progressRepository.getHiddenOrDeletedItems(
+      courseVersionId,
+      session,
+    );
+
+    const hiddenSet = new Set(hiddenItems.map(i => i.itemId.toString()));
+
+    completedItemsSet = new Set(
+      Array.from(completedItemsSet).filter(id => !hiddenSet.has(id)),
+    );
+
+    const totalItems = totalCourseItems - hiddenSet.size;
+
+    const completedCourseItemsCount = Array.from(allCourseItemIdSet).filter(
+      id => completedItemsSet.has(id),
+    ).length;
+
+    const rawPercent =
+      totalItems > 0 ? (completedCourseItemsCount / totalItems) * 100 : 0;
+
+    return {
+      percentCompleted: Math.min(100, parseFloat(rawPercent.toFixed(2))),
+      completedCourseItemsCount,
+    };
+  }
+
+  /**
+   * Move a student's progress pointer past an item that has just been
+   * completed, and refresh their enrollment percentage.
+   *
+   * This is the non-quiz portion of what stopItem does after it closes a watch
+   * session, reused by the orphan recovery job. It deliberately leaves out
+   * stopItem's quiz rewind, its Guru Setu override and its follow-up invite
+   * trigger: the recovery job only ever handles watch-duration items, and it
+   * must not send a student an invite off the back of a background sweep.
+   */
+  private async advanceProgressAfterItemCompletion(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    courseVersion: ICourseVersion,
+    moduleId: string,
+    sectionId: string,
+    itemId: string,
+    cohortId: string | undefined,
+    session: ClientSession,
+  ): Promise<boolean> {
+    const nextItem = await this.getNextItemInSequence(
+      courseVersion,
+      moduleId,
+      sectionId,
+      itemId,
+    );
+
+    const newProgress: Partial<IProgress> = nextItem
+      ? {
+        completed: false,
+        currentModule: nextItem.moduleId,
+        currentSection: nextItem.sectionId,
+        currentItem: nextItem.itemId,
+        ...(cohortId ? {cohortId: new ObjectId(cohortId)} : {}),
+      }
+      : {
+        currentModule: moduleId,
+        currentSection: sectionId,
+        currentItem: itemId,
+        completed: true,
+        completedAt: new Date(),
+        ...(cohortId ? {cohortId: new ObjectId(cohortId)} : {}),
+      };
+
+    const enrollment = await this.resolveEnrollment(
+      userId,
+      courseId,
+      courseVersionId,
+      cohortId,
+    );
+
+    if (!enrollment) {
+      return false;
+    }
+
+    const allCourseItemIds = await this.getAllItemIds(courseVersionId);
+    const allCourseItemIdSet = new Set(
+      allCourseItemIds.map(id => id.toString()),
+    );
+
+    const completedItemsArray = await this.progressRepository.getCompletedItems(
+      userId,
+      courseId,
+      courseVersionId,
+      cohortId,
+    );
+
+    const {percentCompleted, completedCourseItemsCount} =
+      await this.computeCourseProgressPercent(
+        completedItemsArray,
+        allCourseItemIdSet,
+        allCourseItemIdSet.size,
+        courseVersionId,
+        itemId,
+        session,
+      );
+
+    await this.enrollmentRepo.updateProgressPercentById(
+      enrollment._id.toString(),
+      percentCompleted,
+      completedCourseItemsCount,
+      cohortId,
+    );
+
+    const updatedProgress = await this.progressRepository.updateProgress(
+      userId,
+      courseId,
+      courseVersionId,
+      newProgress,
+      cohortId,
+      session,
+    );
+
+    return Boolean(updatedProgress);
+  }
+
+  /**
+   * Reconcile watch sessions that were started but never stopped.
+   *
+   * Completion in ViBe is "a watchTime row with a non-null endTime", and only
+   * the stop API writes that field. When the stop call is lost — connection
+   * dropped as the video ended, tab closed, request timed out — the row stays
+   * open, the item never completes, and linear progression locks the student
+   * out of everything after it with no way forward from the UI.
+   *
+   * This closes such a row at its lastSeenAt heartbeat, but only when the
+   * resulting duration clears isValidWatchTime — the same bar the live stop
+   * path enforces. Someone who opened a video and walked away fails that check
+   * and stays incomplete, so this recovers lost progress without handing out
+   * completions and without weakening linear progression.
+   *
+   * Safe to run concurrently across instances and safe to re-run: closing is
+   * guarded on the row still being open, and the pointer only moves when it is
+   * still parked on the recovered item.
+   */
+  async recoverOrphanedWatchTimes(
+    olderThanMinutes = 30,
+    batchSize = 500,
+  ): Promise<{
+    scanned: number;
+    closed: number;
+    advanced: number;
+    rejected: number;
+    skipped: number;
+  }> {
+    const summary = {scanned: 0, closed: 0, advanced: 0, rejected: 0, skipped: 0};
+
+    const olderThan = new Date(Date.now() - olderThanMinutes * 60 * 1000);
+    const orphans = await this.progressRepository.findOrphanedWatchTimes(
+      olderThan,
+      batchSize,
+    );
+    summary.scanned = orphans.length;
+
+    // Rows judged not recoverable, marked in one write at the end so the next
+    // run does not re-examine them. Records that threw are deliberately left
+    // unmarked, so a transient database error gets another attempt next sweep.
+    const rejectedIds: (string | ObjectId)[] = [];
+
+    // A batch is usually many students spread over a handful of course
+    // versions, so the hidden-item lookup is cached rather than repeated per
+    // record.
+    const hiddenByVersion = new Map<string, Set<string>>();
+
+    for (const orphan of orphans) {
+      const itemId = orphan.itemId.toString();
+      const courseId = orphan.courseId.toString();
+      const courseVersionId = orphan.courseVersionId.toString();
+      const userId = orphan.userId.toString();
+      const cohortId = orphan.cohortId?.toString();
+
+      try {
+        // Without a heartbeat there is no evidence of time spent, so there is
+        // nothing to justify a completion.
+        if (!orphan.lastSeenAt) {
+          rejectedIds.push(orphan._id);
+          summary.skipped++;
+          continue;
+        }
+
+        const item = await this.itemRepo.readItemById(itemId);
+
+        // QUIZ and PROJECT completion depends on a submission this job must
+        // not invent; only watch-duration items can be judged from timestamps.
+        if (!item || !WATCH_TIME_RECOVERABLE_ITEMS.has(item.type)) {
+          rejectedIds.push(orphan._id);
+          summary.skipped++;
+          continue;
+        }
+
+        let hiddenItemIds = hiddenByVersion.get(courseVersionId);
+        if (!hiddenItemIds) {
+          const hiddenItems =
+            await this.progressRepository.getHiddenOrDeletedItems(
+              courseVersionId,
+            );
+          hiddenItemIds = new Set(hiddenItems.map(i => i.itemId.toString()));
+          hiddenByVersion.set(courseVersionId, hiddenItemIds);
+        }
+
+        if (hiddenItemIds.has(itemId)) {
+          rejectedIds.push(orphan._id);
+          summary.skipped++;
+          continue;
+        }
+
+        const endTime = new Date(orphan.lastSeenAt);
+
+        if (!this.isValidWatchTime({...orphan, endTime}, item)) {
+          rejectedIds.push(orphan._id);
+          summary.rejected++;
+          continue;
+        }
+
+        // The counters are derived from the return value rather than mutated
+        // inside the callback: _withTransaction retries on transient errors, and
+        // a retried body would otherwise count the same record twice.
+        const outcome = await this._withTransaction(async session => {
+          const closed = await this.progressRepository.closeOrphanedWatchTime(
+            orphan._id,
+            endTime,
+            session,
+          );
+
+          // Another instance got there first; its run owns the advance.
+          if (!closed) {
+            return {closed: false, advanced: false};
+          }
+
+          const progress = await this.progressRepository.findProgress(
+            userId,
+            courseId,
+            courseVersionId,
+            cohortId,
+          );
+
+          // If the pointer has already moved past this item, closing the row
+          // was the whole fix — the student is not stuck on it.
+          if (!progress || progress.currentItem?.toString() !== itemId) {
+            return {closed: true, advanced: false};
+          }
+
+          const courseVersion =
+            await this.courseRepo.readVersion(courseVersionId);
+          if (!courseVersion) {
+            return {closed: true, advanced: false};
+          }
+
+          const advanced = await this.advanceProgressAfterItemCompletion(
+            userId,
+            courseId,
+            courseVersionId,
+            courseVersion,
+            progress.currentModule.toString(),
+            progress.currentSection.toString(),
+            itemId,
+            cohortId,
+            session,
+          );
+
+          return {closed: true, advanced};
+        });
+
+        if (outcome?.closed) summary.closed++;
+        if (outcome?.advanced) summary.advanced++;
+      } catch (err) {
+        // One bad record must not stop the sweep.
+        console.error(
+          `[watchtime-recovery] Failed to recover watchTime ${orphan._id?.toString()} ` +
+            `(user ${userId}, item ${itemId}):`,
+          err,
+        );
+        summary.skipped++;
+      }
+    }
+
+    await this.progressRepository.markRecoveryAttempted(rejectedIds);
+
+    return summary;
   }
 
   /**

--- a/backend/src/modules/users/tests/ProgressService.watchTimeRecovery.test.ts
+++ b/backend/src/modules/users/tests/ProgressService.watchTimeRecovery.test.ts
@@ -1,0 +1,224 @@
+import {describe, it, expect, vi} from 'vitest';
+import {ObjectId} from 'mongodb';
+import {ProgressService} from '#users/services/ProgressService.js';
+
+/**
+ * Unit tests for the orphaned watch-time recovery sweep.
+ *
+ * DI is bypassed the same way ProgressService.leaderboard.test.ts does it: the
+ * prototype is instantiated directly and only the collaborators the method
+ * touches are stubbed. isValidWatchTime is deliberately left real — the whole
+ * point of the job is that it enforces the same watch-duration bar as the live
+ * stop path, so stubbing it would test nothing.
+ */
+
+const USER_ID = new ObjectId().toString();
+const COURSE_ID = new ObjectId().toString();
+const VERSION_ID = new ObjectId().toString();
+const ITEM_ID = new ObjectId().toString();
+const NEXT_ITEM_ID = new ObjectId().toString();
+const MODULE_ID = new ObjectId().toString();
+const SECTION_ID = new ObjectId().toString();
+
+// 10-minute video: minimum required watch time is min(600 * 0.15, 30) = 30s.
+const VIDEO_ITEM = {
+  _id: ITEM_ID,
+  type: 'VIDEO',
+  details: {startTime: '00:00:00', endTime: '00:10:00'},
+};
+
+const START = new Date('2026-08-19T10:00:00Z');
+const secondsAfterStart = (n: number) =>
+  new Date(START.getTime() + n * 1000);
+
+function orphan(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: new ObjectId(),
+    userId: new ObjectId(USER_ID),
+    courseId: new ObjectId(COURSE_ID),
+    courseVersionId: new ObjectId(VERSION_ID),
+    itemId: new ObjectId(ITEM_ID),
+    startTime: START,
+    lastSeenAt: secondsAfterStart(120),
+    ...overrides,
+  };
+}
+
+function makeService(opts: {
+  orphans: any[];
+  item?: any;
+  progress?: any;
+  closeReturns?: (orphanId: any) => any;
+}) {
+  const service: any = Object.create(ProgressService.prototype);
+
+  const calls = {
+    closed: [] as {id: string; endTime: Date}[],
+    markedAttempted: [] as string[],
+    progressUpdates: [] as any[],
+    enrollmentUpdates: [] as any[],
+  };
+
+  service.progressRepository = {
+    findOrphanedWatchTimes: async () => opts.orphans,
+    closeOrphanedWatchTime: async (id: any, endTime: Date) => {
+      const result = opts.closeReturns
+        ? opts.closeReturns(id)
+        : {_id: id, endTime};
+      if (result) calls.closed.push({id: id.toString(), endTime});
+      return result;
+    },
+    markRecoveryAttempted: async (ids: any[]) => {
+      calls.markedAttempted.push(...ids.map(i => i.toString()));
+    },
+    findProgress: async () =>
+      opts.progress === undefined
+        ? {
+            currentModule: MODULE_ID,
+            currentSection: SECTION_ID,
+            currentItem: ITEM_ID,
+          }
+        : opts.progress,
+    getHiddenOrDeletedItems: async () => [],
+    getCompletedItems: async () => [],
+    updateProgress: async (
+      _u: string,
+      _c: string,
+      _v: string,
+      newProgress: any,
+    ) => {
+      calls.progressUpdates.push(newProgress);
+      return newProgress;
+    },
+  };
+
+  service.itemRepo = {
+    readItemById: async () =>
+      opts.item === undefined ? VIDEO_ITEM : opts.item,
+  };
+  service.courseRepo = {
+    readVersion: async () => ({_id: VERSION_ID, modules: []}),
+  };
+  service.enrollmentRepo = {
+    updateProgressPercentById: async (...args: any[]) => {
+      calls.enrollmentUpdates.push(args);
+    },
+  };
+
+  // Collaborators of the advance path that have their own coverage elsewhere.
+  service._withTransaction = async (fn: any) => fn({} as any);
+  service.resolveEnrollment = async () => ({_id: new ObjectId()});
+  service.getAllItemIds = async () => [ITEM_ID, NEXT_ITEM_ID];
+  service.getNextItemInSequence = async () => ({
+    moduleId: MODULE_ID,
+    sectionId: SECTION_ID,
+    itemId: NEXT_ITEM_ID,
+    completed: false,
+  });
+
+  return {service: service as ProgressService, calls};
+}
+
+describe('ProgressService.recoverOrphanedWatchTimes', () => {
+  it('closes a genuinely watched session and advances the stuck pointer', async () => {
+    const record = orphan();
+    const {service, calls} = makeService({orphans: [record]});
+
+    const summary = await service.recoverOrphanedWatchTimes();
+
+    expect(summary).toMatchObject({
+      scanned: 1,
+      closed: 1,
+      advanced: 1,
+      rejected: 0,
+    });
+    // Closed at the heartbeat, not at "now" — the student stopped watching then.
+    expect(calls.closed[0].endTime).toEqual(record.lastSeenAt);
+    expect(calls.progressUpdates[0]).toMatchObject({
+      completed: false,
+      currentItem: NEXT_ITEM_ID,
+    });
+  });
+
+  it('leaves a session that fails the watch-duration bar incomplete', async () => {
+    // 5 seconds watched of a 10-minute video: nowhere near the 30s minimum.
+    const record = orphan({lastSeenAt: secondsAfterStart(5)});
+    const {service, calls} = makeService({orphans: [record]});
+
+    const summary = await service.recoverOrphanedWatchTimes();
+
+    expect(summary).toMatchObject({scanned: 1, closed: 0, advanced: 0, rejected: 1});
+    expect(calls.closed).toHaveLength(0);
+    expect(calls.progressUpdates).toHaveLength(0);
+    // Marked so the next sweep does not re-examine a record that can never pass.
+    expect(calls.markedAttempted).toEqual([record._id.toString()]);
+  });
+
+  it('skips a session with no heartbeat, since nothing evidences time spent', async () => {
+    const record = orphan({lastSeenAt: undefined});
+    const {service, calls} = makeService({orphans: [record]});
+
+    const summary = await service.recoverOrphanedWatchTimes();
+
+    expect(summary).toMatchObject({scanned: 1, closed: 0, skipped: 1});
+    expect(calls.closed).toHaveLength(0);
+    expect(calls.markedAttempted).toEqual([record._id.toString()]);
+  });
+
+  it('never fabricates completion for submission-based items', async () => {
+    const {service, calls} = makeService({
+      orphans: [orphan()],
+      item: {_id: ITEM_ID, type: 'QUIZ', details: {}},
+    });
+
+    const summary = await service.recoverOrphanedWatchTimes();
+
+    expect(summary).toMatchObject({scanned: 1, closed: 0, advanced: 0, skipped: 1});
+    expect(calls.progressUpdates).toHaveLength(0);
+  });
+
+  it('closes the record but leaves the pointer alone when it has already moved on', async () => {
+    const {service, calls} = makeService({
+      orphans: [orphan()],
+      progress: {
+        currentModule: MODULE_ID,
+        currentSection: SECTION_ID,
+        currentItem: NEXT_ITEM_ID,
+      },
+    });
+
+    const summary = await service.recoverOrphanedWatchTimes();
+
+    expect(summary).toMatchObject({scanned: 1, closed: 1, advanced: 0});
+    expect(calls.progressUpdates).toHaveLength(0);
+  });
+
+  it('does not advance twice when another instance closed the record first', async () => {
+    const {service, calls} = makeService({
+      orphans: [orphan()],
+      closeReturns: () => null,
+    });
+
+    const summary = await service.recoverOrphanedWatchTimes();
+
+    expect(summary).toMatchObject({scanned: 1, closed: 0, advanced: 0});
+    expect(calls.progressUpdates).toHaveLength(0);
+  });
+
+  it('keeps sweeping after one record throws', async () => {
+    const bad = orphan();
+    const good = orphan();
+    const {service, calls} = makeService({orphans: [bad, good]});
+    const readItemById = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('item lookup blew up'))
+      .mockResolvedValue(VIDEO_ITEM);
+    (service as any).itemRepo = {readItemById};
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const summary = await service.recoverOrphanedWatchTimes();
+
+    expect(summary).toMatchObject({scanned: 2, closed: 1, advanced: 1, skipped: 1});
+    expect(calls.closed[0].id).toBe(good._id.toString());
+  });
+});

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -91,6 +91,23 @@ class ProgressRepository {
     }
 
     try {
+      // The orphan recovery job sweeps open watch sessions by age. A partial
+      // index keeps this to just the rows that are still open, so it stays
+      // small however large the collection grows.
+      await this.watchTimeCollection.createIndex(
+        {
+          startTime: 1,
+        },
+        {
+          background: true,
+          partialFilterExpression: { endTime: { $exists: false } },
+        },
+      );
+    } catch (e) {
+      // Index already exists
+    }
+
+    try {
       await this.attemptCollection.createIndex(
         {
           userId: 1,
@@ -636,6 +653,71 @@ class ProgressRepository {
       { returnDocument: 'after', session },
     );
     return result;
+  }
+
+  /**
+   * Watch sessions that were started but never stopped.
+   *
+   * Completion is modelled as "a watchTime row with a non-null endTime", so a
+   * row left open by a lost stop call keeps its item incomplete forever and
+   * blocks linear progression. These are the candidates the recovery job
+   * judges. Rows it has already rejected carry recoveryAttemptedAt and are
+   * excluded, so a session that will never qualify is examined once, not on
+   * every run.
+   */
+  async findOrphanedWatchTimes(
+    olderThan: Date,
+    limit: number,
+  ): Promise<IWatchTime[]> {
+    await this.init();
+    return this.watchTimeCollection
+      .find({
+        endTime: { $exists: false },
+        recoveryAttemptedAt: { $exists: false },
+        isDeleted: { $ne: true },
+        startTime: { $lt: olderThan },
+      })
+      .sort({ startTime: 1 })
+      .limit(limit)
+      .toArray();
+  }
+
+  /**
+   * Close an orphaned session at a specific time.
+   *
+   * Distinct from stopItemTracking, which stamps "now" and is the live stop
+   * path. The endTime guard in the filter makes this safe to run concurrently:
+   * if another instance closed the row first, this returns null rather than
+   * overwriting a legitimate endTime.
+   */
+  async closeOrphanedWatchTime(
+    watchTimeId: string | ObjectId,
+    endTime: Date,
+    session?: ClientSession,
+  ): Promise<IWatchTime | null> {
+    await this.init();
+    return this.watchTimeCollection.findOneAndUpdate(
+      {
+        _id: new ObjectId(watchTimeId),
+        endTime: { $exists: false },
+        isDeleted: { $ne: true },
+      },
+      { $set: { endTime, recoveryAttemptedAt: new Date() } },
+      { returnDocument: 'after', session },
+    );
+  }
+
+  async markRecoveryAttempted(
+    watchTimeIds: (string | ObjectId)[],
+    session?: ClientSession,
+  ): Promise<void> {
+    await this.init();
+    if (!watchTimeIds.length) return;
+    await this.watchTimeCollection.updateMany(
+      { _id: { $in: watchTimeIds.map(id => new ObjectId(id)) } },
+      { $set: { recoveryAttemptedAt: new Date() } },
+      { session },
+    );
   }
 
   async updateLastSeen(

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -545,6 +545,12 @@ export interface IWatchTime {
   endTime?: Date;
   lastSeenAt?: Date;
   cohortId?: ID;
+  // Written by addBulkWatchTime for records the system fabricated rather than
+  // measured, so they can be told apart from genuine watch sessions.
+  isBulk?: boolean;
+  // Set by the orphan recovery job once it has judged an abandoned session, so
+  // a record that fails the watch-duration bar is not re-examined every run.
+  recoveryAttemptedAt?: Date;
 }
 
 export interface ICohort {


### PR DESCRIPTION
An item counts as complete only when its watchTime row has a non-null endTime, and only
the stop API ever writes that field. When the stop call is lost — network drops as the
video ends, tab closed, request times out — the row stays open, the item never completes,
and linear progression locks the student out of everything after it. Nothing in the
backend repaired such a row, so the only remedy was a manual database edit per student.
60+ students are currently affected in the SASTRA deployment.

This adds a sweep that runs every 30 minutes over sessions untouched for at least 30
minutes, closes them at their `lastSeenAt` heartbeat, and advances the progress pointer
when it is still parked on the recovered item.

It does not hand out completions. A candidate must clear the existing `isValidWatchTime`
check — the same watch-duration bar the live stop path enforces — so someone who opened a
video and walked away correctly stays incomplete. QUIZ and PROJECT records are skipped
entirely, since their completion depends on a submission a background sweep must not
invent. Linear progression, rewatch and rollback behaviour are unchanged.

Safe to re-run and to run concurrently across Cloud Run instances: the close is guarded on
the row still being open, and the pointer only moves while it still points at the
recovered item. Rejected records are stamped with `recoveryAttemptedAt` so they are judged
once rather than every sweep, and a partial index keeps the scan to rows that are still
open.

Gated behind `ENABLE_WATCHTIME_RECOVERY_JOB`, defaulting **off** — unlike the neighbouring
jobs — because it mutates student progress and should be enabled per environment after a
dry run.

Also extracts the completion-percentage calculation out of `stopItem` so the recovered path
and the live path compute progress identically.

Verified with a new unit spec (`ProgressService.watchTimeRecovery.test.ts`, 7 cases)
covering the happy path, the duration-gate rejection, missing heartbeat, submission-based
items, a pointer that has already moved, a concurrent close, and error isolation.
`tsc --noEmit` is clean and the users module suite passes.

Fixes #1289
