### PR TITLE
fix(progress): batch Guru Setu progress recalc so item create/delete stops timing out

### DIFF
--- a/backend/src/modules/quizzes/repositories/providers/mongodb/FeedbackRepository.ts
+++ b/backend/src/modules/quizzes/repositories/providers/mongodb/FeedbackRepository.ts
@@ -12,6 +12,7 @@ import {InternalServerError} from 'routing-controllers';
 class FeedbackRepository {
   private feedbackSubmissionCollection: Collection<FeedbackSubmissionItem>;
   private feedbackFormCollection: Collection<FeedBackFormItem>;
+  private initialized = false;
 
   constructor(
     @inject(GLOBAL_TYPES.Database)
@@ -26,6 +27,21 @@ class FeedbackRepository {
 
     this.feedbackFormCollection =
       await this.db.getCollection<FeedBackFormItem>('feedback_forms');
+
+    if (this.initialized) return;
+    this.initialized = true;
+
+    // feedback_submission had no indexes at all, so every lookup by user or
+    // version was a full collection scan. Progress recalculation reads this
+    // collection once per item create/delete on the Guru Setu course.
+    try {
+      await this.feedbackSubmissionCollection.createIndex(
+        {courseVersionId: 1, userId: 1},
+        {background: true},
+      );
+    } catch (e) {
+      // Index already exists
+    }
   }
 
   /* ------------------------------------------------------
@@ -86,6 +102,21 @@ class FeedbackRepository {
       },
       {session},
     ).toArray();
+  }
+
+  /**
+   * All submissions in a course version, across every user. Used by bulk
+   * progress recalculation so it can fetch once instead of once per
+   * enrollment.
+   */
+  async getAllByVersionId(
+    versionId: string,
+    session?: ClientSession,
+  ): Promise<FeedbackSubmissionItem[]> {
+    await this.init();
+    return await this.feedbackSubmissionCollection
+      .find({courseVersionId: new ObjectId(versionId)}, {session})
+      .toArray();
   }
 
   async createFeedback(

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -127,34 +127,62 @@ class ProgressService extends BaseService {
     super(database);
   }
 
+  private isGuruSetu(courseId: string, versionId: string): boolean {
+    return (
+      courseId?.toString() === GURU_SETU_COURSE_ID &&
+      versionId?.toString() === GURU_SETU_VERSION_ID
+    );
+  }
+
+  /**
+   * Guru Setu progress is "feedback forms submitted / feedback forms in the
+   * version". Given the version's feedback form ids and the ids this user has
+   * submitted, derive the numbers in memory. Both the per-user and the bulk
+   * path funnel through here so there is a single formula.
+   */
+  private guruSetuProgressFrom(
+    feedbackFormIds: string[],
+    submittedFormIds: Set<string>,
+  ): { percentCompleted: number; completedItemsCount: number } {
+    const totalFeedbackItems = feedbackFormIds.length;
+
+    if (totalFeedbackItems === 0) {
+      return { percentCompleted: 0, completedItemsCount: 0 };
+    }
+
+    const completedCount = feedbackFormIds.filter(id =>
+      submittedFormIds.has(id),
+    ).length;
+
+    const percentCompleted = parseFloat(
+      ((completedCount / totalFeedbackItems) * 100).toFixed(2),
+    );
+
+    return {
+      percentCompleted,
+      completedItemsCount: completedCount,
+    };
+  }
+
   public async calculateGuruSetuProgress(
     userId: string,
     courseVersionId: string,
   ): Promise<{ percentCompleted: number; completedItemsCount: number }> {
     const feedbackItems = await this.itemRepo.getFeedbackItems(courseVersionId);
-    const totalFeedbackItems = feedbackItems.length;
 
-    if (totalFeedbackItems === 0) return { percentCompleted: 0, completedItemsCount: 0 };
+    if (feedbackItems.length === 0) {
+      return { percentCompleted: 0, completedItemsCount: 0 };
+    }
 
     const feedbackSubmissions = await this.feedbackRepository.getAllByUserAndVersionId(
       userId,
       courseVersionId,
     );
 
-    const submittedItemIds = new Set(
-      feedbackSubmissions.map(s => s.feedbackFormId.toString())
+    return this.guruSetuProgressFrom(
+      feedbackItems.map(item => item._id.toString()),
+      new Set(feedbackSubmissions.map(s => s.feedbackFormId.toString())),
     );
-
-    const completedCount = feedbackItems.filter(item =>
-      submittedItemIds.has(item._id.toString())
-    ).length;
-
-    const percentCompleted = parseFloat(((completedCount / totalFeedbackItems) * 100).toFixed(2));
-
-    return {
-      percentCompleted,
-      completedItemsCount: completedCount,
-    };
   }
 
   /**
@@ -563,52 +591,73 @@ class ProgressService extends BaseService {
     totalItems: number,
     session?: ClientSession,
   ) {
-    // resolve all async operations first
-    const bulkOps = await Promise.all(
-      enrollments.map(async enrollment => {
-        const userId = enrollment.userId?.toString();
+    if (enrollments.length === 0) return null;
 
-        // const completedItems = await this.getUserProgressPercentageWithoutTotal(
-        //   userId,
-        //   courseId,
-        //   versionId,
-        // );
+    // Guru Setu override: progress there is feedback-based rather than
+    // item-count based. Fetch the version's feedback forms and every
+    // submission ONCE, then derive each user's percentage in memory.
+    //
+    // This used to call calculateGuruSetuProgress per enrollment inside a
+    // Promise.all. That re-ran a whole-version traversal (one query per
+    // section, one per feedback form) for every enrolled user even though the
+    // result is identical for all of them, so adding or deleting an item on
+    // the FDP course outlived the request timeout.
+    let guruSetuFormIds: string[] | null = null;
+    let guruSetuSubmissionsByUser: Map<string, Set<string>> | null = null;
 
-        const completedItems = enrollment.completedItemsCount;
+    if (this.isGuruSetu(courseId, versionId)) {
+      const [feedbackItems, submissions] = await Promise.all([
+        this.itemRepo.getFeedbackItems(versionId, session),
+        this.feedbackRepository.getAllByVersionId(versionId, session),
+      ]);
 
-        let percentCompleted = this._calculateProgress(
-          totalItems,
-          completedItems,
-        );
+      guruSetuFormIds = feedbackItems.map(item => item._id.toString());
+      guruSetuSubmissionsByUser = new Map();
 
-        // Guru Setu Override
-        if (courseId?.toString() === GURU_SETU_COURSE_ID && versionId?.toString() === GURU_SETU_VERSION_ID) {
-          const guruProgress = await this.calculateGuruSetuProgress(userId, versionId);
-          percentCompleted = guruProgress.percentCompleted;
+      for (const submission of submissions) {
+        const submissionUserId = submission.userId.toString();
+        let submitted = guruSetuSubmissionsByUser.get(submissionUserId);
+        if (!submitted) {
+          submitted = new Set();
+          guruSetuSubmissionsByUser.set(submissionUserId, submitted);
         }
+        submitted.add(submission.feedbackFormId.toString());
+      }
+    }
 
-        return {
-          updateOne: {
-            filter: {
-              userId: new ObjectId(userId),
-              courseId: new ObjectId(courseId),
-              courseVersionId: new ObjectId(versionId),
-            },
-            update: {
-              $set: {
-                percentCompleted,
-                updatedAt: new Date(),
-              },
+    const bulkOps = enrollments.map(enrollment => {
+      const userId = enrollment.userId?.toString();
+
+      let percentCompleted = this._calculateProgress(
+        totalItems,
+        enrollment.completedItemsCount,
+      );
+
+      if (guruSetuFormIds) {
+        percentCompleted = this.guruSetuProgressFrom(
+          guruSetuFormIds,
+          guruSetuSubmissionsByUser.get(userId) ?? new Set<string>(),
+        ).percentCompleted;
+      }
+
+      return {
+        updateOne: {
+          filter: {
+            userId: new ObjectId(userId),
+            courseId: new ObjectId(courseId),
+            courseVersionId: new ObjectId(versionId),
+          },
+          update: {
+            $set: {
+              percentCompleted,
+              updatedAt: new Date(),
             },
           },
-        };
-      }),
-    );
+        },
+      };
+    });
 
-    if (bulkOps.length > 0) {
-      return this.enrollmentRepo.bulkUpdateEnrollments(bulkOps, session);
-    }
-    return null;
+    return this.enrollmentRepo.bulkUpdateEnrollments(bulkOps, session);
   }
 
   // Helper to calculate progress based on completed items

--- a/backend/src/modules/users/tests/ProgressService.guruSetuBulkProgress.test.ts
+++ b/backend/src/modules/users/tests/ProgressService.guruSetuBulkProgress.test.ts
@@ -1,0 +1,165 @@
+import {describe, it, expect, vi} from 'vitest';
+import {ObjectId} from 'mongodb';
+import {ProgressService} from '#users/services/ProgressService.js';
+
+/**
+ * Regression test for the Guru Setu branch of
+ * updateEnrollmentProgressPercentBulk.
+ *
+ * Creating or deleting an item recomputes progress for every enrollment in
+ * the course version. For Guru Setu that used to re-run the full feedback
+ * calculation (a version-wide scan plus a submissions query) once per
+ * enrollment, concurrently — with a large FDP cohort the request outlived the
+ * proxy timeout and the browser reported a CORS error. The bulk path must now
+ * hit the repositories a constant number of times regardless of cohort size.
+ */
+
+const GURU_SETU_COURSE_ID = '6981df886e100cfe04f9c4ad';
+const GURU_SETU_VERSION_ID = '6981df886e100cfe04f9c4ae';
+
+const FORM_A = new ObjectId();
+const FORM_B = new ObjectId();
+
+function makeService(enrollmentCount: number) {
+  const service: any = Object.create(ProgressService.prototype);
+
+  const userIds = Array.from({length: enrollmentCount}, () => new ObjectId());
+
+  const getFeedbackItems = vi.fn().mockResolvedValue([
+    {_id: FORM_A},
+    {_id: FORM_B},
+  ]);
+  const getAllByVersionId = vi.fn().mockResolvedValue([
+    // user 0 submitted both forms, user 1 submitted one, the rest none
+    {userId: userIds[0], feedbackFormId: FORM_A},
+    {userId: userIds[0], feedbackFormId: FORM_B},
+    {userId: userIds[1], feedbackFormId: FORM_A},
+  ]);
+  const getAllByUserAndVersionId = vi.fn().mockResolvedValue([]);
+  const bulkUpdateEnrollments = vi.fn().mockResolvedValue({ok: 1});
+
+  service.itemRepo = {getFeedbackItems};
+  service.feedbackRepository = {getAllByVersionId, getAllByUserAndVersionId};
+  service.enrollmentRepo = {bulkUpdateEnrollments};
+
+  const enrollments = userIds.map(userId => ({
+    userId,
+    completedItemsCount: 0,
+  }));
+
+  return {
+    service,
+    enrollments,
+    userIds,
+    getFeedbackItems,
+    getAllByVersionId,
+    getAllByUserAndVersionId,
+    bulkUpdateEnrollments,
+  };
+}
+
+describe('ProgressService.updateEnrollmentProgressPercentBulk (Guru Setu)', () => {
+  it('queries feedback items and submissions once, not once per enrollment', async () => {
+    const {
+      service,
+      enrollments,
+      getFeedbackItems,
+      getAllByVersionId,
+      getAllByUserAndVersionId,
+    } = makeService(500);
+
+    await service.updateEnrollmentProgressPercentBulk(
+      enrollments,
+      GURU_SETU_COURSE_ID,
+      GURU_SETU_VERSION_ID,
+      10,
+    );
+
+    expect(getFeedbackItems).toHaveBeenCalledTimes(1);
+    expect(getAllByVersionId).toHaveBeenCalledTimes(1);
+    expect(getAllByUserAndVersionId).not.toHaveBeenCalled();
+  });
+
+  it('derives each enrollment percentage from the batched submissions', async () => {
+    const {service, enrollments, userIds, bulkUpdateEnrollments} =
+      makeService(3);
+
+    await service.updateEnrollmentProgressPercentBulk(
+      enrollments,
+      GURU_SETU_COURSE_ID,
+      GURU_SETU_VERSION_ID,
+      10,
+    );
+
+    const ops = bulkUpdateEnrollments.mock.calls[0][0];
+    const percentFor = (userId: ObjectId) =>
+      ops.find((op: any) => op.updateOne.filter.userId.equals(userId))
+        .updateOne.update.$set.percentCompleted;
+
+    expect(percentFor(userIds[0])).toBe(100);
+    expect(percentFor(userIds[1])).toBe(50);
+    expect(percentFor(userIds[2])).toBe(0);
+  });
+
+  it('matches calculateGuruSetuProgress for the same user (parity)', async () => {
+    const {service, enrollments, userIds, bulkUpdateEnrollments} =
+      makeService(3);
+
+    // the per-user path reads the same two forms, and this user's submissions
+    service.feedbackRepository.getAllByUserAndVersionId = vi
+      .fn()
+      .mockResolvedValue([{userId: userIds[1], feedbackFormId: FORM_A}]);
+
+    const perUser = await service.calculateGuruSetuProgress(
+      userIds[1].toString(),
+      GURU_SETU_VERSION_ID,
+    );
+
+    await service.updateEnrollmentProgressPercentBulk(
+      enrollments,
+      GURU_SETU_COURSE_ID,
+      GURU_SETU_VERSION_ID,
+      10,
+    );
+
+    const ops = bulkUpdateEnrollments.mock.calls[0][0];
+    const batched = ops.find((op: any) =>
+      op.updateOne.filter.userId.equals(userIds[1]),
+    ).updateOne.update.$set.percentCompleted;
+
+    expect(batched).toBe(perUser.percentCompleted);
+  });
+
+  it('returns null without writing when there are no enrollments', async () => {
+    const {service, bulkUpdateEnrollments, getFeedbackItems} = makeService(0);
+
+    const result = await service.updateEnrollmentProgressPercentBulk(
+      [],
+      GURU_SETU_COURSE_ID,
+      GURU_SETU_VERSION_ID,
+      10,
+    );
+
+    expect(result).toBeNull();
+    expect(bulkUpdateEnrollments).not.toHaveBeenCalled();
+    expect(getFeedbackItems).not.toHaveBeenCalled();
+  });
+
+  it('leaves non-Guru-Setu courses on the item-count formula', async () => {
+    const {service, enrollments, getFeedbackItems, getAllByVersionId, bulkUpdateEnrollments} =
+      makeService(2);
+    enrollments[0].completedItemsCount = 5;
+
+    await service.updateEnrollmentProgressPercentBulk(
+      enrollments,
+      new ObjectId().toString(),
+      new ObjectId().toString(),
+      10,
+    );
+
+    expect(getFeedbackItems).not.toHaveBeenCalled();
+    expect(getAllByVersionId).not.toHaveBeenCalled();
+    const ops = bulkUpdateEnrollments.mock.calls[0][0];
+    expect(ops[0].updateOne.update.$set.percentCompleted).toBe(50);
+  });
+});


### PR DESCRIPTION
Adding or deleting an item on the Guru Setu (FDP for Faculty) course failed with "Failed to create item". The POST showed in DevTools as a CORS error with an empty body — which is what a request dropped at Cloud Run's 300s timeout looks like in the browser, not an actual CORS fault.

updateEnrollmentProgressPercentBulk has a Guru Setu override that called calculateGuruSetuProgress once per enrollment inside a Promise.all. Each call re-ran a whole-version traversal (one query per section, one per feedback form) even though that result depends only on the version and is identical for every user, plus an unindexed per-user submissions scan. With a large faculty cohort that is E x (S + F + 2) round-trips fired concurrently while the create-item transaction is held open. deleteItem used the same path.

This fetches the version's feedback forms and every submission for the version once, groups submissions by user, and derives each percentage in memory: two reads and one bulk write regardless of cohort size, with identical results. The reads now also join the caller's session rather than running outside the transaction. Adds the missing {courseVersionId, userId} index on feedback_submission, which had no indexes at all, and folds the per-user and bulk paths onto one shared formula.

Note: commit 0bd7940d6 on fix/gurusetu-progress-cron-bg-v2 diagnosed this in May but was never merged. That branch's approach (defer to the nightly cron) would not work today — scheduleProgressUpdateCron() is never called by production code, and the cron's own Guru Setu path is the same N+1.

Verified: tsc clean; new spec covers call-count (one fetch each for a 500-enrollment cohort), per-user percentages, parity with calculateGuruSetuProgress, the empty-enrollment case, and that non-Guru-Setu courses never touch the feedback repos. The 5 failures in EnrollementController/ProgressController/stopItemEnrollment are pre-existing and reproduce on clean main. Lint could not be run locally: backend/package.json has no lint script and eslint cannot load eslint-plugin-require-extensions.

Follow-ups, not in this PR:
- EnrollmentService.bulkUpdateGuruSetuProgress and the per-cohort loops near lines 1045/1369/1867 are the same N+1.
- DeleteCronService.scheduleProgressUpdateCron() is bound in the container but never called in production.
- CI's lint step runs `pnpm run lint` in backend/, but that script does not exist.

Fixes #1321
