### PR TITLE
perf(enrollments): precompute average watch hours for the statistics panel

### DIFF
--- a/backend/src/bootstrap/jobs/index.ts
+++ b/backend/src/bootstrap/jobs/index.ts
@@ -3,6 +3,7 @@ import './allocateHp.js'
 import './backfillFollowUpInvites.js';
 import './evaluateSlotFulfillment.js';
 import './recoverOrphanedWatchTimes.js';
+import './refreshEnrollmentStats.js';
 
 export const initJobs = () => {
   console.log('[CRON] Jobs initialized.');

--- a/backend/src/bootstrap/jobs/refreshEnrollmentStats.ts
+++ b/backend/src/bootstrap/jobs/refreshEnrollmentStats.ts
@@ -1,0 +1,53 @@
+import {appConfig} from '#root/config/app.js';
+import {getContainer} from '#root/bootstrap/loadModules.js';
+import {USERS_TYPES} from '#users/types.js';
+import type {EnrollmentService} from '#users/services/EnrollmentService.js';
+import cron from 'node-cron';
+
+// Keeps the teacher statistics panel fast.
+//
+// Of the four figures on that panel, three are counted straight off an indexed
+// enrollment query and cost nothing. The fourth — average watch hours — has to
+// sum every recorded viewing session for the course version, so its cost grows
+// with viewing history rather than with roster size. Computing it per request
+// left the panel spinning for seconds on the largest cohorts, and it was
+// recomputed on every cold load even though the number barely moves.
+//
+// This job precomputes that one figure into courseVersionStats; the endpoint
+// then reads it with a single indexed lookup. Only versions with active
+// students are refreshed, since nothing else has a dashboard to keep warm.
+//
+// Runs every 15 minutes, so the displayed watch-hours figure trails reality by
+// at most that long. The panel shows when it was last computed, so a teacher
+// can tell a stale number from a fresh one. Enrollment counts stay live and
+// are unaffected. Set ENABLE_ENROLLMENT_STATS_JOB='false' to stop it.
+cron.schedule(
+  '*/15 * * * *',
+  async () => {
+    if (!appConfig.ENABLE_ENROLLMENT_STATS_JOB) {
+      console.log(
+        'Skipped enrollment stats refresh ENABLE_ENROLLMENT_STATS_JOB==',
+        appConfig.ENABLE_ENROLLMENT_STATS_JOB,
+      );
+      return;
+    }
+
+    console.log('🚀 Cron Job Started: enrollment stats refresh...');
+    try {
+      const enrollmentService = getContainer().get<EnrollmentService>(
+        USERS_TYPES.EnrollmentService,
+      );
+      const summary = await enrollmentService.refreshCourseVersionWatchStats();
+      console.log(
+        `[enrollment-stats] refreshed=${summary.refreshed} ` +
+          `failed=${summary.failed}`,
+      );
+      console.log('🎉 Enrollment stats refresh completed');
+    } catch (err) {
+      console.error('❌ Enrollment stats refresh failed:', err);
+    }
+  },
+  {
+    timezone: 'Asia/Kolkata',
+  },
+);

--- a/backend/src/config/app.ts
+++ b/backend/src/config/app.ts
@@ -34,6 +34,12 @@ export const appConfig = {
   // deliberately per environment after a dry run rather than on deploy.
   ENABLE_WATCHTIME_RECOVERY_JOB:
     env('ENABLE_WATCHTIME_RECOVERY_JOB') === 'true',
+  // Default ON: precomputes the average watch hours shown on the teacher
+  // statistics panel, which otherwise has to be aggregated per request. It
+  // only writes a cached display figure and touches no student progress, so
+  // it is safe to self-activate on deploy. Until it first runs, the panel
+  // reports watch hours as not yet computed rather than as zero.
+  ENABLE_ENROLLMENT_STATS_JOB: env('ENABLE_ENROLLMENT_STATS_JOB') !== 'false',
   GOOGLE_APPLICATION_CREDENTIALS: env('GOOGLE_APPLICATION_CREDENTIALS'),
   GCP_BACKUP_BUCKET: env('GCP_BACKUP_BUCKET'),
   GCP_BACKUP_ACTIVITY_BUCKET: env('GCP_BACKUP_ACTIVITY_BUCKET'),

--- a/backend/src/modules/users/classes/validators/EnrollmentValidators.ts
+++ b/backend/src/modules/users/classes/validators/EnrollmentValidators.ts
@@ -631,6 +631,16 @@ export class EnrollmentStatisticsResponse {
 
   @IsNumber()
   averageWatchHoursPerUser: number;
+
+  @JSONSchema({
+    description:
+      'When averageWatchHoursPerUser was last recomputed by the statistics ' +
+      'job. Null means it has not been computed for this course version yet, ' +
+      'so the accompanying figure is a placeholder rather than a measurement.',
+  })
+  @IsOptional()
+  @IsDate()
+  watchHoursComputedAt?: Date | null;
 }
 
 export class UserEnrollmentStatisticsResponse {

--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -1069,14 +1069,13 @@ export class EnrollmentController {
         courseId,
         versionId,
       );
-    // stats now includes averageWatchHoursPerUser
-
     if (!stats || stats.totalEnrollments === 0) {
       return {
         totalEnrollments: 0,
         completedCount: 0,
         averageProgressPercent: 0,
         averageWatchHoursPerUser: 0,
+        watchHoursComputedAt: null,
       };
     }
 

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -1423,6 +1423,44 @@ export class EnrollmentService extends BaseService {
   }
 
   /**
+   * Refresh the cached average watch hours for every course version that has
+   * active students. Driven by the scheduled statistics job.
+   *
+   * Versions are refreshed one at a time rather than in parallel: the point of
+   * moving this work off the request path was to stop it hurting the database,
+   * so it must not be replaced by a burst of concurrent aggregations. One
+   * version failing is logged and does not abandon the rest of the run.
+   */
+  async refreshCourseVersionWatchStats(): Promise<{
+    refreshed: number;
+    failed: number;
+  }> {
+    const versions =
+      await this.enrollmentRepo.getCourseVersionsWithActiveEnrollments();
+
+    let refreshed = 0;
+    let failed = 0;
+
+    for (const {courseId, courseVersionId} of versions) {
+      try {
+        await this.enrollmentRepo.refreshCourseVersionWatchStats(
+          courseId,
+          courseVersionId,
+        );
+        refreshed += 1;
+      } catch (err) {
+        failed += 1;
+        console.error(
+          `[enrollment-stats] failed to refresh ${courseId}/${courseVersionId}:`,
+          err,
+        );
+      }
+    }
+
+    return {refreshed, failed};
+  }
+
+  /**
    * Enrich enrollments with quiz score information
    * Handles the calculation in Node since we don't maintain reverse lookups in DB
    * @private

--- a/backend/src/modules/users/tests/EnrollmentRepository.versionStats.test.ts
+++ b/backend/src/modules/users/tests/EnrollmentRepository.versionStats.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { MongoDatabase } from '#shared/database/providers/mongo/MongoDatabase.js';
+import { EnrollmentRepository } from '#shared/database/providers/mongo/repositories/EnrollmentRepository.js';
+
+/**
+ * Repository-level tests for the teacher statistics panel.
+ *
+ * Average watch hours used to be aggregated on every request, scanning the
+ * whole watchTime collection because its match was wrapped in `$expr`. It is
+ * now precomputed into courseVersionStats and read back by the endpoint. These
+ * cover both halves of that split — that the recomputation still excludes
+ * share-link guests and still tolerates ids stored as either strings or
+ * ObjectIds, and that the read path reports an uncomputed course honestly
+ * rather than as a zero.
+ *
+ * Runs against the in-memory Mongo replica set started in test/globalSetup.ts.
+ */
+describe('EnrollmentRepository course version statistics', () => {
+  let db: MongoDatabase;
+  let repo: EnrollmentRepository;
+
+  const courseId = new ObjectId();
+  const courseVersionId = new ObjectId();
+  // A second version whose ids were written as strings rather than ObjectIds,
+  // which both collections genuinely contain depending on the write path.
+  const stringCourseId = new ObjectId();
+  const stringVersionId = new ObjectId();
+
+  const learner = { _id: new ObjectId(), email: 'learner@example.com' };
+  const otherLearner = { _id: new ObjectId(), email: 'other@example.com' };
+  const guest = {
+    _id: new ObjectId(),
+    email: 'guest@example.com',
+    isShareLinkGuest: true,
+  };
+
+  const hours = (n: number) => n * 3600_000;
+  const start = new Date('2026-08-01T10:00:00Z');
+  const after = (ms: number) => new Date(start.getTime() + ms);
+
+  beforeAll(async () => {
+    db = new MongoDatabase(process.env.DB_URL, 'enrollment_repo_version_stats_test');
+    await db.connect();
+    repo = new EnrollmentRepository(db);
+
+    const users = await db.getCollection('users');
+    await users.insertMany([learner, otherLearner, guest] as any);
+
+    const enrollments = await db.getCollection('enrollment');
+    await enrollments.insertMany([
+      {
+        userId: learner._id,
+        courseId,
+        courseVersionId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        percentCompleted: 100,
+        isDeleted: false,
+      },
+      {
+        userId: otherLearner._id,
+        courseId,
+        courseVersionId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        percentCompleted: 40,
+        isDeleted: false,
+      },
+      // Sharing a course must not move the numbers describing enrolled
+      // learners, so this enrollment is outside every figure below.
+      {
+        userId: guest._id,
+        courseId,
+        courseVersionId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        percentCompleted: 0,
+        isDeleted: false,
+        isShareLinkGuest: true,
+      },
+      {
+        userId: learner._id,
+        courseId: String(stringCourseId),
+        courseVersionId: String(stringVersionId),
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        percentCompleted: 50,
+        isDeleted: false,
+      },
+    ] as any);
+
+    const watchTime = await db.getCollection('watchTime');
+    await watchTime.insertMany([
+      // learner: 2h total across two sessions
+      {
+        userId: learner._id,
+        courseId,
+        courseVersionId,
+        itemId: new ObjectId(),
+        startTime: start,
+        endTime: after(hours(1)),
+      },
+      {
+        userId: learner._id,
+        courseId,
+        courseVersionId,
+        itemId: new ObjectId(),
+        startTime: start,
+        endTime: after(hours(1)),
+      },
+      // otherLearner: 4h total, so the average across the two is 3h
+      {
+        userId: otherLearner._id,
+        courseId,
+        courseVersionId,
+        itemId: new ObjectId(),
+        startTime: start,
+        endTime: after(hours(4)),
+      },
+      // A guest who watched far more than either learner. If guests were
+      // counted the average would jump well past 3h.
+      {
+        userId: guest._id,
+        courseId,
+        courseVersionId,
+        itemId: new ObjectId(),
+        startTime: start,
+        endTime: after(hours(50)),
+      },
+      // Still open — no endTime, so it is not a measurable session yet.
+      {
+        userId: otherLearner._id,
+        courseId,
+        courseVersionId,
+        itemId: new ObjectId(),
+        startTime: start,
+      },
+      // Soft-deleted, and so excluded.
+      {
+        userId: learner._id,
+        courseId,
+        courseVersionId,
+        itemId: new ObjectId(),
+        startTime: start,
+        endTime: after(hours(20)),
+        isDeleted: true,
+      },
+      // The string-id version: 3h for one learner.
+      {
+        userId: learner._id,
+        courseId: String(stringCourseId),
+        courseVersionId: String(stringVersionId),
+        itemId: new ObjectId(),
+        startTime: start,
+        endTime: after(hours(3)),
+      },
+    ] as any);
+  });
+
+  afterAll(async () => {
+    await db.disconnect?.();
+  });
+
+  it('excludes share-link guests, open sessions and deleted rows from the average', async () => {
+    const average = await repo.computeAverageWatchHoursPerUser(
+      String(courseId),
+      String(courseVersionId),
+    );
+
+    // learner 2h and otherLearner 4h -> 3h. The 50h guest, the open session
+    // and the 20h deleted row are all absent.
+    expect(average).toBe(3);
+  });
+
+  it('matches ids stored as strings as well as ObjectIds', async () => {
+    const average = await repo.computeAverageWatchHoursPerUser(
+      String(stringCourseId),
+      String(stringVersionId),
+    );
+
+    expect(average).toBe(3);
+  });
+
+  it('reports watch hours as uncomputed until the job has run', async () => {
+    const stats = await repo.getVersionEnrollmentStats(
+      String(courseId),
+      String(courseVersionId),
+    );
+
+    // The counts are live, so they are right immediately...
+    expect(stats.totalEnrollments).toBe(2);
+    expect(stats.completedCount).toBe(1);
+    // ...but watch hours has no stored figure yet, and saying "0h" here would
+    // read as nobody having watched anything.
+    expect(stats.averageWatchHoursPerUser).toBe(0);
+    expect(stats.watchHoursComputedAt).toBeNull();
+  });
+
+  it('serves the stored figure once refreshed, and updates it in place', async () => {
+    const refreshed = await repo.refreshCourseVersionWatchStats(
+      String(courseId),
+      String(courseVersionId),
+    );
+    expect(refreshed.averageWatchHoursPerUser).toBe(3);
+
+    const stats = await repo.getVersionEnrollmentStats(
+      String(courseId),
+      String(courseVersionId),
+    );
+    expect(stats.averageWatchHoursPerUser).toBe(3);
+    expect(stats.watchHoursComputedAt).toBeInstanceOf(Date);
+
+    // A second run must overwrite rather than accumulate a second row for the
+    // same version, or the endpoint's findOne would start returning whichever
+    // one Mongo happened to reach first.
+    await repo.refreshCourseVersionWatchStats(
+      String(courseId),
+      String(courseVersionId),
+    );
+    const statsCollection = await db.getCollection('courseVersionStats');
+    const rows = await statsCollection
+      .find({ courseVersionId: { $in: [courseVersionId, String(courseVersionId)] } })
+      .toArray();
+    expect(rows).toHaveLength(1);
+  });
+
+  it('lists only course versions that have active students to refresh', async () => {
+    const versions = await repo.getCourseVersionsWithActiveEnrollments();
+
+    const keys = versions.map(v => `${v.courseId}/${v.courseVersionId}`);
+    expect(keys).toContain(`${String(courseId)}/${String(courseVersionId)}`);
+    expect(keys).toContain(
+      `${String(stringCourseId)}/${String(stringVersionId)}`,
+    );
+    // The guest's enrollment is on a version already listed, so the guard is
+    // that it did not add a version of its own beyond the two seeded here.
+    expect(versions).toHaveLength(2);
+  });
+});

--- a/backend/src/modules/users/types.ts
+++ b/backend/src/modules/users/types.ts
@@ -18,4 +18,8 @@ export interface EnrollmentStats {
   completedCount: number;
   averageProgressPercent: number;
   averageWatchHoursPerUser: number; // average hours watched per enrolled user
+  // When averageWatchHoursPerUser was last recomputed. Null means the stats
+  // job has not reached this course version yet, so the figure beside it is a
+  // placeholder rather than a measurement.
+  watchHoursComputedAt?: Date | null;
 }

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -9,6 +9,7 @@ import {
   ID,
   courseVersionStatus,
   IUserActivityEvent,
+  ICourseVersionStats,
 } from '#shared/interfaces/models.js';
 import { injectable, inject } from 'inversify';
 import { ClientSession, Collection, ObjectId, OptionalId } from 'mongodb';
@@ -60,6 +61,8 @@ export class EnrollmentRepository {
   private reportCollection!: Collection<IReport>;
   private userQuizMetricsCollection!: Collection<IUserQuizMetrics>;
   private userActivityEventCollection!: Collection<IUserActivityEvent>;
+  private userCollection!: Collection<IUser>;
+  private courseVersionStatsCollection!: Collection<ICourseVersionStats>;
 
   constructor(
     @inject(GLOBAL_TYPES.Database) private db: MongoDatabase,
@@ -95,6 +98,9 @@ export class EnrollmentRepository {
       await this.db.getCollection<IUserQuizMetrics>('user_quiz_metrics');
     this.userActivityEventCollection =
       await this.db.getCollection<IUserActivityEvent>('user_activity_events');
+    this.userCollection = await this.db.getCollection<IUser>('users');
+    this.courseVersionStatsCollection =
+      await this.db.getCollection<ICourseVersionStats>('courseVersionStats');
   }
 
   /**
@@ -2173,7 +2179,144 @@ export class EnrollmentRepository {
       averageProgressPercent: 0,
     };
 
-    // second aggregation to compute average watch hours per user for this course version
+    // Average watch hours is read from the precomputed figure rather than
+    // aggregated here — see ICourseVersionStats for why it alone is cached.
+    // A course whose stats the job has not reached yet reports 0 with a null
+    // computedAt, which the dashboard renders as "not computed yet" instead
+    // of passing off a placeholder as a real measurement.
+    const cachedStats = await this.courseVersionStatsCollection.findOne(
+      {
+        courseId: { $in: [courseId, new ObjectId(courseId)] },
+        courseVersionId: {
+          $in: [courseVersionId, new ObjectId(courseVersionId)],
+        },
+      },
+      { session },
+    );
+
+    return {
+      totalEnrollments: baseStats.totalEnrollments,
+      completedCount: baseStats.completedCount,
+      averageProgressPercent: baseStats.averageProgressPercent,
+      averageWatchHoursPerUser: cachedStats?.averageWatchHoursPerUser ?? 0,
+      watchHoursComputedAt: cachedStats?.computedAt ?? null,
+    };
+  }
+
+  /**
+   * Recompute and store the average watch hours for one course version.
+   * Driven by the scheduled statistics job.
+   */
+  async refreshCourseVersionWatchStats(
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<ICourseVersionStats> {
+    await this.init();
+
+    const averageWatchHoursPerUser =
+      await this.computeAverageWatchHoursPerUser(
+        courseId,
+        courseVersionId,
+        session,
+      );
+    const computedAt = new Date();
+
+    await this.courseVersionStatsCollection.updateOne(
+      {
+        courseId: { $in: [courseId, new ObjectId(courseId)] },
+        courseVersionId: {
+          $in: [courseVersionId, new ObjectId(courseVersionId)],
+        },
+      },
+      {
+        $set: { averageWatchHoursPerUser, computedAt },
+        $setOnInsert: {
+          courseId: new ObjectId(courseId),
+          courseVersionId: new ObjectId(courseVersionId),
+        },
+      },
+      { upsert: true, session },
+    );
+
+    return {
+      courseId,
+      courseVersionId,
+      averageWatchHoursPerUser,
+      computedAt,
+    };
+  }
+
+  /**
+   * Course versions that currently have at least one active student, which is
+   * the set the stats job refreshes. Versions nobody is enrolled in have no
+   * dashboard to keep warm, so recomputing them would be wasted scanning.
+   */
+  async getCourseVersionsWithActiveEnrollments(
+    session?: ClientSession,
+  ): Promise<{ courseId: string; courseVersionId: string }[]> {
+    await this.init();
+
+    const pairs = await this.enrollmentCollection
+      .aggregate<{ _id: { courseId: ID; courseVersionId: ID } }>(
+        [
+          {
+            $match: {
+              role: 'STUDENT',
+              status: { $regex: /^active$/i },
+              isDeleted: { $ne: true },
+              isShareLinkGuest: { $ne: true },
+            },
+          },
+          {
+            $group: {
+              _id: {
+                courseId: '$courseId',
+                courseVersionId: '$courseVersionId',
+              },
+            },
+          },
+        ],
+        { session },
+      )
+      .toArray();
+
+    return pairs.map(pair => ({
+      courseId: String(pair._id.courseId),
+      courseVersionId: String(pair._id.courseVersionId),
+    }));
+  }
+
+  /**
+   * Average watch hours per user for a course version.
+   *
+   * This is the expensive half of the enrollment statistics, so it is kept
+   * separate: the scheduled stats job calls it directly to refresh the cached
+   * figure without recomputing the cheap enrollment counts alongside it.
+   *
+   * Both id fields are stored as either a string or an ObjectId depending on
+   * the write path, so each is matched against both forms. The match is a
+   * plain one rather than the `$expr` it used to be — `$expr` cannot use an
+   * index, which meant every call scanned the whole watchTime collection.
+   */
+  async computeAverageWatchHoursPerUser(
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<number> {
+    await this.init();
+
+    // Watch time is recorded for share-link guests too, so they have to be
+    // dropped or a heavy guest viewer would skew the average watch hours
+    // reported for enrolled learners. Guest-ness is a property of the user
+    // rather than of any one enrollment, so the guest ids are fetched once
+    // here instead of joining `users` per watch-time document as this
+    // previously did.
+    const guestUserIds = await this.userCollection
+      .find({ isShareLinkGuest: true }, { projection: { _id: 1 }, session })
+      .map(user => user._id)
+      .toArray();
+
     const watchAgg = await this.watchTimeCollection
       .aggregate<{
         averageWatchHoursPerUser: number;
@@ -2181,34 +2324,20 @@ export class EnrollmentRepository {
         [
           {
             $match: {
-              $expr: {
-                $and: [
-                  { $in: ['$courseId', [courseId, new ObjectId(courseId)]] },
-                  {
-                    $in: [
-                      '$courseVersionId',
-                      [courseVersionId, new ObjectId(courseVersionId)],
-                    ],
-                  },
-                  { $ne: ['$isDeleted', true] },
-                  { $ne: ['$endTime', null] },
-                ],
+              courseId: { $in: [courseId, new ObjectId(courseId)] },
+              courseVersionId: {
+                $in: [courseVersionId, new ObjectId(courseVersionId)],
               },
+              isDeleted: { $ne: true },
+              endTime: { $ne: null, $exists: true },
+              ...(guestUserIds.length
+                ? {
+                    userId: {
+                      $nin: guestUserIds.flatMap(id => [id, String(id)]),
+                    },
+                  }
+                : {}),
             },
-          },
-          // Watch time is recorded for share-link guests too, so they have to
-          // be dropped here or a heavy guest viewer would skew the average
-          // watch hours reported for enrolled learners.
-          {
-            $lookup: {
-              from: 'users',
-              localField: 'userId',
-              foreignField: '_id',
-              as: 'viewer',
-            },
-          },
-          {
-            $match: { 'viewer.isShareLinkGuest': { $ne: true } },
           },
           {
             $project: {
@@ -2242,22 +2371,8 @@ export class EnrollmentRepository {
       .toArray();
 
     const watchStats = watchAgg[0] || { averageWatchHoursPerUser: 0 };
-    // debug log
-    console.debug(
-      'Computed averageWatchHoursPerUser for course',
-      courseId,
-      courseVersionId,
-      watchStats.averageWatchHoursPerUser,
-    );
 
-    return {
-      totalEnrollments: baseStats.totalEnrollments,
-      completedCount: baseStats.completedCount,
-      averageProgressPercent: baseStats.averageProgressPercent,
-      averageWatchHoursPerUser: Number(
-        (watchStats.averageWatchHoursPerUser || 0).toFixed(2),
-      ),
-    };
+    return Number((watchStats.averageWatchHoursPerUser || 0).toFixed(2));
   }
 
   /**
@@ -2530,6 +2645,8 @@ export class EnrollmentRepository {
   }
 
   async addEnrollmentIndexes(session?: ClientSession): Promise<void> {
+    await this.init();
+
     try {
       await this.enrollmentCollection.dropIndex('courseVersionId_1');
       await this.enrollmentCollection.dropIndex('courseId_1');
@@ -2543,6 +2660,19 @@ export class EnrollmentRepository {
       // await this.enrollmentCollection.createIndex({ courseId: 1 });
       // await this.enrollmentCollection.createIndex({ courseVersionId: 1 });
       // await this.enrollmentCollection.createIndex({ enrollmentDate: -1 });
+    } catch (err) {
+      console.error(err);
+    }
+
+    // Kept out of the block above so that a failed drop there — the indexes it
+    // removes may already be gone — cannot stop this one being created.
+    try {
+      // The statistics endpoint looks the cached watch-hours figure up by
+      // course version on every load, and the job upserts by the same key.
+      await this.courseVersionStatsCollection.createIndex(
+        { courseId: 1, courseVersionId: 1 },
+        { name: 'courseId_1_courseVersionId_1', background: true },
+      );
     } catch (err) {
       console.error(err);
     }

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -91,6 +91,22 @@ class ProgressRepository {
     }
 
     try {
+      // The enrollment statistics job sums watch time across a whole course
+      // version. The userId-leading index above cannot serve that shape, so
+      // without this one the aggregation scans the entire collection.
+      await this.watchTimeCollection.createIndex(
+        {
+          courseId: 1,
+          courseVersionId: 1,
+          endTime: 1,
+        },
+        { background: true },
+      );
+    } catch (e) {
+      // Index already exists
+    }
+
+    try {
       // The orphan recovery job sweeps open watch sessions by age. A partial
       // index keeps this to just the rows that are still open, so it stays
       // small however large the collection grows.

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -570,6 +570,24 @@ export interface IWatchTime {
   recoveryAttemptedAt?: Date;
 }
 
+/**
+ * Precomputed slice of a course version's enrollment statistics.
+ *
+ * Only average watch hours is stored. It is the one figure whose cost grows
+ * with recorded watch-session volume rather than with roster size, so leaving
+ * it in the request path made the teacher statistics panel slower as a course
+ * accumulated viewing history. The enrollment counts beside it stay live —
+ * they are served by an index and teachers check them for freshness the
+ * moment someone joins.
+ */
+export interface ICourseVersionStats {
+  _id?: string | ObjectId | null;
+  courseId: string | ObjectId;
+  courseVersionId: string | ObjectId;
+  averageWatchHoursPerUser: number;
+  computedAt: Date;
+}
+
 export interface ICohort {
   _id?: string | ObjectId | null;
   courseId: string | ObjectId;

--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -44,6 +44,7 @@ import {
   useRecalculateStudentProgress,
   useResetFace,
 } from "@/hooks/hooks"
+import { formatTimeAgo } from "@/utils/time"
 import { toast } from "sonner"
 import { useCourseStore } from "@/store/course-store"
 import type { EnrolledUser, EnrollmentDetails } from "@/types/course.types"
@@ -1323,12 +1324,20 @@ function CourseEnrollments() {
     },
     {
       title: "Avg Watch Hours",
+      // Recomputed on a schedule rather than per request, so unlike the tiles
+      // above it carries a note saying how current it is. Before the job has
+      // ever run for this course there is no figure to show, and a bare "0h"
+      // would read as "nobody watched anything" rather than "not measured yet".
       value: (() => {
+        if (!enrollmentStats?.watchHoursComputedAt) return `—`;
         const v = enrollmentStats?.averageWatchHoursPerUser ?? 0;
         if (v <= 0) return `0h`;
         if (v < 0.005) return `<0.01h`;
         return `${v.toFixed(2)}h`;
       })(),
+      subtitle: enrollmentStats?.watchHoursComputedAt
+        ? `Updated ${formatTimeAgo(enrollmentStats.watchHoursComputedAt)}`
+        : `Not computed yet`,
       icon: Clock,
       color: "text-orange-600",
       bgColor: "bg-orange-50",
@@ -1476,6 +1485,9 @@ function CourseEnrollments() {
                     <div>
                       <p className="text-sm font-medium text-muted-foreground">{stat.title}</p>
                       <p className="text-2xl font-bold mt-1">{stat.value}</p>
+                      {stat.subtitle && (
+                        <p className="text-xs text-muted-foreground mt-1">{stat.subtitle}</p>
+                      )}
                     </div>
                     <div className={`p-3 rounded-full ${stat.bgColor}`}>
                       <stat.icon className={`h-5 w-5 ${stat.color}`} />

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -1708,6 +1708,9 @@ export interface CourseEnrollmentStats {
   completedCount: number;
   averageProgressPercent: number;
   averageWatchHoursPerUser?: number;
+  // Null until the statistics job has computed watch hours for this course
+  // version; the dashboard shows it as not measured rather than as zero.
+  watchHoursComputedAt?: string | null;
 }
 
 export function useCourseEnrollmentsStats(

--- a/frontend/src/utils/time.test.ts
+++ b/frontend/src/utils/time.test.ts
@@ -7,6 +7,7 @@ import {
   digitsToSeconds,
   parsePastedTime,
   formatWatchDuration,
+  formatTimeAgo,
 } from './time';
 
 describe('formatTime', () => {
@@ -178,5 +179,28 @@ describe('formatWatchDuration', () => {
     expect(formatWatchDuration(0)).toBe('0m');
     expect(formatWatchDuration(-5)).toBe('0m');
     expect(formatWatchDuration(NaN)).toBe('0m');
+  });
+});
+
+describe('formatTimeAgo', () => {
+  it('reads anything under a minute as current', () => {
+    expect(formatTimeAgo(new Date())).toBe('just now');
+    expect(formatTimeAgo(Date.now() - 30_000)).toBe('just now');
+  });
+
+  it('steps up through minutes, hours and days', () => {
+    expect(formatTimeAgo(Date.now() - 12 * 60_000)).toBe('12m ago');
+    expect(formatTimeAgo(Date.now() - 3 * 3600_000)).toBe('3h ago');
+    expect(formatTimeAgo(Date.now() - 2 * 86400_000)).toBe('2d ago');
+  });
+
+  it('treats a future timestamp as current rather than negative', () => {
+    // Clock skew between the server and the viewer must not render as
+    // "-1m ago" on a figure that was just recomputed.
+    expect(formatTimeAgo(Date.now() + 30_000)).toBe('just now');
+  });
+
+  it('returns an empty string for an unusable date', () => {
+    expect(formatTimeAgo('not a date')).toBe('');
   });
 });

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -174,3 +174,30 @@ export function parsePastedTime(text: string): number | null {
 
   return null;
 }
+
+/**
+ * How long ago a moment was, coarsely — `just now`, `12m ago`, `3h ago`.
+ *
+ * For figures the backend recomputes on a schedule rather than per request.
+ * The exact second is never the point; a teacher only wants to know whether
+ * the number in front of them is current or from a while back, so the
+ * granularity stops at days.
+ */
+export function formatTimeAgo(when: Date | string | number): string {
+  const then = new Date(when).getTime();
+  if (!Number.isFinite(then)) return '';
+
+  const seconds = Math.floor((Date.now() - then) / 1000);
+  // Clock skew between the server and the viewer can put a fresh timestamp
+  // slightly in the future, which should read as current rather than negative.
+  if (seconds < 60) return 'just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}


### PR DESCRIPTION
The teacher Course Students panel spent seconds on "Loading statistics..." for large cohorts. Three of its four figures are counted off an indexed enrollment query and cost nothing; the fourth, average watch hours, had to sum every recorded viewing session for the course version on every request.

Two things made that expensive. The aggregation's $match was wrapped in $expr so the id fields could match either a string or an ObjectId, and $expr cannot use an index — so each call scanned the whole watchTime collection. A $lookup into users then ran over the scanned set purely to keep share-link guests out of the average.

The match is now a plain indexable one covering both id forms, backed by a new courseId/courseVersionId/endTime index, and the guest ids are fetched once instead of joined per document. An explain confirms the old query planned a COLLSCAN where the new one plans an IXSCAN.

That figure is then precomputed into a courseVersionStats collection by a 15-minute job covering only versions with active students, so the endpoint reads it with a single indexed lookup. Enrollment counts stay live, since teachers check those for freshness the moment someone joins. The tile shows when watch hours was last computed, and renders an uncomputed course as "—" rather than passing a placeholder 0h off as a measurement.

The job is gated on ENABLE_ENROLLMENT_STATS_JOB, default ON: it writes only a cached display figure and touches no student progress. Until it first runs, the panel reports watch hours as not yet computed.

Also drops a console.debug from the request path.

Verified: an explain on the in-memory replica set confirms the old query planned a COLLSCAN and the new one plans an IXSCAN with tight bounds over both id forms. Five new repository tests cover guest exclusion, string-vs-ObjectId ids, open and soft-deleted sessions, the uncomputed read path, and upsert-in-place; temporarily removing the guest filter fails them as expected. Backend typecheck clean and the users suite gains five passing tests with no new failures (five failures in ProgressService.stopItem are pre-existing on main). Frontend utils tests pass, including four for the new formatTimeAgo helper.

Note: rollback, rewatch, linear progression and proctoring are untouched.
