### PR TITLE
fix(notifications): make invite acceptance and enrollment atomic (main-v1 backport)

### DIFF
--- a/backend/src/modules/notifications/services/InviteService.ts
+++ b/backend/src/modules/notifications/services/InviteService.ts
@@ -697,23 +697,29 @@ export class InviteService extends BaseService {
       acceptedAt: date,
     };
 
-    await this.inviteRepo.updateInvite(inviteId, updatedPayload);
-
-    // If existing user, enroll them
+    // If existing user, enroll them. Status write and enrollment share one
+    // transaction so a failed enrollment leaves the invite un-ACCEPTED
+    // (retriable) instead of stranding it as accepted-but-not-enrolled.
     if (!invite.isNewUser && !invite.isAlreadyEnrolled) {
       const user = await this.userRepo.findByEmail(invite.email);
       if (!user) {
         throw new NotFoundError('User not found');
       }
-      // Enroll user in course
-      const result = await this.enrollmentService.enrollUser(
-        user._id.toString(),
-        invite.courseId.toString(),
-        invite.courseVersionId.toString(),
-        invite.role,
-        true,
-        invite.cohortId?.toString(),
-      );
+
+      const result = await this._withTransaction(async session => {
+        await this.inviteRepo.updateInvite(inviteId, updatedPayload, session);
+        return this.enrollmentService.enrollUser(
+          user._id.toString(),
+          invite.courseId.toString(),
+          invite.courseVersionId.toString(),
+          invite.role,
+          true,
+          invite.cohortId?.toString(),
+          undefined,
+          session,
+        );
+      });
+
       if (!result) {
         throw new InternalServerError('Failed to enroll user in course');
       }
@@ -726,6 +732,8 @@ export class InviteService extends BaseService {
         message: `You have been successfully enrolled in the course as ${result.role}.`,
       };
     }
+
+    await this.inviteRepo.updateInvite(inviteId, updatedPayload);
 
     // If new user, message that their invite acceptance as has been acknowledged please sign up
     if (invite.isNewUser) {


### PR DESCRIPTION
Backport of #1350 to `main-v1`.

## Problem

`InviteService.processInvite` writes `inviteStatus: 'ACCEPTED'` to the invite document *before* calling `EnrollmentService.enrollUser`, with no shared transaction between the two steps. If `enrollUser` fails partway through — a duplicate-enrollment race, a transient DB error, a course-version mismatch, etc. — the invite is left permanently marked `ACCEPTED` with no corresponding enrollment ever created, and `processInvite` short-circuits on `ACCEPTED` status, so there's no way to retry.

Closes #1349

## Fix

Wrap the status update and the `enrollUser` call in a single `_withTransaction` block, passing the shared session to both `inviteRepo.updateInvite` and `enrollUser` (which already supports reusing a passed-in session instead of starting its own nested transaction). Either both commit or both roll back. No behavior change for the success path or the other branches (new user, already enrolled, rejection), which don't call `enrollUser`.

## Testing

Same verification as #1350: confirmed against a real MongoDB replica set that this exact failure mode (enrollment throwing mid-acceptance) left the invite stuck at `ACCEPTED` before the fix, and correctly rolls back to `PENDING` (retriable) after it. Cherry-picked cleanly from the `main`-targeted fix with no conflicts; `tsc --noEmit` passes clean on this branch.