### PR TITLE
fix(notifications): make invite acceptance and enrollment atomic

### DIFF
--- a/backend/src/modules/notifications/services/InviteService.ts
+++ b/backend/src/modules/notifications/services/InviteService.ts
@@ -697,23 +697,29 @@ export class InviteService extends BaseService {
       acceptedAt: date,
     };
 
-    await this.inviteRepo.updateInvite(inviteId, updatedPayload);
-
-    // If existing user, enroll them
+    // If existing user, enroll them. Status write and enrollment share one
+    // transaction so a failed enrollment leaves the invite un-ACCEPTED
+    // (retriable) instead of stranding it as accepted-but-not-enrolled.
     if (!invite.isNewUser && !invite.isAlreadyEnrolled) {
       const user = await this.userRepo.findByEmail(invite.email);
       if (!user) {
         throw new NotFoundError('User not found');
       }
-      // Enroll user in course
-      const result = await this.enrollmentService.enrollUser(
-        user._id.toString(),
-        invite.courseId.toString(),
-        invite.courseVersionId.toString(),
-        invite.role,
-        true,
-        invite.cohortId?.toString(),
-      );
+
+      const result = await this._withTransaction(async session => {
+        await this.inviteRepo.updateInvite(inviteId, updatedPayload, session);
+        return this.enrollmentService.enrollUser(
+          user._id.toString(),
+          invite.courseId.toString(),
+          invite.courseVersionId.toString(),
+          invite.role,
+          true,
+          invite.cohortId?.toString(),
+          undefined,
+          session,
+        );
+      });
+
       if (!result) {
         throw new InternalServerError('Failed to enroll user in course');
       }
@@ -726,6 +732,8 @@ export class InviteService extends BaseService {
         message: `You have been successfully enrolled in the course as ${result.role}.`,
       };
     }
+
+    await this.inviteRepo.updateInvite(inviteId, updatedPayload);
 
     // If new user, message that their invite acceptance as has been acknowledged please sign up
     if (invite.isNewUser) {


### PR DESCRIPTION
## Problem

`InviteService.processInvite` writes `inviteStatus: 'ACCEPTED'` to the invite document *before* calling `EnrollmentService.enrollUser`, with no shared transaction between the two steps. If `enrollUser` fails partway through — a duplicate-enrollment race, a transient DB error, a course-version mismatch, etc. — the invite is left permanently marked `ACCEPTED` with no corresponding enrollment ever created.

There's no way to recover: `processInvite` short-circuits early with "You have already accepted this invite." whenever `inviteStatus === 'ACCEPTED'`, so the learner can never retry acceptance, and support has no path to unstick them short of manual DB surgery.

Closes #1349

## Fix

Wrap the status update and the `enrollUser` call in a single `_withTransaction` block (the same pattern `BaseService` subclasses already use elsewhere in this file, and that `EnrollmentService.enrollUser` already supports via its optional trailing `session` parameter — `enrollUser` reuses a passed-in session instead of starting its own nested transaction). Both `inviteRepo.updateInvite` and `enrollUser` now receive the shared session, so either both commit or both roll back. On failure, the invite is left in its prior state and the learner (or a retry) can attempt acceptance again.

No behavior change for the success path or for the "new user" / already-enrolled / rejection branches, which don't call `enrollUser` and are untouched.

## Testing

Verified locally against a real MongoDB replica set (`mongodb-memory-server`, since this needs multi-document transaction support): built an integration test that creates a real invite for an existing user, corrupts it so `enrollUser`'s course/version mismatch check genuinely throws partway through acceptance, and asserts what the invite record actually ends up as.

- Against the pre-fix code: invite ends up stuck at `ACCEPTED` with no enrollment — reproducing the bug exactly.
- Against this fix: invite correctly rolls back to `PENDING`, and retrying afterward succeeds and enrolls the user.

Not including that test in this PR: `backend/src/modules/notifications/tests/InviteController.test.ts` as it exists on `main` currently fails wholesale locally (all 15 existing tests, unrelated to this change) — `POST /courses`'s `@Ability` decorator calls the real `FirebaseAuthService.getCurrentUserFromToken` regardless of the test harness's `authorizationChecker` override, and this file doesn't mock that out or send a bearer token anywhere. That's a pre-existing gap in this test file, orthogonal to the bug being fixed here, so fixing it felt out of scope for this PR — happy to send it separately if useful.