### PR TITLE
fix(ui): stop Select popover clamping to trigger height

### DIFF
--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -74,7 +74,7 @@ function SelectContent({
           className={cn(
             "p-1",
             position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+              "w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
           )}
         >
           {children}


### PR DESCRIPTION
SelectViewport bound its height to --radix-select-trigger-height, so a long dropdown (e.g. 28 cohorts in the teacher invite picker) only rendered/scrolled through roughly as many items as the trigger button is tall — the rest were cut off. Drop that binding so the viewport fills SelectContent's max-h instead, which already tracks the available popup height.

Fixes #1332

