### PR TITLE
fix(student): sidebar false-locks completed items when currentItemInd…

### DIFF
--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1754,6 +1754,12 @@ const handleGoToNextItem = async () => {
     const itemIndex = sectionItemsList.findIndex((i: any) => i._id === itemId);
   const currentItemIndex = sectionItemsList.findIndex((i: any) => i._id === currentItemId);
 
+  // currentItemId not found in this section's (possibly not-yet-loaded) item
+  // list — every real itemIndex (>= 0) would otherwise fail the "next item"
+  // check below and fall through to locked, mass-locking the whole section
+  // even for already-completed items. Unknown position must not imply locked.
+  if (currentItemIndex === -1) return false;
+
   // Only unlock next item if it's a QUIZ paired with current VIDEO
   if (itemIndex === currentItemIndex + 1) {
     const currentItemInList = sectionItemsList[currentItemIndex] as any;


### PR DESCRIPTION
## What

Fixes a sidebar bug: a student's course sidebar shows already-completed items as locked, even though their backend progress is correct. Confirmed not a caching issue — persists after a hard refresh.

## Root cause

`isItemLocked()` in `course-page.tsx` computes `currentItemIndex` by searching for the student's current-item id inside `sectionItemsList`:

```ts
const currentItemIndex = sectionItemsList.findIndex((i) => i._id === currentItemId);
```

When that lookup misses — e.g. the section's items haven't loaded into this list yet, or the item was moved/deleted — `currentItemIndex` resolves to `-1`. Every real item index (`>= 0`) then fails the "is this the very next item" check (`itemIndex === currentItemIndex + 1`) and falls through to the locked branch (`itemIndex > currentItemIndex + 1`), which mass-locks almost the entire section regardless of the student's actual completion state.

`sectionItemsList` and the current-item id are both live-fetched from the backend on load (no localStorage/browser cache involved), which is why a hard refresh doesn't fix it.

## Fix

Treat an unresolved index as "unknown, don't lock" instead of "before index 0, lock everything":

```ts
if (currentItemIndex === -1) return false;
```

Placed immediately after `currentItemIndex` is computed, before any comparison depends on it.

## Testing

- Verified via hot-reload against a live dev instance — no build/type errors introduced.
- Change is a single early-return, scoped to exactly the one function; no other logic paths touched.
