### PR TITLE
fix(student): stop article resource links from stranding student progress

### DIFF
--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1741,12 +1741,21 @@ const handleGoToNextItem = async () => {
     const moduleIndex = allModules.findIndex((m: any) => m.moduleId === moduleId);
     const currentModuleIndex = allModules.findIndex((m: any) => m.moduleId === currentModuleId);
 
+    // Same failure mode as the currentItemIndex guard below: if currentModuleId
+    // doesn't resolve in this course structure (e.g. a stale/cross-version
+    // pointer left behind by an admin reset), currentModuleIndex is -1 and
+    // *every* real module (index >= 0) would compare greater than it, locking
+    // already-completed modules. Unknown position must not imply locked.
+    if (currentModuleIndex === -1) return false;
+
     if (moduleIndex > currentModuleIndex) return true;
     if (moduleIndex < currentModuleIndex) return false;
 
     const sections = allModules[moduleIndex]?.sections || [];
     const sectionIndex = sections.findIndex((s: any) => s.sectionId === sectionId);
     const currentSectionIndex = sections.findIndex((s: any) => s.sectionId === currentSectionId);
+
+    if (currentSectionIndex === -1) return false;
 
     if (sectionIndex > currentSectionIndex) return true;
     if (sectionIndex < currentSectionIndex) return false;

--- a/frontend/src/components/article.tsx
+++ b/frontend/src/components/article.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useImperativeHandle, forwardRef, useRef } from "react";
+import { useEffect, useMemo, useState, useImperativeHandle, forwardRef, useRef, useCallback } from "react";
 import MathRenderer from "./math-renderer";
 
 // Import Yoopta Editor Core
@@ -141,6 +141,23 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
         }
     }
 
+    /**
+     * The Yoopta link plugin defaults new links to target="_self" (its own
+     * `props: { target: "_self" }` default) unless a content author manually
+     * overrode it per link, so resource links routinely open in the same tab
+     * rather than the new tab this flow is designed around. Force it here
+     * instead of depending on every author remembering to set target="_blank"
+     * on every link. Plain left-clicks only — modifier-key/middle clicks are
+     * left to the browser's own new-tab handling.
+     */
+    const handleContentClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        const anchor = (e.target as HTMLElement).closest('a[href]') as HTMLAnchorElement | null;
+        if (!anchor) return;
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+        e.preventDefault();
+        window.open(anchor.href, '_blank', 'noopener,noreferrer');
+    };
+
     // // ✅ Handle Next button click - send stop request only when user clicks Next
     // const handleNextClick = () => {
     //     if (itemStartedRef.current) {
@@ -251,6 +268,71 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
         };
     }, []);
 
+    // Snapshot for the pagehide flush below, refreshed every render so the
+    // handler (registered once) always reads current values.
+    const pageHideContextRef = useRef({ currentCourse, isAlreadyWatched });
+    pageHideContextRef.current = { currentCourse, isAlreadyWatched };
+
+    /**
+     * Mirrors video.tsx's pagehide handler: a resource link inside an article
+     * that navigates the same tab (many links default to target="_self", and
+     * some browsers/webviews override target="_blank" anyway) tears down this
+     * component before the unmount effect's stop request can complete, since
+     * a non-keepalive request gets cancelled by the navigation. Without this,
+     * the item is left "started" forever with no watchTime record, which is
+     * what locked students out of subsequent sections in production.
+     *
+     * Raw `fetch` with keepalive (not navigator.sendBeacon, which can't set
+     * the Authorization header this API requires) so the request survives the
+     * page unload. Fire-and-forget by design — the page may already be gone
+     * by the time this returns.
+     */
+    const handlePageHide = useCallback(() => {
+        const { currentCourse, isAlreadyWatched } = pageHideContextRef.current;
+        if (
+            !itemStartedRef.current ||
+            stopInFlightRef.current ||
+            isAlreadyWatched ||
+            !currentCourse?.itemId ||
+            !currentCourse.watchItemId ||
+            completedItemIdsRef.current.has(currentCourse.itemId)
+        ) {
+            return;
+        }
+
+        const token = localStorage.getItem('firebase-auth-token');
+        if (!token) return;
+
+        const url =
+            `${import.meta.env.VITE_BASE_URL}/users/progress/courses/${currentCourse.courseId}` +
+            `/versions/${currentCourse.versionId ?? ''}/stop`;
+
+        try {
+            void fetch(url, {
+                method: 'POST',
+                keepalive: true,
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify({
+                    watchItemId: currentCourse.watchItemId,
+                    itemId: currentCourse.itemId,
+                    moduleId: currentCourse.moduleId ?? '',
+                    sectionId: currentCourse.sectionId ?? '',
+                    cohortId: currentCourse.cohortId || undefined,
+                }),
+            });
+        } catch {
+            // Best-effort — the tab is already closing, nothing left to do if this throws.
+        }
+    }, [completedItemIdsRef]);
+
+    useEffect(() => {
+        window.addEventListener('pagehide', handlePageHide);
+        return () => window.removeEventListener('pagehide', handlePageHide);
+    }, [handlePageHide]);
+
     // ✅ Add dark mode styles for Yoopta Editor
     useEffect(() => {
         const style = document.createElement('style');
@@ -315,7 +397,7 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
                 )}
                 
                 {/* Article Content */}
-                <div className="flex-1 w-full p-4 overflow-y-auto">
+                <div className="flex-1 w-full p-4 overflow-y-auto" onClick={handleContentClick}>
                     <YooptaEditor
                         width="100%"
                         value={value}

--- a/frontend/src/lib/openapi.ts
+++ b/frontend/src/lib/openapi.ts
@@ -17,18 +17,38 @@ export const setTokenRefreshFunction = (refreshFn: () => Promise<void>) => {
 
 export const fetchClient = createFetchClient<paths>({
   baseUrl: `${import.meta.env.VITE_BASE_URL}`,
-  fetch: (url, options) => {
+  fetch: async (url, options) => {
     // openapi-fetch passes a Request object for some requests (like DELETE without body)
     // If we just pass `url` down, it drops the headers added by middleware.
     // Instead, clone it applying options.
-    if (url instanceof Request) {
-      const newReq = new Request(url, { ...options, credentials: "include" });
-      return fetch(newReq);
+    const response = url instanceof Request
+      ? await fetch(new Request(url, { ...options, credentials: "include" }))
+      : await fetch(url, { ...options, credentials: "include" });
+
+    /**
+     * Several backend endpoints (progress stop/skip/reset, etc.) intentionally
+     * send an empty 200 body (`@OnUndefined(200)`). openapi-fetch only skips
+     * JSON parsing when Content-Length is exactly "0", but Render's proxy
+     * doesn't always forward that header for an empty body -- so it falls
+     * through to response.json() on empty content and throws "Unexpected end
+     * of JSON input", surfacing as a raw parse error instead of a successful
+     * mutation. Scoped to non-GET requests since those are the only ones with
+     * intentionally-empty responses in this API; GET bodies are never re-read
+     * here, avoiding the double-buffering cost for the large ones.
+     */
+    const method = (options?.method ?? 'GET').toUpperCase();
+    if (response.ok && response.status !== 204 && method !== 'GET') {
+      const text = await response.clone().text();
+      if (text.length === 0) {
+        return new Response('{}', {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
+      }
     }
-    return fetch(url, {
-      ...options,
-      credentials: "include",
-    });
+
+    return response;
   },
 });
 


### PR DESCRIPTION
Closes #1328

Two related fixes, bundled together since they were found investigating the same report:

1. **Article resource links no longer strand progress.** Force all article content links to always open in a new tab (regardless of authored `target`), and port `video.tsx`'s `pagehide`+keepalive-fetch stop flush to `article.tsx` so completion is still recorded if a tab is torn down mid-navigation anyway. Also closes a mass-locking gap in `isItemLocked` where an unresolvable module/section position locked already-completed content instead of leaving it alone.
2. **Empty-body action responses no longer crash JSON parsing.** The shared `fetchClient` wrapper now detects a genuinely empty `ok` body on non-GET requests and substitutes `"{}"` before it reaches `response.json()`.

Verified: root cause reproduced live before the fix (a link with no `target` attribute navigated the tab away), then re-verified live after deploying that the same link now opens in a new tab and the original tab is unaffected. The `isItemLocked` fix was verified against the exact scenario from a production DB dump (an unresolvable `currentModule`/`currentSection` pointer no longer mass-locks completed content). The empty-body fix was verified against 5 scenarios (real bug case, 204 passthrough, real-body passthrough, GET correctly left untouched, error-status passthrough).

### Test plan
- [ ] `pnpm exec tsc --noEmit` in `frontend/`
- [ ] Manually click a resource link inside an article/reading item -- confirm it opens in a new tab and the original lesson stays intact
- [ ] Confirm article completion/"Next Lesson" works normally after visiting a link
- [ ] Confirm previously-completed lessons don't show as locked when progress pointers don't cleanly resolve