### PR TITLE
fix(ejection): create policies inactive and state the intended status

### DIFF
--- a/backend/src/modules/ejectionPolicy/services/EjectionPolicyService.ts
+++ b/backend/src/modules/ejectionPolicy/services/EjectionPolicyService.ts
@@ -49,9 +49,13 @@ export class EjectionPolicyService extends BaseService {
       // Check for conflicts
       // await this.checkPolicyConflicts(policyData, undefined, session);
 
-      // Create the policy
+      // Create the policy. isActive is forced off regardless of what the
+      // caller sent: this feature ejects students, so a policy becomes live
+      // only through an explicit activation (toggle/update), never as a side
+      // effect of being created.
       const policy = new EjectionPolicy({
         ...policyData,
+        isActive: false,
         createdBy,
       });
 

--- a/backend/src/modules/ejectionPolicy/tests/EjectionPolicyService.createInactive.test.ts
+++ b/backend/src/modules/ejectionPolicy/tests/EjectionPolicyService.createInactive.test.ts
@@ -1,0 +1,77 @@
+import {describe, it, expect, vi} from 'vitest';
+import {EjectionPolicyService} from '../services/EjectionPolicyService.js';
+
+/**
+ * A policy created through this service must never be live.
+ *
+ * Auto-ejection unenrolls students without anyone asking it to, so switching it
+ * on has to be a separate, deliberate act (the toggle/update path, which the UI
+ * confirms first). Creation is not that act. DI is bypassed the same way the
+ * other service unit tests in this repo do it: the prototype is instantiated
+ * directly and only the collaborators this call path touches are stubbed.
+ */
+
+const CREATED_BY = 'admin-1';
+
+function makeService() {
+  const service: any = Object.create(EjectionPolicyService.prototype);
+
+  service._withTransaction = async (fn: any) => fn({} as any);
+
+  const create = vi.fn().mockResolvedValue('policy-1');
+
+  service.policyRepo = {
+    findByCohort: async () => null,
+    create,
+    // Echoes back what create() was handed, so the assertions below read the
+    // object as it would actually be persisted.
+    findById: async () => create.mock.calls[0][0],
+  };
+
+  // The triggers/actions shape is validated separately; this path only cares
+  // about isActive, so validation is stubbed out.
+  service.validatePolicyData = () => undefined;
+
+  return {service, create};
+}
+
+const basePolicy = {
+  name: 'Progress policy',
+  courseId: 'course-1',
+  courseVersionId: 'version-1',
+  cohortId: 'cohort-1',
+};
+
+describe('EjectionPolicyService.createPolicy', () => {
+  it('creates the policy inactive when isActive was not supplied', async () => {
+    const {service, create} = makeService();
+
+    await service.createPolicy({...basePolicy}, CREATED_BY);
+
+    expect(create.mock.calls[0][0].isActive).toBe(false);
+  });
+
+  it('creates the policy inactive even when the caller asks for isActive: true', async () => {
+    const {service, create} = makeService();
+
+    await service.createPolicy(
+      {...basePolicy, isActive: true} as any,
+      CREATED_BY,
+    );
+
+    // A client that posts isActive: true — including an older frontend build —
+    // must not be able to bring up a live ejection policy in one call.
+    expect(create.mock.calls[0][0].isActive).toBe(false);
+  });
+
+  it('still records the rest of the policy it was given', async () => {
+    const {service, create} = makeService();
+
+    await service.createPolicy({...basePolicy} as any, CREATED_BY);
+
+    const created = create.mock.calls[0][0];
+    expect(created.name).toBe('Progress policy');
+    expect(created.cohortId).toBe('cohort-1');
+    expect(created.createdBy).toBe(CREATED_BY);
+  });
+});

--- a/frontend/src/app/pages/teacher/components/ejection-policies/EjectionPolicyCard.tsx
+++ b/frontend/src/app/pages/teacher/components/ejection-policies/EjectionPolicyCard.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Edit3, Trash2, Power, Shield, AlertTriangle, Flag } from "lucide-react";
 import { EjectionPolicy } from "@/types/ejection-policy.types";
-import { useTogglePolicyStatus, useDeleteEjectionPolicy } from "@/hooks/ejection-policy-hooks";
+import { useUpdateEjectionPolicy, useDeleteEjectionPolicy } from "@/hooks/ejection-policy-hooks";
 import { toast } from "sonner";
 import ConfirmationModal from "@/app/pages/teacher/components/confirmation-modal";
 
@@ -17,18 +17,34 @@ interface EjectionPolicyCardProps {
 
 export const EjectionPolicyCard = ({ policy, onEdit, canEdit, canDelete }: EjectionPolicyCardProps) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const toggleStatus = useTogglePolicyStatus();
+  const [showActivateModal, setShowActivateModal] = useState(false);
+  const updatePolicy = useUpdateEjectionPolicy();
   const deletePolicy = useDeleteEjectionPolicy();
 
-  const handleToggle = async () => {
+  // Sets isActive to an explicit value rather than flipping whatever the
+  // server currently holds. The toggle endpoint negates the stored value, so a
+  // double click — or two admins acting at once — could switch ejection back
+  // ON. For a feature that unenrolls students, the intended state is stated.
+  const setActive = async (isActive: boolean) => {
     try {
-      await toggleStatus.mutateAsync({
-        params: { path: { policyId: policy._id } }
-      });
-      toast.success(`Policy ${policy.isActive ? 'deactivated' : 'activated'} successfully`);
+      await updatePolicy.mutateAsync({
+        params: { path: { policyId: policy._id } },
+        body: { isActive },
+      } as any);
+      toast.success(`Policy ${isActive ? 'activated' : 'deactivated'} successfully`);
     } catch (error: any) {
-      toast.error(error?.message || 'Failed to toggle policy status');
+      toast.error(error?.message || 'Failed to update policy status');
     }
+  };
+
+  const handleToggle = async () => {
+    // Deactivating is always safe, so it applies immediately. Activating turns
+    // on automatic ejection of students, so it is confirmed first.
+    if (policy.isActive) {
+      await setActive(false);
+      return;
+    }
+    setShowActivateModal(true);
   };
 
   const handleDelete = async () => {
@@ -123,7 +139,7 @@ export const EjectionPolicyCard = ({ policy, onEdit, canEdit, canDelete }: Eject
                     variant="outline"
                     size="sm"
                     onClick={handleToggle}
-                    disabled={toggleStatus.isPending}
+                    disabled={updatePolicy.isPending}
                   >
                     <Power className="h-3 w-3 mr-1" />
                     {policy.isActive ? 'Deactivate' : 'Activate'}
@@ -194,6 +210,21 @@ export const EjectionPolicyCard = ({ policy, onEdit, canEdit, canDelete }: Eject
         </CardContent>
       </Card>
 
+      <ConfirmationModal
+        isOpen={showActivateModal}
+        onClose={() => setShowActivateModal(false)}
+        onConfirm={async () => {
+          await setActive(true);
+          setShowActivateModal(false);
+        }}
+        title="Activate Policy"
+        description="Activating this policy lets the system automatically eject students from this cohort when they meet its triggers. Review the triggers before continuing."
+        confirmText="Activate"
+        cancelText="Cancel"
+        isDestructive={true}
+        isLoading={updatePolicy.isPending}
+        loadingText="Activating..."
+      />
       <ConfirmationModal
         isOpen={showDeleteModal}
         onClose={() => setShowDeleteModal(false)}

--- a/frontend/src/app/pages/teacher/components/ejection-policies/EjectionPolicyModal.tsx
+++ b/frontend/src/app/pages/teacher/components/ejection-policies/EjectionPolicyModal.tsx
@@ -47,7 +47,10 @@ export const EjectionPolicyModal = ({
     courseId: defaultScope === PolicyScope.COURSE ? courseId || "" : "",
     courseVersionId: defaultScope === PolicyScope.COURSE ? courseVersionId || "" : "",
     cohortId: cohortId ||"",
-    isActive: true,
+    // New policies start inactive: this feature ejects students, so it must be
+    // switched on deliberately after its triggers have been reviewed, never by
+    // simply being created.
+    isActive: false,
     
     // Triggers
     inactivityEnabled: false,
@@ -131,8 +134,8 @@ export const EjectionPolicyModal = ({
         courseId: courseId || "",
         courseVersionId: courseVersionId || "",
         cohortId: cohortId || "",
-        
-        isActive: true,
+
+        isActive: false,
         inactivityEnabled: false,
         inactivityThresholdDays: 30,
         inactivityWarningDays: 7,
@@ -364,14 +367,25 @@ export const EjectionPolicyModal = ({
                
               </div>
 
-              <div className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
-                <Label htmlFor="isActive" className="cursor-pointer">Active Status</Label>
-                <Switch
-                  id="isActive"
-                  checked={formData.isActive}
-                  onCheckedChange={(checked) => setFormData({ ...formData, isActive: checked })}
-                />
-              </div>
+              {/* Only offered when editing. A new policy is always created
+                  inactive and is activated from its card, which confirms the
+                  consequence first — creating a policy must never be what
+                  starts ejecting students. */}
+              {editPolicy ? (
+                <div className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+                  <Label htmlFor="isActive" className="cursor-pointer">Active Status</Label>
+                  <Switch
+                    id="isActive"
+                    checked={formData.isActive}
+                    onCheckedChange={(checked) => setFormData({ ...formData, isActive: checked })}
+                  />
+                </div>
+              ) : (
+                <p className="p-3 bg-muted/50 rounded-lg text-sm text-muted-foreground">
+                  This policy will be created <span className="font-medium">inactive</span>. Activate it
+                  from the policy list once you have reviewed its triggers.
+                </p>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
Auto-ejection unenrolls students on a schedule with no environment flag to stop it — policy state is the only control surface. Two things made that surface easier to trip than it should be.

New policies were born active. The create modal defaulted isActive to true and sent it, and the service passed whatever arrived straight into the document, so filling in the form was enough to put a live ejection policy in front of a cohort. The switch that set it sat in the same form as the triggers, presented as one more field rather than as the moment ejection starts.

The card's Deactivate button called POST /:policyId/toggle, which negates the stored value. Clicking twice, or two admins acting at once, turns ejection back on — and the second click looks the same as the first.

- Policies are now created inactive. The frontend no longer sends isActive on create, and createPolicy forces it false regardless of what the caller sent, so an older client (or a direct API call) cannot bring one up live in a single request either.
- The Active Status switch is shown only when editing an existing policy. On create the form says the policy will be inactive and where to activate it.
- The card sets isActive explicitly via PUT instead of toggling, so the result no longer depends on the state the client happened to be showing. Deactivating still applies immediately; activating now confirms first, naming the consequence.

Existing policies are unaffected — this changes creation, not stored state.

Permissions are unchanged: every mutating endpoint stays admin-only, and the card's controls stay behind canEdit/canDelete. (The admin gating was already correct; no permission changes were needed.)

Verified: added unit tests covering create-without-isActive, create-with-isActive-true, and that the rest of the policy is still recorded; they fail against the previous service and pass now. Backend tsc clean, lint clean. Frontend tsc shows one fewer pre-existing error in the two edited files than main does (8 -> 7) and no new ones; the remainder are generated-API-type gaps this change does not touch.
