### PR TITLE
fix(progress): resolve article stop race condition and sidebar false-lock

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -2457,17 +2457,9 @@ class ProgressService extends BaseService {
           );
 
           if (!stoppedWatchTime) {
-            /**
-             * If your repository currently returns null when already stopped,
-             * this hard failure creates retry bugs.
-             *
-             * Recommended:
-             * either make stopItemTracking idempotent in repo,
-             * or treat "already stopped" as safe.
-             *
-             * For now, keeping compatibility:
-             */
-            throw new NotFoundError('Watch time record not found');
+            // Record was already closed by a concurrent request (endTime already
+            // set). Treat as idempotent success — progress has already advanced.
+            return;
           }
 
           await this.validateItemStopEligibility(

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -686,6 +686,7 @@ class ProgressRepository {
       {
         _id: new ObjectId(watchTimeId),
         isDeleted: { $ne: true },
+        endTime: { $exists: false },
       },
       { $set: { endTime: new Date() } },
       { returnDocument: 'after', session },

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1754,6 +1754,10 @@ const handleGoToNextItem = async () => {
     const itemIndex = sectionItemsList.findIndex((i: any) => i._id === itemId);
   const currentItemIndex = sectionItemsList.findIndex((i: any) => i._id === currentItemId);
 
+  // If the current item isn't in this section's loaded list (stale/incomplete
+  // data), position comparison is meaningless — don't over-lock.
+  if (currentItemIndex === -1) return false;
+
   // Only unlock next item if it's a QUIZ paired with current VIDEO
   if (itemIndex === currentItemIndex + 1) {
     const currentItemInList = sectionItemsList[currentItemIndex] as any;

--- a/frontend/src/components/article.tsx
+++ b/frontend/src/components/article.tsx
@@ -83,6 +83,7 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
     // ✅ Track if item has been started and if start request has been sent
     const itemStartedRef = useRef(false);
     const startRequestSentRef = useRef(false);
+    const stopInFlightRef = useRef(false);
 
     function handleSendStartItem() {
         if (!currentCourse?.itemId || startRequestSentRef.current) return;
@@ -108,7 +109,9 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
 
    async function handleStopItem() {
         if (!currentCourse?.itemId || !currentCourse.watchItemId || !itemStartedRef.current) return;
-        
+        if (stopInFlightRef.current) return;
+
+        stopInFlightRef.current = true;
         try {
             if(!isAlreadyWatched && (currentCourse!.itemId && !completedItemIdsRef.current.has(currentCourse!.itemId))){
                 await stopItem.mutateAsync({
@@ -128,12 +131,13 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
                 });
                 completedItemIdsRef.current.add(currentCourse!.itemId);
             }
-            
+
             itemStartedRef.current = false;
         } catch (error: any) {
             console.error('❌ handleStopItem error:', error);
-            // Re-throw the error so it can be caught by the parent
             throw error;
+        } finally {
+            stopInFlightRef.current = false;
         }
     }
 
@@ -236,12 +240,12 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
         return () => {
             // Defense in depth: if this document was opened but is being left by a
             // path that didn't explicitly stop it (e.g. browser back / tab change),
-            // record its completion so it still gets ticked. No-op if already stopped
-            // (itemStartedRef is cleared by handleStopItem), so this never double-fires.
-            if (itemStartedRef.current) {
+            // record its completion so it still gets ticked. Skipped if a stop is
+            // already in flight (e.g. user clicked Next — handleNextClick awaited
+            // handleStopItem but the component unmounted before the Promise resolved).
+            if (itemStartedRef.current && !stopInFlightRef.current) {
                 void handleStopItemRef.current?.();
             }
-            // Reset refs on unmount
             itemStartedRef.current = false;
             startRequestSentRef.current = false;
         };


### PR DESCRIPTION
﻿We had two separate bugs reported this week, both blocking students from progressing normally through courses.

The first was affecting 45 students who got permanently stuck on article items. The article component has two code paths that call `/stop` on the watch-time session: the "Next Lesson" button handler, and the unmount cleanup that fires when React tears the component down. Clicking Next triggers both in quick succession — the button handler sends the request and then immediately navigates away, which unmounts the component and fires the cleanup. Under normal latency those two requests race into the same MongoDB transaction. The second one arrives while the first is still in flight, finds the `endTime` already written, and throws — rolling back the transaction. The watch-time record ends up closed but the student's `currentItem` pointer never advances. @JoelJosephPhilip fixed this by adding a `stopInFlightRef` guard to the article component (the video component already had one, it just never got ported over), and adding an `endTime: { $exists: false }` filter to `stopItemTracking` in the repository so a duplicate call returns null instead of conflicting. @tanvishdesai handled what happens when that null comes back up through `ProgressService`, turning what was previously a hard `NotFoundError` throw into a clean return, since the first concurrent call already did the work.

The second bug was about completed items showing as locked in the sidebar even though the student had already finished them. @iamsaisamhithreddy traced it to `isItemLocked()`, which uses `findIndex` to locate the student's `currentItem` inside a section's loaded item list before comparing positions. When that list is stale or still loading, `findIndex` returns -1, and the subsequent comparison `itemIndex > currentItemIndex + 1` evaluates to true for every item in the section, locking all of them. The fix is a single guard before that comparison: if `currentItemIndex` is -1, the position check is meaningless and we already know from the module and section level checks above that the section is behind the student, so we return false.
