### PR TITLE
fix(auth): identify Google vs. email accounts in signup/login errors

### DIFF
--- a/backend/src/modules/auth/controllers/AuthController.ts
+++ b/backend/src/modules/auth/controllers/AuthController.ts
@@ -205,12 +205,26 @@ export class AuthController {
     const result = await data.json();
 
     if (!data.ok) {
-      // Firebase's client SDK collapses wrong-password and no-such-account
-      // into the same generic error for anyone but us (email enumeration
-      // protection) -- but it still tells the Admin SDK exactly which
-      // providers are on an account, so this is the only reliable place
-      // left to tell "wrong password" apart from "this account has no
-      // password credential" (e.g. it was created via Google Sign-In).
+      const errorReason = (result as {error?: {message?: string}})?.error?.message;
+
+      // These aren't credential mismatches -- treating them as one would
+      // both show a misleading message and run a needless provider lookup.
+      if (errorReason === 'USER_DISABLED') {
+        throw new HttpError(401, 'Your account has been disabled. Please contact support.');
+      }
+      if (errorReason === 'TOO_MANY_ATTEMPTS_TRY_LATER') {
+        throw new HttpError(429, 'Too many failed attempts. Please try again later.');
+      }
+
+      // Every other failure here (EMAIL_NOT_FOUND, INVALID_PASSWORD, or the
+      // unified INVALID_LOGIN_CREDENTIALS Firebase now returns for both) is a
+      // credential mismatch. Firebase's client SDK collapses wrong-password
+      // and no-such-account into the same generic error for anyone but us
+      // (email enumeration protection) -- but the Admin SDK still tells us
+      // exactly which providers are on an account, so this is the only
+      // reliable place left to tell "wrong password" apart from "this
+      // account has no password credential" (e.g. it was created via
+      // Google Sign-In).
       const providers = await this.authService.getSignInProviders(email);
       if (providers.length > 0 && !providers.includes('password')) {
         const provider = providers.includes('google.com') ? 'Google Sign-In' : providers[0];

--- a/backend/src/modules/auth/controllers/AuthController.ts
+++ b/backend/src/modules/auth/controllers/AuthController.ts
@@ -204,6 +204,24 @@ export class AuthController {
     );
     const result = await data.json();
 
+    if (!data.ok) {
+      // Firebase's client SDK collapses wrong-password and no-such-account
+      // into the same generic error for anyone but us (email enumeration
+      // protection) -- but it still tells the Admin SDK exactly which
+      // providers are on an account, so this is the only reliable place
+      // left to tell "wrong password" apart from "this account has no
+      // password credential" (e.g. it was created via Google Sign-In).
+      const providers = await this.authService.getSignInProviders(email);
+      if (providers.length > 0 && !providers.includes('password')) {
+        const provider = providers.includes('google.com') ? 'Google Sign-In' : providers[0];
+        throw new HttpError(
+          401,
+          `This email is registered with ${provider}. Please use that to sign in instead.`,
+        );
+      }
+      throw new HttpError(401, 'Incorrect email or password. Please try again.');
+    }
+
     // ✅ fetch your app user from DB
     // const user = await this.authService.getCurrentUserFromToken(result.idToken);
     return result;

--- a/backend/src/modules/auth/interfaces/IAuthService.ts
+++ b/backend/src/modules/auth/interfaces/IAuthService.ts
@@ -63,6 +63,17 @@ export interface IAuthService {
    * viewer can call the normal APIs without signing up.
    */
   createCustomToken(firebaseUID: string): Promise<string>;
+
+  /**
+   * Looks up which sign-in providers (e.g. 'password', 'google.com') are
+   * linked to a Firebase account by email, using the Admin SDK -- unlike the
+   * client SDK's fetchSignInMethodsForEmail, this isn't subject to Firebase's
+   * email enumeration protection, so it's the only reliable way left to tell
+   * "wrong password" apart from "this account has no password credential"
+   * (e.g. it was created via Google Sign-In). Returns an empty array if no
+   * account exists for that email.
+   */
+  getSignInProviders(email: string): Promise<string[]>;
 }
 
 /**

--- a/backend/src/modules/auth/services/FirebaseAuthService.ts
+++ b/backend/src/modules/auth/services/FirebaseAuthService.ts
@@ -474,4 +474,17 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
       );
     }
   }
+
+  async getSignInProviders(email: string): Promise<string[]> {
+    try {
+      const userRecord = await this.auth.getUserByEmail(email);
+      return userRecord.providerData.map(provider => provider.providerId);
+    } catch (error: any) {
+      if (error?.code === 'auth/user-not-found') {
+        return [];
+      }
+      console.error('Failed to look up sign-in providers:', error);
+      return [];
+    }
+  }
 }

--- a/backend/src/modules/auth/services/FirebaseAuthService.ts
+++ b/backend/src/modules/auth/services/FirebaseAuthService.ts
@@ -190,7 +190,16 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
     // ==========================================================
     const existingUser = await this.userRepository.findByEmail(body.email);
     if (existingUser) {
-      throw new InternalServerError('User with this email already exists');
+      const providers = await this.getSignInProviders(body.email);
+      if (providers.length > 0 && !providers.includes('password')) {
+        const provider = providers.includes('google.com') ? 'Google Sign-In' : providers[0];
+        throw new InternalServerError(
+          `This email already has an account via ${provider}. Please use that to sign in instead.`,
+        );
+      }
+      throw new InternalServerError(
+        'An account with this email already exists. Please sign in instead.',
+      );
     }
 
     let userRecord: any;

--- a/backend/src/modules/auth/services/FirebaseAuthService.ts
+++ b/backend/src/modules/auth/services/FirebaseAuthService.ts
@@ -190,14 +190,17 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
     // ==========================================================
     const existingUser = await this.userRepository.findByEmail(body.email);
     if (existingUser) {
+      // A duplicate email is a normal user-driven validation failure, not a
+      // server fault -- a 4xx here (rather than the 500 this used to throw)
+      // lets the frontend treat it as an expected auth/validation error.
       const providers = await this.getSignInProviders(body.email);
       if (providers.length > 0 && !providers.includes('password')) {
         const provider = providers.includes('google.com') ? 'Google Sign-In' : providers[0];
-        throw new InternalServerError(
+        throw new BadRequestError(
           `This email already has an account via ${provider}. Please use that to sign in instead.`,
         );
       }
-      throw new InternalServerError(
+      throw new BadRequestError(
         'An account with this email already exists. Please sign in instead.',
       );
     }

--- a/frontend/src/app/pages/auth-page.tsx
+++ b/frontend/src/app/pages/auth-page.tsx
@@ -806,6 +806,30 @@ export default function AuthPage() {
                                     {loading ? "Creating account..." : "Create Account"}
                                   </Button>
                                 </div>
+
+                                <div className="relative my-6">
+                                  <div className="relative flex justify-center text-xs uppercase">
+                                    <span className="text-[rgb(52,152,169)] text-xl font-semibold">
+                                      OR
+                                    </span>
+                                  </div>
+                                </div>
+                                <div className="w-full max-w-[294px] mx-auto">
+                                  <Button
+                                    variant="outline"
+                                    className="w-full h-16 text-lg font-semibold !bg-[rgb(52,152,169)] hover:!bg-[rgb(102,187,205)] text-white border-0 shadow-[0_2px_8px_rgba(52,152,169,0.3)] hover:shadow-[0_4px_16px_rgba(52,152,169,0.4)] hover:-translate-y-0.5 transition-all duration-300"
+                                    onClick={handleGoogleLogin}
+                                    disabled={loading}
+                                  >
+                                    <svg className="mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+                                      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                                      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                                      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+                                    </svg>
+                                    Continue with Google
+                                  </Button>
+                                </div>
                               </CardContent>
 
                               <CardFooter className="pt-5 md:px-20 px-5">

--- a/frontend/src/app/pages/auth-page.tsx
+++ b/frontend/src/app/pages/auth-page.tsx
@@ -270,7 +270,7 @@ export default function AuthPage() {
 
   //SignUp
 
-  const { mutateAsync: signupMutation, error: signupError, isError: isSignUpError } = useSignup();
+  const { mutateAsync: signupMutation } = useSignup();
 
   // New function for handling signup
   const handleEmailSignup = async () => {
@@ -303,14 +303,42 @@ export default function AuthPage() {
       const firstName = nameParts[0] || '';
       const lastName = nameParts.length > 1 ? nameParts.slice(1).join(' ') : ' ';
 
-      await signupMutation({
-        body: {
-          email: email,
-          password: password,
-          firstName: firstName,
-          lastName: lastName
+      try {
+        await signupMutation({
+          body: {
+            email: email,
+            password: password,
+            firstName: firstName,
+            lastName: lastName
+          }
+        });
+      } catch (mutationError: any) {
+        // Caught locally (rather than read off the useSignup() hook's error/isError
+        // state) because that hook state is stale across attempts: it only updates
+        // when mutateAsync is called, so a later attempt that fails before ever
+        // reaching signupMutation (e.g. a Firebase-level auth/email-already-in-use)
+        // would otherwise still see isError=true from this mutation's *previous*
+        // failure and show its stale message instead of the real one.
+        let message = "";
+        if (mutationError?.message === "Invalid body, check 'errors' property for more info.") {
+          for (const err of mutationError?.errors || []) {
+            message += `${Object.values(err.constraints).join(', ')}`;
+          }
+        } else {
+          message = mutationError?.message || "An error occurred during signup";
         }
-      });
+
+        setFormErrors({
+          ...formErrors,
+          auth: message || "Failed to create account. Please try again.",
+          email: Object.values(mutationError?.errors?.find((e: any) => e.property === 'email')?.constraints || {}).join(', ') || "",
+          fullName:
+            (Object.values(mutationError?.errors?.find((e: any) => e.property === 'firstName')?.constraints || {}).join(', ') +
+              (Object.values(mutationError?.errors?.find((e: any) => e.property === 'lastName')?.constraints || {}).join(', '))).trim() || "",
+          password: Object.values(mutationError?.errors?.find((e: any) => e.property === 'password')?.constraints || {}).join(', ') || ""
+        });
+        return;
+      }
       // const result = await loginWithEmail(email, password);
 
       const token = await result.user.getIdToken();
@@ -334,36 +362,15 @@ export default function AuthPage() {
       navigate({ to: "/student" });
 
     } catch (error: any) {
+      // Firebase-level failures land here (e.g. auth/email-already-in-use for a
+      // retried signup) -- backend-mutation failures are handled in the inner
+      // catch above instead, so this branch's message is never masked by a
+      // stale error from a previous attempt.
       console.error("Email Signup Failed", error);
-      console.log(signupError, isSignUpError);
-      if (isSignUpError) {
-        let message = "";
-        if (signupError?.message === "Invalid body, check 'errors' property for more info.") {
-          for (const error of signupError?.errors || []) {
-            message += `${Object.values(error.constraints).join(', ')}`;
-          }
-        }
-        else message = signupError?.message || "An error occurred during signup";
-
-        setFormErrors({
-          ...formErrors,
-          auth: message || "Failed to create account. Please try again.",
-          email: Object.values(signupError?.errors?.find((e: any) => e.property === 'email')?.constraints || {}).join(', ') || "",
-          fullName:
-            (Object.values(signupError?.errors?.find((e: any) => e.property === 'firstName')?.constraints || {}).join(', ') +
-              (Object.values(signupError?.errors?.find((e: any) => e.property === 'lastName')?.constraints || {}).join(', '))).trim() || "",
-          password: Object.values(signupError?.errors?.find((e: any) => e.property === 'password')?.constraints || {}).join(', ') || ""
-        });
-      } else {
-        // Firebase itself rejected the signup (e.g. auth/email-already-in-use for a
-        // retried signup) before the backend mutation ever ran, so isSignUpError is
-        // false here -- this branch was previously silent, leaving the user with no
-        // feedback at all beyond the spinner stopping.
-        setFormErrors({
-          ...formErrors,
-          auth: error?.message || "Failed to create account. Please try again."
-        });
-      }
+      setFormErrors({
+        ...formErrors,
+        auth: error?.message || "Failed to create account. Please try again."
+      });
     } finally {
       setLoading(false);
     }

--- a/frontend/src/app/pages/auth-page.tsx
+++ b/frontend/src/app/pages/auth-page.tsx
@@ -257,11 +257,11 @@ export default function AuthPage() {
       });
 
       navigate({ to: `/${activeRole}` });
-    } catch (error) {
+    } catch (error: any) {
       console.error("Email Login Failed", error);
       setFormErrors({
         ...formErrors,
-        auth: "Invalid email or password. Please try again."
+        auth: error?.message || "Invalid email or password. Please try again."
       });
     } finally {
       setLoading(false);
@@ -353,6 +353,15 @@ export default function AuthPage() {
             (Object.values(signupError?.errors?.find((e: any) => e.property === 'firstName')?.constraints || {}).join(', ') +
               (Object.values(signupError?.errors?.find((e: any) => e.property === 'lastName')?.constraints || {}).join(', '))).trim() || "",
           password: Object.values(signupError?.errors?.find((e: any) => e.property === 'password')?.constraints || {}).join(', ') || ""
+        });
+      } else {
+        // Firebase itself rejected the signup (e.g. auth/email-already-in-use for a
+        // retried signup) before the backend mutation ever ran, so isSignUpError is
+        // false here -- this branch was previously silent, leaving the user with no
+        // feedback at all beyond the spinner stopping.
+        setFormErrors({
+          ...formErrors,
+          auth: error?.message || "Failed to create account. Please try again."
         });
       }
     } finally {

--- a/frontend/src/app/pages/auth-page.tsx
+++ b/frontend/src/app/pages/auth-page.tsx
@@ -261,7 +261,17 @@ export default function AuthPage() {
       console.error("Email Login Failed", error);
       setFormErrors({
         ...formErrors,
-        auth: error?.message || "Invalid email or password. Please try again."
+        auth: (() => {
+          // loginWithEmail (lib/firebase.ts) produces this specific message
+          // when it detects the account only has a Google credential --
+          // prefer it. Otherwise, an error with a Firebase .code is the raw
+          // SDK error (e.g. "Firebase: Error (auth/invalid-credential)."),
+          // which isn't something to show a user directly.
+          if (typeof error?.message === "string" && error.message.startsWith("This email is registered with")) return error.message;
+          if (error?.code === "auth/too-many-requests") return "Too many attempts. Please wait a moment and try again.";
+          if (error?.code) return "Invalid email or password. Please try again.";
+          return error?.message || "Invalid email or password. Please try again.";
+        })()
       });
     } finally {
       setLoading(false);

--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -816,6 +816,10 @@ export default function AuthPage({ role }: AuthPageProps) {
         ...formErrors,
         auth: (() => {
           const code = (error as any)?.code;
+          // loginWithEmail (lib/firebase.ts) already produces this specific message
+          // when it detects the account only has a Google credential -- prefer it
+          // over the generic per-code messages below.
+          if (typeof error?.message === "string" && error.message.startsWith("This email is registered with")) return error.message;
           if (code === "auth/invalid-credential" || code === "auth/wrong-password" || code === "auth/user-not-found") return "Incorrect email or password. Please try again.";
           if (code === "auth/too-many-requests") return "Too many failed attempts. Please try again later.";
           if (code === "auth/user-disabled") return "Your account has been disabled. Please contact support.";
@@ -830,7 +834,7 @@ export default function AuthPage({ role }: AuthPageProps) {
 
   //SignUp
 
-  const { mutateAsync: signupMutation, error: signupError, isError: isSignUpError } = useSignup();
+  const { mutateAsync: signupMutation } = useSignup();
 
   // New function for handling signup
   const handleEmailSignup = async () => {
@@ -887,17 +891,45 @@ export default function AuthPage({ role }: AuthPageProps) {
       const firstName = nameParts[0] || '';
       const lastName = nameParts.length > 1 ? nameParts.slice(1).join(' ') : ' ';
 
-      await signupMutation({
-        body: {
-          email: email,
-          password: password,
-          firstName: firstName,
-          lastName: lastName,
-          recaptchaToken: isRecaptchaEnabled ? recaptchaToken : "NO_CAPTCHA",
-          profileImage,
-          faceEmbedding,
+      try {
+        await signupMutation({
+          body: {
+            email: email,
+            password: password,
+            firstName: firstName,
+            lastName: lastName,
+            recaptchaToken: isRecaptchaEnabled ? recaptchaToken : "NO_CAPTCHA",
+            profileImage,
+            faceEmbedding,
+          }
+        });
+      } catch (mutationError: any) {
+        // Caught locally (rather than read off the useSignup() hook's error/isError
+        // state) because that hook state is stale across attempts: it only updates
+        // when mutateAsync is called, so a later attempt that fails after this step
+        // (e.g. the loginWithEmail call below) would otherwise still see isError=true
+        // from this mutation's *previous* failure and show its stale message instead
+        // of the real one.
+        let message = "";
+        if (mutationError?.message === "Invalid body, check 'errors' property for more info.") {
+          for (const err of mutationError?.errors || []) {
+            message += `${Object.values(err.constraints).join(', ')}`;
+          }
+        } else {
+          message = mutationError?.message || "An error occurred during signup";
         }
-      });
+
+        setFormErrors({
+          ...formErrors,
+          auth: message || "Failed to create account. Please try again.",
+          email: Object.values(mutationError?.errors?.find((e: any) => e.property === 'email')?.constraints || {}).join(', ') || "",
+          fullName:
+            (Object.values(mutationError?.errors?.find((e: any) => e.property === 'firstName')?.constraints || {}).join(', ') +
+              (Object.values(mutationError?.errors?.find((e: any) => e.property === 'lastName')?.constraints || {}).join(', '))).trim() || "",
+          password: Object.values(mutationError?.errors?.find((e: any) => e.property === 'password')?.constraints || {}).join(', ') || ""
+        });
+        return;
+      }
       const result = await loginWithEmail(email, password);
 
       // Set user in store
@@ -920,27 +952,15 @@ export default function AuthPage({ role }: AuthPageProps) {
       }
 
     } catch (error: any) {
+      // Reaches here only if loginWithEmail (the step right after a successful
+      // signupMutation) itself fails -- backend-mutation failures are handled in
+      // the inner catch above instead, so this message is never masked by a stale
+      // error from a previous attempt.
       console.error("Email Signup Failed", error);
-      console.log(signupError, isSignUpError);
-      if (isSignUpError) {
-        let message = "";
-        if (signupError?.message === "Invalid body, check 'errors' property for more info.") {
-          for (const error of signupError?.errors || []) {
-            message += `${Object.values(error.constraints).join(', ')}`;
-          }
-        }
-        else message = signupError?.message || "An error occurred during signup";
-
-        setFormErrors({
-          ...formErrors,
-          auth: message || "Failed to create account. Please try again.",
-          email: Object.values(signupError?.errors?.find((e: any) => e.property === 'email')?.constraints || {}).join(', ') || "",
-          fullName:
-            (Object.values(signupError?.errors?.find((e: any) => e.property === 'firstName')?.constraints || {}).join(', ') +
-              (Object.values(signupError?.errors?.find((e: any) => e.property === 'lastName')?.constraints || {}).join(', '))).trim() || "",
-          password: Object.values(signupError?.errors?.find((e: any) => e.property === 'password')?.constraints || {}).join(', ') || ""
-        });
-      }
+      setFormErrors({
+        ...formErrors,
+        auth: error?.message || "Failed to create account. Please try again."
+      });
     } finally {
       setLoading(false);
     }
@@ -1723,6 +1743,34 @@ export default function AuthPage({ role }: AuthPageProps) {
                         disabled={!passwordsMatch || passwordStrength.value < 50 || loading || (!recaptchaToken && isRecaptchaEnabled)}
                       >
                         {loading ? "Creating account..." : "Create Account"}
+                      </Button>
+
+                      {/* Divider */}
+                      <div className="relative my-6">
+                        <div className="absolute inset-0 flex items-center">
+                          <Separator />
+                        </div>
+                        <div className="relative flex justify-center text-xs uppercase">
+                          <span className="bg-background px-2 text-muted-foreground">
+                            or continue with
+                          </span>
+                        </div>
+                      </div>
+
+                      {/* Google Signup */}
+                      <Button
+                        variant="outline"
+                        className="w-full h-11 font-medium border-2 hover:bg-muted/50 transition-all duration-200"
+                        onClick={handleGoogleLogin}
+                        disabled={loading}
+                      >
+                        <svg className="mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+                          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+                        </svg>
+                        Continue with Google
                       </Button>
                     </CardContent>
 

--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -816,10 +816,13 @@ export default function AuthPage({ role }: AuthPageProps) {
         ...formErrors,
         auth: (() => {
           const code = (error as any)?.code;
-          // loginWithEmail (lib/firebase.ts) already produces this specific message
-          // when it detects the account only has a Google credential -- prefer it
-          // over the generic per-code messages below.
-          if (typeof error?.message === "string" && error.message.startsWith("This email is registered with")) return error.message;
+          // Errors thrown from the backend /auth/login response never carry a
+          // Firebase .code (only client SDK errors do) and already have a
+          // human-friendly message -- including the Google-only-account case,
+          // which the backend can now detect reliably via the Admin SDK
+          // (unlike the client SDK, which Firebase's email enumeration
+          // protection prevents from telling us anything useful here).
+          if (!code && typeof error?.message === "string" && error.message.length > 0) return error.message;
           if (code === "auth/invalid-credential" || code === "auth/wrong-password" || code === "auth/user-not-found") return "Incorrect email or password. Please try again.";
           if (code === "auth/too-many-requests") return "Too many failed attempts. Please try again later.";
           if (code === "auth/user-disabled") return "Your account has been disabled. Please contact support.";

--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -820,6 +820,12 @@ export default function AuthPage({ role }: AuthPageProps) {
         ...formErrors,
         auth: (() => {
           const code = (error as any)?.code;
+          // A failed fetch() itself (offline, DNS failure, ...) throws a
+          // TypeError with no .code either, same shape as our own backend
+          // errors below -- but its message ("Failed to fetch") is a raw
+          // browser string, not something to show a user. Route it to the
+          // network message instead of the "trust the message" branch.
+          if (error instanceof TypeError) return "Network error. Please check your connection and try again.";
           // Errors thrown from the backend /auth/login response never carry a
           // Firebase .code (only client SDK errors do) and already have a
           // human-friendly message -- including the Google-only-account case,

--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -521,7 +521,11 @@ export default function AuthPage({ role }: AuthPageProps) {
     else if (!/\S+@\S+\.\S+/.test(email)) errors.email = "Invalid email format";
 
     if (!password) errors.password = "Password is required";
-    else if (isSignUp && password.length < 8) errors.password = "Password must be at least 8 characters";
+    // The backend's LoginBody requires 8+ characters too (every real account's
+    // password is at least that long, enforced at signup), so a shorter one is
+    // guaranteed wrong either way -- catch it here instead of round-tripping to
+    // the backend just to get its raw validation-framework message back.
+    else if (password.length < 8) errors.password = "Password must be at least 8 characters";
 
     if (isSignUp && !fullName) errors.fullName = "Full name is required";
 

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -55,25 +55,27 @@ export const loginWithGoogle = async () => {
  * security (so a failed login can't be used to probe which emails are
  * registered). fetchSignInMethodsForEmail is the supported way to still
  * give an accurate, helpful message in that specific case.
+ *
+ * Returns null when there's nothing more specific to say than the original
+ * error already conveys, so callers can fall back to their own handling
+ * (several callers switch on error.code themselves) instead of this
+ * silently overwriting a message they already handle better.
  */
-const describeEmailAuthError = async (email: string, error: any): Promise<string> => {
+const describeGoogleOnlyAccountError = async (email: string, error: any): Promise<string | null> => {
   const code = error?.code;
-  if (code === 'auth/user-not-found' || code === 'auth/invalid-credential' || code === 'auth/wrong-password') {
-    try {
-      const methods = await fetchSignInMethodsForEmail(auth, email);
-      if (methods.length > 0 && !methods.includes('password')) {
-        const provider = methods.includes('google.com') ? 'Google Sign-In' : methods[0];
-        return `This email is registered with ${provider}. Please use that to sign in instead.`;
-      }
-    } catch {
-      // Best-effort -- fall through to the generic message below if this lookup itself fails.
+  if (code !== 'auth/user-not-found' && code !== 'auth/invalid-credential' && code !== 'auth/wrong-password') {
+    return null;
+  }
+  try {
+    const methods = await fetchSignInMethodsForEmail(auth, email);
+    if (methods.length > 0 && !methods.includes('password')) {
+      const provider = methods.includes('google.com') ? 'Google Sign-In' : methods[0];
+      return `This email is registered with ${provider}. Please use that to sign in instead.`;
     }
-    return 'Invalid email or password. Please try again.';
+  } catch {
+    // Best-effort -- fall through to null if this lookup itself fails.
   }
-  if (code === 'auth/too-many-requests') {
-    return 'Too many attempts. Please wait a moment and try again.';
-  }
-  return 'Invalid email or password. Please try again.';
+  return null;
 };
 
 export const loginWithEmail = async (email: string, password: string) => {
@@ -88,7 +90,15 @@ export const loginWithEmail = async (email: string, password: string) => {
 
     return result;
   } catch (error: any) {
-    throw new Error(await describeEmailAuthError(email, error));
+    const message = await describeGoogleOnlyAccountError(email, error);
+    if (message) {
+      // Preserve the original code so callers with their own code-based
+      // error handling (there are a couple) still see a recognizable error.
+      const wrapped = new Error(message);
+      (wrapped as any).code = error?.code;
+      throw wrapped;
+    }
+    throw error;
   }
 };
 
@@ -109,13 +119,19 @@ export const createUserWithEmail = async (email: string, password: string, displ
       } catch {
         // Best-effort -- fall back to the generic message above if this lookup itself fails.
       }
-      throw new Error(message);
+      const wrapped = new Error(message);
+      (wrapped as any).code = error.code;
+      throw wrapped;
     }
-    if (error?.code === 'auth/weak-password') {
-      throw new Error('Password is too weak. Please choose a stronger password.');
-    }
-    if (error?.code === 'auth/invalid-email') {
-      throw new Error('Invalid email address.');
+    if (error?.code === 'auth/weak-password' || error?.code === 'auth/invalid-email') {
+      // Firebase's own default message for these is a raw "Firebase: Error
+      // (auth/weak-password)." string, not something to show a user.
+      const message = error.code === 'auth/weak-password'
+        ? 'Password is too weak. Please choose a stronger password.'
+        : 'Invalid email address.';
+      const wrapped = new Error(message);
+      (wrapped as any).code = error.code;
+      throw wrapped;
     }
     throw error;
   }

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -1,16 +1,17 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
-import { getAuth, 
-  GoogleAuthProvider, 
-  signInWithPopup, 
-  signInWithEmailAndPassword, 
-  signOut, 
-  createUserWithEmailAndPassword, 
-  updateProfile, 
+import { getAuth,
+  GoogleAuthProvider,
+  signInWithPopup,
+  signInWithEmailAndPassword,
+  signOut,
+  createUserWithEmailAndPassword,
+  updateProfile,
   sendPasswordResetEmail as firebaseSendPasswordResetEmail,
   confirmPasswordReset,
-  verifyPasswordResetCode } from "firebase/auth";
+  verifyPasswordResetCode,
+  fetchSignInMethodsForEmail } from "firebase/auth";
 import { useAuthStore } from "../store/auth-store";
 import { useLoginWithGoogle } from "@/hooks/hooks";
 
@@ -47,30 +48,85 @@ export const loginWithGoogle = async () => {
   return result;
 };
 
+/**
+ * `signInWithEmailAndPassword` alone can't tell "wrong password" apart from
+ * "this email only has a Google account" -- recent Firebase Auth versions
+ * collapse both into the same generic auth/invalid-credential error for
+ * security (so a failed login can't be used to probe which emails are
+ * registered). fetchSignInMethodsForEmail is the supported way to still
+ * give an accurate, helpful message in that specific case.
+ */
+const describeEmailAuthError = async (email: string, error: any): Promise<string> => {
+  const code = error?.code;
+  if (code === 'auth/user-not-found' || code === 'auth/invalid-credential' || code === 'auth/wrong-password') {
+    try {
+      const methods = await fetchSignInMethodsForEmail(auth, email);
+      if (methods.length > 0 && !methods.includes('password')) {
+        const provider = methods.includes('google.com') ? 'Google Sign-In' : methods[0];
+        return `This email is registered with ${provider}. Please use that to sign in instead.`;
+      }
+    } catch {
+      // Best-effort -- fall through to the generic message below if this lookup itself fails.
+    }
+    return 'Invalid email or password. Please try again.';
+  }
+  if (code === 'auth/too-many-requests') {
+    return 'Too many attempts. Please wait a moment and try again.';
+  }
+  return 'Invalid email or password. Please try again.';
+};
+
 export const loginWithEmail = async (email: string, password: string) => {
-  const result = await signInWithEmailAndPassword(auth, email, password);
-  
-  // Get ID token for backend authentication
-  const idToken = await result.user.getIdToken();
-  
-  // Store the token
-  useAuthStore.getState().setToken(idToken);
-  
-  return result;
+  try {
+    const result = await signInWithEmailAndPassword(auth, email, password);
+
+    // Get ID token for backend authentication
+    const idToken = await result.user.getIdToken();
+
+    // Store the token
+    useAuthStore.getState().setToken(idToken);
+
+    return result;
+  } catch (error: any) {
+    throw new Error(await describeEmailAuthError(email, error));
+  }
 };
 
 // Add a function to create a user with email and password
 export const createUserWithEmail = async (email: string, password: string, displayName?: string) => {
   const auth = getAuth(app);
-  const userCredential = await createUserWithEmailAndPassword(auth, email, password);
-  
+  let userCredential;
+  try {
+    userCredential = await createUserWithEmailAndPassword(auth, email, password);
+  } catch (error: any) {
+    if (error?.code === 'auth/email-already-in-use') {
+      let message = 'An account with this email already exists. Please sign in instead.';
+      try {
+        const methods = await fetchSignInMethodsForEmail(auth, email);
+        if (methods.includes('google.com') && !methods.includes('password')) {
+          message = 'This email already has an account via Google Sign-In. Please use "Continue with Google" instead.';
+        }
+      } catch {
+        // Best-effort -- fall back to the generic message above if this lookup itself fails.
+      }
+      throw new Error(message);
+    }
+    if (error?.code === 'auth/weak-password') {
+      throw new Error('Password is too weak. Please choose a stronger password.');
+    }
+    if (error?.code === 'auth/invalid-email') {
+      throw new Error('Invalid email address.');
+    }
+    throw error;
+  }
+
   // Update user profile if display name is provided
   if (displayName && userCredential.user) {
     await updateProfile(userCredential.user, {
       displayName
     });
   }
-  
+
   return userCredential;
 };
 

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -53,8 +53,14 @@ export const loginWithGoogle = async () => {
  * "this email only has a Google account" -- recent Firebase Auth versions
  * collapse both into the same generic auth/invalid-credential error for
  * security (so a failed login can't be used to probe which emails are
- * registered). fetchSignInMethodsForEmail is the supported way to still
- * give an accurate, helpful message in that specific case.
+ * registered). fetchSignInMethodsForEmail is the *documented* way to try to
+ * tell them apart, but it's best-effort only: projects with Firebase's email
+ * enumeration protection enabled make it return an empty list unconditionally,
+ * same as the error code above -- when that happens this silently returns
+ * null (see below) rather than claiming an answer it doesn't have. The
+ * backend's Admin-SDK-based lookup (FirebaseAuthService.getSignInProviders)
+ * is not subject to that restriction and is the reliable version of this
+ * check; this client-side one is a nice-to-have on top when it works.
  *
  * Returns null when there's nothing more specific to say than the original
  * error already conveys, so callers can fall back to their own handling


### PR DESCRIPTION
Closes #1341

## Summary

- Signup no longer silently swallows an error when the account is created but a later step fails.
- Fixed a stale-state bug where the signup form's error handling could show a previous attempt's message instead of the current one.
- Login's `/auth/login` endpoint now actually checks the Firebase REST call's result instead of always returning 200 regardless of success.
- Both login and signup now use `FirebaseAuthService.getSignInProviders` (Admin SDK, not subject to email enumeration protection) to tell the user when an email is already registered via Google Sign-In, instead of a generic "incorrect password" / "already exists" message.
- Added a "Continue with Google" option to the signup card (previously only the login card had it).
- Login's client-side validation now enforces the same 8-character password minimum signup does, instead of round-tripping to the backend for its raw validation-framework message.

## Test plan

- [x] `tsc --noEmit` passes for both `backend` and `frontend`
- [x] Verified live on a fork deployment: retry-signup with an already-registered email now shows a clear message; login with a Google-only account's email shows "This email is registered with Google Sign-In..."; login with a too-short password is caught client-side
- [x] Reviewer: spot-check the teacher-role signup/login forms too, since they share this component