### PR TITLE
fix(progress): match cohortId tolerant of both string and ObjectId (main-v1 backport)

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -136,6 +136,23 @@ class ProgressRepository {
     }
   }
 
+  /**
+   * Some older/externally-written progress and watchTime records have
+   * cohortId stored as a plain string instead of ObjectId (unlike
+   * userId/courseId/courseVersionId, which every query here already
+   * matches with the same $in-both-types tolerance). Matching cohortId by
+   * strict equality against ObjectId alone makes those records silently
+   * invisible to every cohort-scoped query. This mirrors the tolerant
+   * pattern already used for the other ID fields.
+   *
+   * Takes only the truthy-cohortId match value -- callers keep their own
+   * ternary/else-branch (some fall back to {}, some to {cohortId: null}),
+   * this only fixes the truthy side.
+   */
+  private cohortIdMatch(cohortId: string): { cohortId: { $in: (string | ObjectId)[] } } {
+    return { cohortId: { $in: [cohortId, new ObjectId(cohortId)] } };
+  }
+
   async getCompletedItems(
     userId: string,
     courseId: string,
@@ -153,7 +170,7 @@ class ProgressRepository {
         courseVersionId: new ObjectId(courseVersionId),
         endTime: { $exists: true, $ne: null },
         isDeleted: { $ne: true },
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {cohortId: null }),
+        ...(cohortId ? this.cohortIdMatch(cohortId) : {cohortId: null }),
       },
       { session },
     );
@@ -219,7 +236,7 @@ class ProgressRepository {
           userId: new ObjectId(userId),
           courseId: new ObjectId(courseId),
           courseVersionId: new ObjectId(courseVersionId),
-          ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
+          ...(cohortId ? this.cohortIdMatch(cohortId) : {}),
           itemId: new ObjectId(itemId),
           endTime: { $exists: true, $ne: null },
           isDeleted: { $ne: true },
@@ -355,7 +372,7 @@ class ProgressRepository {
         userId: new ObjectId(userId),
         courseId: new ObjectId(courseId),
         courseVersionId: new ObjectId(courseVersionId),
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {cohortId: null }),
+        ...(cohortId ? this.cohortIdMatch(cohortId) : {cohortId: null }),
       },
       { $set: { isDeleted: true, deletedAt: new Date() } },
       { session },
@@ -434,7 +451,7 @@ class ProgressRepository {
           {
             userId: { $in: [userIdStr, userIdObj] },
             quizId: { $in: [quizIdStr, quizIdObj] },
-            ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {cohortId: null}),
+            ...(cohortId ? this.cohortIdMatch(cohortId) : {cohortId: null}),
           },
           { session },
         )
@@ -450,7 +467,7 @@ class ProgressRepository {
           filter: {
             userId: { $in: [userIdStr, userIdObj] },
             quizId: { $in: [quizIdStr, quizIdObj] },
-            ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {cohortId: null }),
+            ...(cohortId ? this.cohortIdMatch(cohortId) : {cohortId: null }),
           },
         },
       });
@@ -461,7 +478,7 @@ class ProgressRepository {
           filter: {
             quizId: { $in: [quizIdStr, quizIdObj] },
             userId: { $in: [userIdStr, userIdObj] },
-            ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {cohortId: null}),
+            ...(cohortId ? this.cohortIdMatch(cohortId) : {cohortId: null}),
           },
           update: {
             $set: {
@@ -526,7 +543,7 @@ class ProgressRepository {
         courseId: { $in: [new ObjectId(courseId), courseId] },
         courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
         isDeleted: { $ne: true },
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
+        ...(cohortId ? this.cohortIdMatch(cohortId) : {}),
       },
       {
         session,
@@ -602,7 +619,7 @@ class ProgressRepository {
         userId: { $in: [new ObjectId(userId), userId] },
         courseId: { $in: [new ObjectId(courseId), courseId] },
         courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
+        ...(cohortId ? this.cohortIdMatch(cohortId) : {}),
         isDeleted: { $ne: true },
       },
       { $set: normalizedProgress },
@@ -631,7 +648,7 @@ class ProgressRepository {
         userId: { $in: [new ObjectId(userId), userId] },
         courseId: { $in: [new ObjectId(courseId), courseId] },
         courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
+        ...(cohortId ? this.cohortIdMatch(cohortId) : {}),
         isDeleted: { $ne: true },
       },
       {
@@ -818,7 +835,7 @@ class ProgressRepository {
       query.courseVersionId = new ObjectId(courseVersionId);
     }
     if (cohortId) {
-      query.cohortId = new ObjectId(cohortId);
+      Object.assign(query, this.cohortIdMatch(cohortId));
     } else {
       query.$or = [
         { cohortId: null },
@@ -871,10 +888,20 @@ class ProgressRepository {
         userId: { $in: [new ObjectId(userId), userId] },
         courseId: { $in: [new ObjectId(courseId), courseId] },
         courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
+        ...(cohortId ? this.cohortIdMatch(cohortId) : {}),
         isDeleted: { $ne: true },
       },
-      { $set: progress },
+      {
+        $set: {
+          ...progress,
+          // Mongo only auto-populates an upserted document's fields from
+          // filter conditions that are plain equality -- the $in match above
+          // (needed to also find string-typed legacy cohortId values) isn't
+          // one, so without this a newly-inserted doc would end up with no
+          // cohortId at all.
+          ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
+        },
+      },
       {
         upsert: true, // ⭐ creates document if not found
         returnDocument: 'after', // return updated or inserted doc
@@ -931,7 +958,7 @@ class ProgressRepository {
             $match: {
               courseId: new ObjectId(courseId),
               courseVersionId: new ObjectId(courseVersionId),
-              ...(cohortId ? { cohortId: new ObjectId(cohortId) } : { cohortId: null }),
+              ...(cohortId ? this.cohortIdMatch(cohortId) : { cohortId: null }),
               isDeleted: { $ne: true },
               endTime: { $gte: since, $ne: null },
             },
@@ -991,7 +1018,7 @@ class ProgressRepository {
             $match: {
               courseId: new ObjectId(courseId),
               courseVersionId: new ObjectId(courseVersionId),
-              ...(cohortId ? { cohortId: new ObjectId(cohortId) } : { cohortId: null }),
+              ...(cohortId ? this.cohortIdMatch(cohortId) : { cohortId: null }),
               isDeleted: { $ne: true },
               startTime: { $ne: null, $exists: true },
             },
@@ -1030,7 +1057,7 @@ class ProgressRepository {
         {
           courseId: { $in: [new ObjectId(courseId), courseId] },
           courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
-          ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {cohortId: null}),
+          ...(cohortId ? this.cohortIdMatch(cohortId) : {cohortId: null}),
         },
         { session },
       )
@@ -1141,7 +1168,7 @@ class ProgressRepository {
       {
         userId: { $in: [new ObjectId(userId), userId] },
         courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
-        ...(cohort ? { cohortId: new ObjectId(cohort) } : {}),
+        ...(cohort ? this.cohortIdMatch(cohort) : {}),
         isDeleted: { $ne: true },
       },
       { session },
@@ -1341,7 +1368,7 @@ class ProgressRepository {
         courseId: new ObjectId(courseId),
         courseVersionId: new ObjectId(courseVersionId),
         itemId: new ObjectId(itemId),
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {cohortId: null}),
+        ...(cohortId ? this.cohortIdMatch(cohortId) : {cohortId: null}),
         isDeleted: { $ne: true },
       },
       { session, limit: 1 },


### PR DESCRIPTION
Backport of #1344 to main-v1. See #1343 for full details.

## Summary

Every cohort-scoped query in `ProgressRepository` matches `userId`/`courseId`/`courseVersionId` with a type-tolerant `$in: [ObjectId, string]` pattern, except `cohortId`, which used strict `{ cohortId: new ObjectId(cohortId) }` equality alone. Progress records with `cohortId` stored as a plain string were silently invisible to every cohort-scoped lookup (`current-path`, watch-time, quiz-attempt queries, etc.) as a result.

- Added a small `cohortIdMatch()` helper mirroring the existing `$in` pattern, applied at all 16 read sites that filter by `cohortId`.
- Left the 2 legitimate write sites (building new documents before insert) untouched -- they already cast correctly.
- `findAndReplaceProgress` needed special handling since it upserts: MongoDB only auto-populates an upserted document's fields from plain-equality filter conditions, not `$in`, so its `$set` now explicitly includes `cohortId` too -- otherwise a newly-inserted document via that path would end up with no `cohortId` at all.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Verified live against a real existing progress record on a test database: confirmed the strict-equality query fails to find the record once its `cohortId` is rewritten to a string (reproducing the bug for real, not just in theory), confirmed the new tolerant query still finds it, then reverted the record to its original value (no data changed)