### PR TITLE
fix(courses): make the nightly progress recompute cron actually run on schedule

### DIFF
--- a/backend/src/modules/courses/services/deleteCronService.ts
+++ b/backend/src/modules/courses/services/deleteCronService.ts
@@ -46,53 +46,34 @@ export class DeleteCronService extends BaseService {
     console.log('Delete cron job scheduled for 1:00 AM daily');
   }
 
-  public async scheduleProgressUpdateCron() {
-    // const courseVersionMap = [
-    //   { courseId: "6968e12cbf2860d6e39051ae", versionId: "6968e12cbf2860d6e39051af" },
-    //   {
-    //     courseId: "6970f87e30644cbc74b6714f", versionId:
-    //       "6970f87e30644cbc74b67150"
-    //   },
-
-    // ];
-
+  /**
+   * Nightly reconciliation of enrollment completed-item counts and percentages
+   * across every course version, from watchTime records that already have an
+   * endTime. This does not create or close watchTime rows — it only keeps
+   * enrollment.percentCompleted/completedItemsCount in sync with what the
+   * watchTime collection already shows, correcting drift from any path that
+   * updates progress without going through the normal stop flow.
+   *
+   * Previously this call sat outside the cron.schedule callback below, so it
+   * ran once — un-awaited — on every process boot instead of at 3 AM, and
+   * never ran on the schedule its own log message described. On Cloud Run
+   * that meant a full-database recompute on every cold start.
+   */
+  public scheduleProgressUpdateCron() {
     cron.schedule('0 3 * * *', async () => {
-      console.log(
-        `⏰ Running parallel progress cron for ${/*courseVersionMap.length*/''} course versions`,
-      );
+      console.log('⏰ Running nightly progress recompute cron');
+      try {
+        const response =
+          await this.enrollmentService.bulkUpdateCompletedItemsCountParallelPerCourseVersion();
+        console.log(
+          `🎉 Progress recompute completed — total: ${response.totalCount}, updated: ${response.updatedCount}`,
+        );
+      } catch (err) {
+        console.error('❌ Progress recompute cron failed:', err);
+      }
     });
 
-    // const results = await Promise.allSettled(
-    //   courseVersionMap.map(({ courseId, versionId }) =>
-    //     this.enrollmentService.bulkUpdateCompletedItemsCountParallelPerCourseVersion(
-    //       courseId,
-    //       versionId,
-    //     ),
-    //   ),
-    // );
-    const response = await this.enrollmentService.bulkUpdateCompletedItemsCountParallelPerCourseVersion();
-    // results.forEach((result, index) => {
-    //   const { courseId, versionId } = courseVersionMap[index];
-
-    //   if (result.status === 'fulfilled') {
-    //     console.log(
-    //       `✅ Course ${courseId} | Version ${versionId} completed`,
-    //       `Total count:${result.value.totalCount}`, `Updated count:${result.value.updatedCount}`,
-    //     );
-    //   } else {
-    //     console.error(
-    //       `❌ Course ${courseId} | Version ${versionId} failed`,
-    //       result.reason?.message || result.reason,
-    //     );
-    //   }
-    // });
-
-    console.log(`🎉 Parallel progress cron completed \n
-        Total count : ${response.totalCount} \n
-        Updated count : ${response.updatedCount}`);
-    // });
-
-    // console.log('🗓️ Progress update cron scheduled (hourly, parallel)');
+    console.log('Progress recompute cron scheduled for 3:00 AM daily');
   }
 
 

--- a/backend/src/modules/courses/tests/DeleteCronService.progressCron.test.ts
+++ b/backend/src/modules/courses/tests/DeleteCronService.progressCron.test.ts
@@ -1,0 +1,68 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import cron from 'node-cron';
+import {DeleteCronService} from '#root/modules/courses/services/deleteCronService.js';
+
+/**
+ * Regression test for the bracing bug in scheduleProgressUpdateCron: the
+ * enrollment recompute call previously sat outside the cron.schedule
+ * callback, so it ran once on every call to scheduleProgressUpdateCron()
+ * (i.e. on every process boot) instead of only when the 3 AM schedule fires.
+ *
+ * node-cron is mocked so the schedule callback can be invoked directly,
+ * without waiting on a real cron tick.
+ */
+
+vi.mock('node-cron', () => ({
+  default: {schedule: vi.fn()},
+}));
+
+function makeService(bulkUpdate: any) {
+  const service: any = Object.create(DeleteCronService.prototype);
+  service.enrollmentService = {
+    bulkUpdateCompletedItemsCountParallelPerCourseVersion: bulkUpdate,
+  };
+  return service as DeleteCronService;
+}
+
+describe('DeleteCronService.scheduleProgressUpdateCron', () => {
+  beforeEach(() => {
+    (cron.schedule as any).mockClear();
+  });
+
+  it('does not run the recompute while merely registering the schedule', () => {
+    const bulkUpdate = vi.fn().mockResolvedValue({totalCount: 0, updatedCount: 0});
+    const service = makeService(bulkUpdate);
+
+    service.scheduleProgressUpdateCron();
+
+    expect(cron.schedule).toHaveBeenCalledTimes(1);
+    expect(cron.schedule).toHaveBeenCalledWith('0 3 * * *', expect.any(Function));
+    // The bug this guards against: the recompute used to fire synchronously
+    // here, before the schedule ever ticked.
+    expect(bulkUpdate).not.toHaveBeenCalled();
+  });
+
+  it('runs the recompute only when the scheduled callback fires', async () => {
+    const bulkUpdate = vi.fn().mockResolvedValue({totalCount: 5, updatedCount: 3});
+    const service = makeService(bulkUpdate);
+
+    service.scheduleProgressUpdateCron();
+    const scheduledCallback = (cron.schedule as any).mock.calls[0][1];
+
+    await scheduledCallback();
+
+    expect(bulkUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and swallows a failure so one bad run does not crash the process', async () => {
+    const bulkUpdate = vi.fn().mockRejectedValue(new Error('db unavailable'));
+    const service = makeService(bulkUpdate);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    service.scheduleProgressUpdateCron();
+    const scheduledCallback = (cron.schedule as any).mock.calls[0][1];
+
+    await expect(scheduledCallback()).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
scheduleProgressUpdateCron's cron.schedule('0 3 * * *', ...) callback closed after a
single console.log, and the real work — the enrollment completed-item-count and
percentage recompute — sat outside that callback, in the enclosing function body.

The recompute never ran at 3 AM. It ran once, un-awaited, every time
scheduleProgressUpdateCron() was called from startCron() inside app.listen — i.e. on
every process boot. On Cloud Run that meant a full-database progress recompute, across
every course version, on every cold start, with no error handling around the call site.

Moves the call inside the schedule callback with try/catch and logging, matching the
pattern already used by the newer jobs in bootstrap/jobs/. Also drops the stale
commented-out per-course-version code the function had carried since before it was
switched to iterate the whole database.

This changes nothing about what the recompute does — it only reads watchTime rows that
already have an endTime and never creates or closes any — only when it runs.

Verified with a regression test (DeleteCronService.progressCron.test.ts, 3 cases) that
fails against the pre-fix code and passes after: confirms the recompute doesn't fire
during registration, only fires when the scheduled callback runs, and that a failure is
caught rather than crashing the process. tsc --noEmit is clean; the courses module suite
shows the same pre-existing failures as main (22, unrelated /auth/signup 500s), no new
ones introduced.

Fixes #1291
