### PR TITLE
fix(progress): stop the nightly recompute zeroing out completed items

### DIFF
--- a/backend/src/modules/users/tests/EnrollmentRepository.bulkRecomputeCohort.test.ts
+++ b/backend/src/modules/users/tests/EnrollmentRepository.bulkRecomputeCohort.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { MongoDatabase } from '#shared/database/providers/mongo/MongoDatabase.js';
+import { EnrollmentRepository } from '#shared/database/providers/mongo/repositories/EnrollmentRepository.js';
+
+/**
+ * Repository-level tests for the nightly progress recompute
+ * (bulkUpdateCompletedItemsCountForCourseVersion), which rewrites every
+ * enrollment's completedItemsCount/percentCompleted from watch-time rows.
+ *
+ * The recompute must agree with the live completion path
+ * (ProgressRepository.getCompletedItems): a completion recorded against a
+ * cohort belongs to that cohort's enrollment, and hidden/deleted items are
+ * excluded. Runs against the in-memory Mongo replica set started in
+ * test/globalSetup.ts.
+ */
+describe('EnrollmentRepository.bulkUpdateCompletedItemsCountForCourseVersion', () => {
+  let db: MongoDatabase;
+  let repo: EnrollmentRepository;
+
+  const courseId = new ObjectId();
+  const courseVersionId = new ObjectId();
+  const cohortId = new ObjectId();
+  const otherCohortId = new ObjectId();
+
+  // Four items in the version, so each completion is worth 25%.
+  const itemA = new ObjectId();
+  const itemB = new ObjectId();
+  const itemC = new ObjectId();
+  const itemD = new ObjectId();
+
+  // Enrolled through a cohort, with two items genuinely completed.
+  const cohortLearner = new ObjectId();
+  // No cohort at all (legacy enrollment), with two items completed.
+  const soloLearner = new ObjectId();
+  // In a cohort, but their watch-time rows are still open (no endTime).
+  const unfinishedLearner = new ObjectId();
+
+  const enrollmentIds = {
+    cohortLearner: new ObjectId(),
+    soloLearner: new ObjectId(),
+    unfinishedLearner: new ObjectId(),
+  };
+
+  const watchTime = (
+    userId: ObjectId,
+    itemId: ObjectId,
+    cohort: ObjectId | null,
+    closed = true,
+  ) => ({
+    userId,
+    courseId,
+    courseVersionId,
+    itemId,
+    cohortId: cohort,
+    startTime: new Date('2026-08-22T10:00:00Z'),
+    ...(closed ? { endTime: new Date('2026-08-22T10:10:00Z') } : {}),
+    isDeleted: false,
+  });
+
+  beforeAll(async () => {
+    db = new MongoDatabase(
+      process.env.DB_URL,
+      'enrollment_repo_bulk_recompute_cohort_test',
+    );
+    await db.connect();
+    repo = new EnrollmentRepository(db);
+
+    const courseVersions = await db.getCollection('newCourseVersion');
+    await courseVersions.insertOne({
+      _id: courseVersionId,
+      totalItems: 4,
+    } as any);
+
+    const enrollments = await db.getCollection('enrollment');
+    await enrollments.insertMany([
+      {
+        _id: enrollmentIds.cohortLearner,
+        userId: cohortLearner,
+        courseId,
+        courseVersionId,
+        cohortId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        enrollmentDate: new Date('2026-08-01'),
+        percentCompleted: 0,
+        completedItemsCount: 0,
+        isDeleted: false,
+      },
+      {
+        _id: enrollmentIds.soloLearner,
+        userId: soloLearner,
+        courseId,
+        courseVersionId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        enrollmentDate: new Date('2026-08-01'),
+        percentCompleted: 0,
+        completedItemsCount: 0,
+        isDeleted: false,
+      },
+      {
+        _id: enrollmentIds.unfinishedLearner,
+        userId: unfinishedLearner,
+        courseId,
+        courseVersionId,
+        cohortId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        enrollmentDate: new Date('2026-08-01'),
+        percentCompleted: 0,
+        completedItemsCount: 0,
+        isDeleted: false,
+      },
+    ] as any);
+
+    const watchTimes = await db.getCollection('watchTime');
+    await watchTimes.insertMany([
+      // Genuine cohort-scoped completions.
+      watchTime(cohortLearner, itemA, cohortId),
+      watchTime(cohortLearner, itemB, cohortId),
+      // Same item twice — must be counted once, not twice.
+      watchTime(cohortLearner, itemB, cohortId),
+      // A completion belonging to a different cohort's enrollment: this
+      // learner has no enrollment there, so it must not inflate any count.
+      watchTime(cohortLearner, itemC, otherCohortId),
+
+      // Legacy rows with no cohort at all.
+      watchTime(soloLearner, itemA, null),
+      watchTime(soloLearner, itemD, null),
+
+      // Started but never stopped — not a completion.
+      watchTime(unfinishedLearner, itemA, cohortId, false),
+    ] as any);
+  }, 60000);
+
+  afterAll(async () => {
+    await db.disconnect?.();
+  });
+
+  it('counts cohort-scoped completions instead of zeroing them out', async () => {
+    const result = await repo.bulkUpdateCompletedItemsCountForCourseVersion({
+      courseVersionId: courseVersionId.toString(),
+      courseId: courseId.toString(),
+    });
+
+    expect(result.totalCount).toBe(3);
+
+    const enrollments = await db.getCollection('enrollment');
+    const updated = await enrollments.findOne({
+      _id: enrollmentIds.cohortLearner,
+    } as any);
+
+    // Two distinct items completed within this cohort, out of four.
+    expect(updated?.completedItemsCount).toBe(2);
+    expect(updated?.percentCompleted).toBe(50);
+  });
+
+  it('still counts legacy completions recorded without a cohort', async () => {
+    await repo.bulkUpdateCompletedItemsCountForCourseVersion({
+      courseVersionId: courseVersionId.toString(),
+      courseId: courseId.toString(),
+    });
+
+    const enrollments = await db.getCollection('enrollment');
+    const updated = await enrollments.findOne({
+      _id: enrollmentIds.soloLearner,
+    } as any);
+
+    expect(updated?.completedItemsCount).toBe(2);
+    expect(updated?.percentCompleted).toBe(50);
+  });
+
+  it('does not count watch-time rows that were never closed', async () => {
+    await repo.bulkUpdateCompletedItemsCountForCourseVersion({
+      courseVersionId: courseVersionId.toString(),
+      courseId: courseId.toString(),
+    });
+
+    const enrollments = await db.getCollection('enrollment');
+    const updated = await enrollments.findOne({
+      _id: enrollmentIds.unfinishedLearner,
+    } as any);
+
+    expect(updated?.completedItemsCount).toBe(0);
+    expect(updated?.percentCompleted).toBe(0);
+  });
+});

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -2600,13 +2600,22 @@ export class EnrollmentRepository {
   ): Promise<number> {
     if (enrollments.length === 0) return 0;
 
+    // An enrollment with no cohort and one whose cohort simply wasn't loaded
+    // must not collapse to the same key, and neither may collide with a real
+    // cohort's. Normalising null/undefined to '' matches how the grouping
+    // stage below emits a missing cohortId.
+    const cohortKey = (cohortId: unknown) => cohortId?.toString() ?? '';
+
     const enrollmentMap = new Map<string, any>();
 
     enrollments.forEach(e => {
-      enrollmentMap.set(`${e.userId}_${e.courseId}_${e.courseVersionId}_${e.cohortId}`, {
-        id: e._id,
-        courseVersionId: e.courseVersionId.toString(),
-      });
+      enrollmentMap.set(
+        `${e.userId}_${e.courseId}_${e.courseVersionId}_${cohortKey(e.cohortId)}`,
+        {
+          id: e._id,
+          courseVersionId: e.courseVersionId.toString(),
+        },
+      );
     });
 
     const completedCounts = await this.watchTimeCollection
@@ -2615,13 +2624,22 @@ export class EnrollmentRepository {
           {
             $match: {
               isDeleted: { $ne: true },
-              isHidden: { $ne: true },
-              endTime: { $exists: true },
+              endTime: { $exists: true, $ne: null },
               $or: enrollments.map(e => ({
                 userId: e.userId,
                 courseId: e.courseId,
                 courseVersionId: e.courseVersionId,
-                ...(e.cohortId ? { cohortId: e.cohortId } : { cohortId: null }),
+                // A cohort-scoped enrollment counts only its own cohort's
+                // rows; one without a cohort counts the legacy rows that
+                // carry no cohortId (missing or explicitly null).
+                ...(e.cohortId
+                  ? { cohortId: e.cohortId }
+                  : {
+                      $or: [
+                        { cohortId: null },
+                        { cohortId: { $exists: false } },
+                      ],
+                    }),
               })),
             },
           },
@@ -2631,7 +2649,7 @@ export class EnrollmentRepository {
                 userId: '$userId',
                 courseId: '$courseId',
                 courseVersionId: '$courseVersionId',
-                cohortId: '$cohortId',
+                cohortId: { $ifNull: ['$cohortId', ''] },
               },
               completedItemsCount: { $addToSet: '$itemId' },
             },
@@ -2648,7 +2666,7 @@ export class EnrollmentRepository {
 
     const operations = completedCounts
       .map(c => {
-        const key = `${c._id.userId}_${c._id.courseId}_${c._id.courseVersionId}_${c._id.cohortId}`;
+        const key = `${c._id.userId}_${c._id.courseId}_${c._id.courseVersionId}_${cohortKey(c._id.cohortId)}`;
         const entry = enrollmentMap.get(key);
         if (!entry) return null;
 
@@ -2724,7 +2742,10 @@ export class EnrollmentRepository {
 
     const cursor = this.enrollmentCollection
       .find(match)
-      .project({ userId: 1, courseId: 1, courseVersionId: 1 })
+      // cohortId is required: the batch below scopes each enrollment's
+      // completions to its own cohort, and omitting it here silently counted
+      // every cohort-scoped enrollment as having completed nothing.
+      .project({ userId: 1, courseId: 1, courseVersionId: 1, cohortId: 1 })
       .batchSize(BATCH_SIZE);
 
     let batch: any[] = [];


### PR DESCRIPTION
The nightly progress recompute rewrote every enrollment's completedItemsCount/percentCompleted from watch-time rows, but its cohort handling was broken in three compounding ways, so it wrote counts far below what the live completion path reports.

- The enrollment cursor projected only userId/courseId/courseVersionId, so cohortId was undefined by the time processCompletedItemsBatch used it. Every cohort-scoped enrollment was matched against `cohortId: null` and counted as having completed nothing.
- The enrollmentMap key interpolated that raw value, producing the literal strings "undefined"/"null", while the aggregation grouped on the real cohortId. Even the no-cohort enrollments never matched their own aggregation result and were skipped — which is why the undercount hit everyone, not just cohort members.
- The $match filtered `isHidden: { $ne: true }` on watchTime, a field watchTime documents do not carry. It excluded nothing and only implied a hidden-item guard that was not there.

Projects cohortId, normalises null/undefined to '' on both sides of the lookup via a shared cohortKey helper, and matches no-cohort enrollments against rows where cohortId is null or absent — mirroring the fallback ProgressRepository.isItemCompleted already uses for legacy rows. Also tightens endTime to `$ne: null`, matching getCompletedItems. Drops the dead isHidden filter rather than leaving a guard that never applied.

This only changes how the recompute counts. It reads watch-time rows and never creates or closes them, so the underlying completion data was never damaged: re-running the recompute restores the true percentages for enrollments an earlier run had lowered.

Reported by the SASTRA deployment: ~79 students clustered at exactly 58.62% with identical updatedAt timestamps to the second, consistent with an automated batch write rather than individual activity. Note that #1292 (making the 3 AM cron actually run on schedule) increased exposure to this bug, which matches when the mass drop appeared.

Verified: added repository-level tests over the in-memory replica set covering a cohort-scoped enrollment, a legacy one with no cohort, duplicate rows for one item, another cohort's rows, and a still-open session. The tests fail on the previous code (expected 2, received 0) and pass with the fix. Also ran the four related enrollment/progress suites (29 tests green), tsc --noEmit clean, lint clean.

Known remaining divergence, deliberately out of scope: the live path excludes hidden/deleted items via getHiddenOrDeletedItems and this recompute still does not. That spans another repository and interacts with how totalItems is maintained, so it needs its own review.
