### PR TITLE
fix(courses): stop cohortDetails from silently dropping cohorts beyond 10

### DIFF
--- a/backend/src/modules/courses/services/CourseVersionService.ts
+++ b/backend/src/modules/courses/services/CourseVersionService.ts
@@ -194,9 +194,13 @@ export class CourseVersionService extends BaseService {
         throw new InternalServerError('Failed to read course version.');
       }
       if (readVersion.cohorts?.length) {
+        // getCohortsByIds defaults to limit: 10 for its paginated cohort-browser
+        // callers -- passing that default here silently dropped every cohort
+        // beyond the 10 most recently created from cohortDetails, which every
+        // cohort picker in the UI is populated from.
         const cohorts = await this.courseRepo.getCohortsByIds(
           readVersion.cohorts,
-          undefined,
+          {limit: readVersion.cohorts.length},
           session,
         );
 
@@ -900,9 +904,10 @@ export class CourseVersionService extends BaseService {
         throw new InternalServerError('Failed to read course version.');
       }
       if (readVersion.cohorts?.length) {
+        // See readCourseVersion's cohortDetails hydration above -- same default-limit trap.
         const cohorts = await this.courseRepo.getCohortsByIds(
           readVersion.cohorts,
-          undefined,
+          {limit: readVersion.cohorts.length},
           session,
         );
 

--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -623,6 +623,7 @@ function CourseEnrollments() {
   const [activeCount, setActiveCount] = useState(0)
   const [inactiveCount, setInactiveCount] = useState(0)
   const [cohort, setCohort] = useState<string | null>(null);
+  const [cohortFilterSearch, setCohortFilterSearch] = useState("");
   const {
     data: quizScores,
     isLoading: isLoadingQuizScores,
@@ -3172,7 +3173,7 @@ function EnrollmentsTable({
           </Button> */}
 
           {(version as any)?.cohortDetails?.length > 0 && (
-            <DropdownMenu>
+            <DropdownMenu onOpenChange={(open) => { if (!open) setCohortFilterSearch(""); }}>
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="outline"
@@ -3182,7 +3183,20 @@ function EnrollmentsTable({
                   {cohort ? (version as any).cohortDetails.find((c: any) => c.id === cohort)?.name : "Select Cohort"}
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent>
+              <DropdownMenuContent className="max-h-80 overflow-y-auto">
+                {(version as any).cohortDetails.length > 8 && (
+                  <div className="p-1">
+                    <Input
+                      placeholder="Search cohorts..."
+                      value={cohortFilterSearch}
+                      onChange={(e) => setCohortFilterSearch(e.target.value)}
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => e.stopPropagation()}
+                      className="h-8"
+                      autoFocus
+                    />
+                  </div>
+                )}
                 <DropdownMenuRadioGroup
                   value={cohort ?? ""}
                   onValueChange={(id) => {
@@ -3194,14 +3208,19 @@ function EnrollmentsTable({
                     onClick={() => setCohort(null)}>
                     All Cohorts
                   </DropdownMenuRadioItem>
-                  {(version as any)?.cohortDetails?.map((cohort: any) => (
-                    <DropdownMenuRadioItem
-                      key={cohort.id}
-                      value={cohort.id}
-                    >
-                      {cohort.name}
-                    </DropdownMenuRadioItem>
-                  ))}
+                  {(version as any).cohortDetails
+                    .filter((c: any) => c.name.toLowerCase().includes(cohortFilterSearch.toLowerCase()))
+                    .map((cohort: any) => (
+                      <DropdownMenuRadioItem
+                        key={cohort.id}
+                        value={cohort.id}
+                      >
+                        {cohort.name}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  {cohortFilterSearch && !(version as any).cohortDetails.some((c: any) => c.name.toLowerCase().includes(cohortFilterSearch.toLowerCase())) && (
+                    <div className="px-2 py-1.5 text-sm text-muted-foreground">No cohorts match "{cohortFilterSearch}"</div>
+                  )}
                 </DropdownMenuRadioGroup>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -1654,6 +1654,8 @@ function CourseEnrollments() {
                   version={version}
                   cohort={cohort}
                   setCohort={setCohort}
+                  cohortFilterSearch={cohortFilterSearch}
+                  setCohortFilterSearch={setCohortFilterSearch}
                   courseId= {courseId}
                 />
               )}
@@ -1713,6 +1715,8 @@ function CourseEnrollments() {
                   version={version}
                   cohort={cohort}
                   setCohort={setCohort}
+                  cohortFilterSearch={cohortFilterSearch}
+                  setCohortFilterSearch={setCohortFilterSearch}
                 />
               )}
             </div>
@@ -3047,6 +3051,8 @@ interface EnrollmentsTableProps {
   version: any;
   cohort: string | null;
   setCohort: (cohort: string | null) => void;
+  cohortFilterSearch: string;
+  setCohortFilterSearch: (search: string) => void;
   courseId: string | undefined
 }
 
@@ -3093,6 +3099,8 @@ function EnrollmentsTable({
   version,
   cohort,
   setCohort,
+  cohortFilterSearch,
+  setCohortFilterSearch,
   courseId
 }: EnrollmentsTableProps) {
   const isInactiveTab = enrollmentTab === "INACTIVE"

--- a/frontend/src/app/pages/teacher/invite.tsx
+++ b/frontend/src/app/pages/teacher/invite.tsx
@@ -96,6 +96,7 @@ export default function InvitePage() {
   // exactly one cohort — course-wide access is granted by assigning cohorts on
   // the instructors page, not by inviting without one.
   const [cohort, setCohort] = useState<string | null>(null);
+  const [cohortSearch, setCohortSearch] = useState("");
 
   // handle edit or remove csv parsed emails starts
   const startEdit = (item: { id: string, email: string }) => {
@@ -830,6 +831,7 @@ const hasInvalidEmail = inviteEmails.some(
                 <Select
                   value={cohort ?? ""}
                   onValueChange={(value) => setCohort(value)}
+                  onOpenChange={(open) => { if (!open) setCohortSearch(""); }}
                 >
                   <SelectTrigger
                     aria-label="Cohort to invite into"
@@ -839,11 +841,26 @@ const hasInvalidEmail = inviteEmails.some(
                     <SelectValue placeholder="Select cohort *" />
                   </SelectTrigger>
                   <SelectContent>
-                    {courseVersion?.cohortDetails?.map((c) => (
-                      <SelectItem key={c.id} value={c.id}>
-                        {c.name}
-                      </SelectItem>
-                    ))}
+                    {(courseVersion?.cohortDetails?.length ?? 0) > 8 && (
+                      <div className="p-1">
+                        <Input
+                          placeholder="Search cohorts..."
+                          value={cohortSearch}
+                          onChange={(e) => setCohortSearch(e.target.value)}
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => e.stopPropagation()}
+                          className="h-8"
+                          autoFocus
+                        />
+                      </div>
+                    )}
+                    {courseVersion?.cohortDetails
+                      ?.filter((c) => c.name.toLowerCase().includes(cohortSearch.toLowerCase()))
+                      .map((c) => (
+                        <SelectItem key={c.id} value={c.id}>
+                          {c.name}
+                        </SelectItem>
+                      ))}
                     {canInviteAllCohorts && (
                       <SelectItem value={ALL_COHORTS}>All cohorts</SelectItem>
                     )}


### PR DESCRIPTION
Closes #1336

**Root cause fix:** both `CourseVersionService.ts` call sites that hydrate `cohortDetails` now pass `{ limit: readVersion.cohorts.length }` instead of relying on `getCohortsByIds`'s paginated-browser default, so every cohort actually referenced by the version is returned -- scales to any count, not a hardcoded number.

**Also added**, since the fix means large cohort lists now render in full: a search box on both cohort pickers affected by this bug (enrollments page filter, invite page selector), shown only once there are more than 8 cohorts, so scrolling through 100+ by hand isn't the only option.

Verified live at each step: reproduced the truncation via direct API call before the fix, confirmed `cohortDetails` length matches the real cohort count after, then verified both search boxes render and filter correctly against a real 14-cohort version -- including catching and fixing a real prop-threading bug in the enrollments page's implementation (`cohortFilterSearch` not passed down to the child component that actually renders the dropdown) before it ever reached users.

### Test plan
- [ ] `pnpm exec tsc --noEmit` in `frontend/` and `backend/`
- [ ] Confirm a course version with 11+ cohorts shows all of them in both the enrollments filter and invite selector
- [ ] Confirm the search box only appears once cohort count exceeds 8, and filters correctly