### PR TITLE
fix(studentQuestions): collapse status + gate-state into one filter dropdown

### DIFF
--- a/frontend/src/app/pages/teacher/StudentQuestionReview.tsx
+++ b/frontend/src/app/pages/teacher/StudentQuestionReview.tsx
@@ -9,12 +9,11 @@ import {
   useUpdateStudentQuestionContent,
   useUpdateStudentQuestionStatus,
 } from '@/hooks/hooks';
-import {
-  STUDENT_QUESTION_STATUS_LABELS,
-  type StudentQuestionGateStateFilter,
-  type StudentQuestionListItem,
-  type StudentQuestionStatusFilter,
-  type UpdateStudentQuestionPayload,
+import type {
+  StudentQuestionGateStateFilter,
+  StudentQuestionListItem,
+  StudentQuestionStatusFilter,
+  UpdateStudentQuestionPayload,
 } from '@/types/student-question.types';
 import StudentQuestionRow from './components/StudentQuestionRow';
 import StudentQuestionRejectDialog from './components/StudentQuestionRejectDialog';
@@ -22,47 +21,35 @@ import StudentQuestionEditDialog from './components/StudentQuestionEditDialog';
 import SegmentDetailsDialog from './components/SegmentDetailsDialog';
 import CourseBackButton from './CourseBackButton';
 
-// HELD first — it's the one status that actually needs a teacher's call
-// (AI screening was unsure). PENDING is already live/served, not waiting on
-// anyone; the label reflects that rather than the DB status name.
-const STATUS_FILTER_OPTIONS: StudentQuestionStatusFilter[] = [
-  'ALL',
-  'HELD',
-  'PENDING',
-  'APPROVED',
-  'REJECTED',
+/**
+ * One filter dropdown instead of status + gate-state as two separate
+ * controls — gate state only ever means anything for PENDING questions, so
+ * showing it as its own axis was confusing more often than it was useful.
+ * Each option here is a fixed (status, gateState) pair.
+ */
+const COMBINED_FILTER_OPTIONS: {
+  value: string;
+  label: string;
+  status: StudentQuestionStatusFilter;
+  gateState: StudentQuestionGateStateFilter;
+}[] = [
+  {value: 'all', label: 'All', status: 'ALL', gateState: 'ALL'},
+  {value: 'held', label: 'Needs review', status: 'HELD', gateState: 'ALL'},
+  {value: 'pending-eligible', label: 'Live — eligible for review', status: 'PENDING', gateState: 'ELIGIBLE'},
+  {value: 'pending-collecting', label: 'Live — collecting responses', status: 'PENDING', gateState: 'COLLECTING'},
+  {value: 'approved', label: 'Approved', status: 'APPROVED', gateState: 'ALL'},
+  {value: 'rejected', label: 'Rejected', status: 'REJECTED', gateState: 'ALL'},
 ];
-
-const STATUS_FILTER_LABELS: Record<StudentQuestionStatusFilter, string> = {
-  ALL: 'All statuses',
-  ...STUDENT_QUESTION_STATUS_LABELS,
-};
-
-// Peer-validation gate state filter — only meaningful while status is PENDING
-// (or ALL); HELD/APPROVED/REJECTED questions have no gate state.
-const GATE_STATE_FILTER_OPTIONS: StudentQuestionGateStateFilter[] = [
-  'ALL',
-  'ELIGIBLE',
-  'COLLECTING',
-];
-
-const GATE_STATE_FILTER_LABELS: Record<StudentQuestionGateStateFilter, string> = {
-  ALL: 'Any gate state',
-  ELIGIBLE: 'Eligible for review',
-  COLLECTING: 'Collecting',
-};
 
 export default function StudentQuestionReview() {
   const {currentCourse} = useCourseStore();
   const courseId = currentCourse?.courseId;
   const courseVersionId = currentCourse?.versionId;
 
-  // Defaults show everything so the first thing a teacher sees is never a
-  // false "nothing to do here" — PENDING+ELIGIBLE was empty in practice,
-  // since most live questions sit in COLLECTING and HELD wasn't even
-  // reachable as a filter.
-  const [statusFilter, setStatusFilter] = useState<StudentQuestionStatusFilter>('ALL');
-  const [gateStateFilter, setGateStateFilter] = useState<StudentQuestionGateStateFilter>('ALL');
+  // Defaults to "All" so the first thing a teacher sees is never a false
+  // "nothing to do here" — PENDING+ELIGIBLE was empty in practice, since
+  // most live questions sit in COLLECTING and HELD wasn't even reachable.
+  const [combinedFilter, setCombinedFilter] = useState(COMBINED_FILTER_OPTIONS[0]);
   const [items, setItems] = useState<StudentQuestionListItem[]>([]);
   const [hasFetched, setHasFetched] = useState(false);
 
@@ -82,16 +69,16 @@ export default function StudentQuestionReview() {
       const response = await listForCourseVersion(
         courseId,
         courseVersionId,
-        statusFilter,
+        combinedFilter.status,
         100,
-        gateStateFilter,
+        combinedFilter.gateState,
       );
       setItems(response?.items ?? []);
       setHasFetched(true);
     } catch (err: any) {
       toast.error(err?.message || 'Failed to load student questions');
     }
-  }, [courseId, courseVersionId, listForCourseVersion, statusFilter, gateStateFilter]);
+  }, [courseId, courseVersionId, listForCourseVersion, combinedFilter]);
 
   useEffect(() => {
     void fetchQuestions();
@@ -161,31 +148,19 @@ export default function StudentQuestionReview() {
         </div>
         <div className="flex items-center gap-2">
           <Select
-            value={statusFilter}
-            onValueChange={value => setStatusFilter(value as StudentQuestionStatusFilter)}
+            value={combinedFilter.value}
+            onValueChange={value => {
+              const next = COMBINED_FILTER_OPTIONS.find(o => o.value === value);
+              if (next) setCombinedFilter(next);
+            }}
           >
-            <SelectTrigger className="w-[160px]">
-              <SelectValue placeholder="Status" />
+            <SelectTrigger className="w-[220px]">
+              <SelectValue placeholder="Filter" />
             </SelectTrigger>
             <SelectContent>
-              {STATUS_FILTER_OPTIONS.map(option => (
-                <SelectItem key={option} value={option}>
-                  {STATUS_FILTER_LABELS[option]}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select
-            value={gateStateFilter}
-            onValueChange={value => setGateStateFilter(value as StudentQuestionGateStateFilter)}
-          >
-            <SelectTrigger className="w-[160px]">
-              <SelectValue placeholder="Gate state" />
-            </SelectTrigger>
-            <SelectContent>
-              {GATE_STATE_FILTER_OPTIONS.map(option => (
-                <SelectItem key={option} value={option}>
-                  {GATE_STATE_FILTER_LABELS[option]}
+              {COMBINED_FILTER_OPTIONS.map(option => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
                 </SelectItem>
               ))}
             </SelectContent>


### PR DESCRIPTION
Follow-up to #1309. **Depends on #1309 and #1307** (neither merged yet) —
this branch is built on top of #1309's. Until both merge, this PR's diff
will show all three PRs' commits combined; merge order: #1307 → #1309 →
this one.

Two separate filter columns were confusing since gate state only ever
means anything for PENDING questions — for HELD/APPROVED/REJECTED it did
nothing (the control just sat there, inert). Replaced both with one
dropdown of fixed (status, gateState) pairs: All, Needs review, Live —
eligible for review, Live — collecting responses, Approved, Rejected.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Manual: confirm each of the six combined filter options returns the
      expected question set