### PR TITLE
feat(teacher): add CSV export for course enrollment registration details

### DIFF
--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -50,7 +50,7 @@ import { useCourseStore } from "@/store/course-store"
 import type { EnrolledUser, EnrollmentDetails } from "@/types/course.types"
 import { useAuthStore } from "@/store/auth-store"
 import { EnrollmentRole } from "@/types/invite.types"
-import { generateExcel, generateStudentContactsExcel, type ExcelExportOptions } from "@/lib/excel-export"
+import { generateExcel, generateStudentContactsExcel, generateRegistrationDetailsCsv, type ExcelExportOptions, type RegistrationDetailData } from "@/lib/excel-export"
 import {
   downloadGuruSetuFeedbackExport,
   isGuruSetuPilotCourse,
@@ -438,6 +438,7 @@ function CourseEnrollments() {
   const [isSearching, setIsSearching] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isExportingStudentContacts, setIsExportingStudentContacts] = useState(false);
+  const [isExportingRegistrationDetails, setIsExportingRegistrationDetails] = useState(false);
   const [isExportingGuruSetuFeedback, setIsExportingGuruSetuFeedback] = useState(false);
   const [quizExportOptions, setQuizExportOptions] = useState<ExcelExportOptions>({
     includeAttempts: true,
@@ -890,7 +891,7 @@ function CourseEnrollments() {
     debouncedSearch,
     sortBy,
     sortOrder,
-    isExportingStudentContacts,
+    isExportingStudentContacts || isExportingRegistrationDetails,
     'STUDENT',
     statusTab,
     cohort,
@@ -976,6 +977,72 @@ function CourseEnrollments() {
     }
   };
 
+  const handleExportRegistrationDetails = async () => {
+    if (!courseId || !versionId) {
+      toast.error('Course ID or Version ID is missing');
+      return;
+    }
+
+    if (!totalDocuments) {
+      toast.warning('No students found to export');
+      return;
+    }
+
+    const enrollments = exportEnrollmentsData?.enrollments || [];
+
+    if (!enrollments.length) {
+      toast.warning('No students found to export');
+      return;
+    }
+
+    try {
+      const formattedData: RegistrationDetailData[] = enrollments.map((enrollment: any) => ({
+        name:
+          `${enrollment?.user?.firstName ?? ''} ${enrollment?.user?.lastName ?? ''}`.trim() ||
+          'Unknown User',
+        email: enrollment?.user?.email || '',
+        cohortName: enrollment.cohortName || null,
+        enrolledDate: enrollment.enrollmentDate || null,
+        status: statusTab,
+        unenrolledAt: enrollment.unenrolledAt || null,
+        progress: Math.min(enrollment.progress ?? 0, 100),
+        completedItems: enrollment.completedItemsCount || 0,
+        totalItems: enrollment.contentCounts?.total || 0,
+        completedVideos: enrollment.contentCounts?.completedItemCounts?.VIDEO || 0,
+        totalVideos: enrollment.contentCounts?.itemCounts?.VIDEO || 0,
+        completedQuizzes: enrollment.contentCounts?.completedItemCounts?.QUIZ || 0,
+        totalQuizzes: enrollment.contentCounts?.itemCounts?.QUIZ || 0,
+        completedArticles: enrollment.contentCounts?.completedItemCounts?.BLOG || 0,
+        totalArticles: enrollment.contentCounts?.itemCounts?.BLOG || 0,
+        completedProjects: enrollment.contentCounts?.completedItemCounts?.PROJECT || 0,
+        totalProjects: enrollment.contentCounts?.itemCounts?.PROJECT || 0,
+        totalQuizScore: enrollment.totalQuizScore || 0,
+        totalQuizMaxScore: enrollment.totalQuizMaxScore || 0,
+      }));
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '_');
+      const statusLabel = enrollmentTab === 'ACTIVE' ? 'active' : 'inactive';
+      const courseLabel = sanitizeFilenamePart(course?.name || 'course');
+      const cohortName = cohort
+        ? (version as any)?.cohortDetails?.find((item: any) => item.id === cohort)?.name
+        : null;
+      const cohortLabel = cohortName
+        ? `${sanitizeFilenamePart(cohortName)}_`
+        : '';
+      const filename = `${courseLabel}_${cohortLabel}${statusLabel}_registration_details_${timestamp}.csv`;
+
+      generateRegistrationDetailsCsv(formattedData, filename);
+      toast.success('Registration details exported successfully');
+    } catch (error) {
+      console.error('Error exporting registration details:', error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to export registration details',
+      );
+    }
+  };
+
   const handleExportGuruSetuFeedback = async () => {
     if (!courseId || !versionId) {
       toast.error('Course ID or Version ID is missing');
@@ -1040,6 +1107,12 @@ function CourseEnrollments() {
       handleExportStudentContacts().finally(() => setIsExportingStudentContacts(false));
     }
   }, [isExportingStudentContacts, isLoadingStudentContacts, exportEnrollmentsData]);
+
+  useEffect(() => {
+    if (isExportingRegistrationDetails && !isLoadingStudentContacts) {
+      handleExportRegistrationDetails().finally(() => setIsExportingRegistrationDetails(false));
+    }
+  }, [isExportingRegistrationDetails, isLoadingStudentContacts, exportEnrollmentsData]);
 
   const handleResetProgress = (user: EnrolledUser) => {
     setSelectedUser(user)
@@ -1627,8 +1700,11 @@ function CourseEnrollments() {
                   sortOrder={sortOrder}
                   isLoadingQuizScores={isLoadingQuizScores}
                   setIsExporting={setIsExporting}
-                  isExportingStudentContacts={isLoadingStudentContacts}
+                  isExportingStudentContacts={isExportingStudentContacts && isLoadingStudentContacts}
                   setIsExportingStudentContacts={setIsExportingStudentContacts}
+                  isExportingRegistrationDetails={isExportingRegistrationDetails && isLoadingStudentContacts}
+                  setIsExportingRegistrationDetails={setIsExportingRegistrationDetails}
+                  isAnyExporting={isExportingStudentContacts || isExportingRegistrationDetails}
                   isExportingGuruSetuFeedback={isExportingGuruSetuFeedback}
                   onExportGuruSetuFeedback={handleExportGuruSetuFeedback}
                   isGuruSetuCourse={isGuruSetuCourse}
@@ -1674,8 +1750,11 @@ function CourseEnrollments() {
                   sortOrder={sortOrder}
                   isLoadingQuizScores={isLoadingQuizScores}
                   setIsExporting={setIsExporting}
-                  isExportingStudentContacts={isLoadingStudentContacts}
+                  isExportingStudentContacts={isExportingStudentContacts && isLoadingStudentContacts}
                   setIsExportingStudentContacts={setIsExportingStudentContacts}
+                  isExportingRegistrationDetails={isExportingRegistrationDetails && isLoadingStudentContacts}
+                  setIsExportingRegistrationDetails={setIsExportingRegistrationDetails}
+                  isAnyExporting={isExportingStudentContacts || isExportingRegistrationDetails}
                   isExportingGuruSetuFeedback={isExportingGuruSetuFeedback}
                   onExportGuruSetuFeedback={handleExportGuruSetuFeedback}
                   isGuruSetuCourse={isGuruSetuCourse}
@@ -3023,6 +3102,9 @@ interface EnrollmentsTableProps {
   setIsExporting: (exporting: boolean) => void;
   isExportingStudentContacts: boolean;
   setIsExportingStudentContacts: (exporting: boolean) => void;
+  isExportingRegistrationDetails: boolean;
+  setIsExportingRegistrationDetails: (exporting: boolean) => void;
+  isAnyExporting: boolean;
   isExportingGuruSetuFeedback: boolean;
   onExportGuruSetuFeedback: () => void;
   isGuruSetuCourse: boolean;
@@ -3071,6 +3153,9 @@ function EnrollmentsTable({
   setIsExporting,
   isExportingStudentContacts,
   setIsExportingStudentContacts,
+  isExportingRegistrationDetails,
+  setIsExportingRegistrationDetails,
+  isAnyExporting,
   isExportingGuruSetuFeedback,
   onExportGuruSetuFeedback,
   isGuruSetuCourse,
@@ -3263,13 +3348,22 @@ function EnrollmentsTable({
                 )}
               </DropdownMenuItem>
 
-              <DropdownMenuItem onClick={() => setIsExportingStudentContacts(true)} disabled={isExportingStudentContacts || enrollmentsLoading || isSearching}>
+              <DropdownMenuItem onClick={() => setIsExportingStudentContacts(true)} disabled={isAnyExporting || enrollmentsLoading || isSearching}>
                 {isExportingStudentContacts ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
                   <Download className="h-4 w-4" />
                 )}
                 <span>{isExportingStudentContacts ? "Exporting..." : "Export Student Contacts"}</span>
+              </DropdownMenuItem>
+
+              <DropdownMenuItem onClick={() => setIsExportingRegistrationDetails(true)} disabled={isAnyExporting || enrollmentsLoading || isSearching}>
+                {isExportingRegistrationDetails ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Download className="h-4 w-4" />
+                )}
+                <span>{isExportingRegistrationDetails ? "Exporting..." : "Export Registration Details"}</span>
               </DropdownMenuItem>
 
               <DropdownMenuItem onClick={() => setIsExporting(true)} disabled={isLoadingQuizScores}>

--- a/frontend/src/lib/excel-export.ts
+++ b/frontend/src/lib/excel-export.ts
@@ -5,6 +5,28 @@ export interface StudentContactData {
   email: string;
 }
 
+export interface RegistrationDetailData {
+  name: string;
+  email: string;
+  cohortName?: string | null;
+  enrolledDate?: string | null;
+  status: 'ACTIVE' | 'INACTIVE';
+  unenrolledAt?: string | null;
+  progress: number;
+  completedItems: number;
+  totalItems: number;
+  completedVideos: number;
+  totalVideos: number;
+  completedQuizzes: number;
+  totalQuizzes: number;
+  completedArticles: number;
+  totalArticles: number;
+  completedProjects: number;
+  totalProjects: number;
+  totalQuizScore: number;
+  totalQuizMaxScore: number;
+}
+
 interface QuestionScore {
   questionId: string;
   score: number;
@@ -571,4 +593,59 @@ export function generateStudentContactsExcel(
 
   XLSX.utils.book_append_sheet(workbook, worksheet, 'Students');
   XLSX.writeFile(workbook, filename);
+}
+
+export function generateRegistrationDetailsCsv(
+  data: RegistrationDetailData[],
+  filename: string = 'registration_details.csv'
+): void {
+  const header = [
+    'S.No.', 'Name', 'Email', 'Cohort', 'Enrollment Date', 'Status', 'Unenrolled Date',
+    'Progress %', 'Completed Items', 'Total Items',
+    'Videos Completed', 'Videos Total',
+    'Quizzes Completed', 'Quizzes Total',
+    'Articles Completed', 'Articles Total',
+    'Projects Completed', 'Projects Total',
+    'Total Quiz Score', 'Total Quiz Max Score',
+  ];
+
+  const rows = data.map((student, index) => [
+    index + 1,
+    student.name || 'Unknown User',
+    student.email || '',
+    student.cohortName || '',
+    student.enrolledDate ? new Date(student.enrolledDate).toLocaleDateString('en-US') : '',
+    student.status,
+    student.unenrolledAt ? new Date(student.unenrolledAt).toLocaleDateString('en-US') : '',
+    Number(student.progress || 0).toFixed(2),
+    student.completedItems || 0,
+    student.totalItems || 0,
+    student.completedVideos || 0,
+    student.totalVideos || 0,
+    student.completedQuizzes || 0,
+    student.totalQuizzes || 0,
+    student.completedArticles || 0,
+    student.totalArticles || 0,
+    student.completedProjects || 0,
+    student.totalProjects || 0,
+    student.totalQuizScore || 0,
+    student.totalQuizMaxScore || 0,
+  ]);
+
+  if (!rows.length) {
+    console.warn('No registration data to export');
+    return;
+  }
+
+  const worksheet = XLSX.utils.aoa_to_sheet([header, ...rows]);
+  const csv = XLSX.utils.sheet_to_csv(worksheet);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
## Summary

Teachers could already export a bare name/email contact list ("Export Student Contacts") or quiz scores from the course enrollments page, but had no way to get a fuller snapshot of registration + progress data for record-keeping or reporting outside the app.

Adds an "Export Registration Details" action next to the existing export options in the enrollments page's dropdown menu. It reuses the same already-fetched full enrollment list used by the existing contacts export (no extra API calls), and produces a CSV with:

- Name, Email, Cohort
- Enrollment Date, Status (Active/Inactive), Unenrollment Date
- Progress %, Completed/Total Items
- Per-content-type completion (Videos, Quizzes, Articles, Projects — completed/total each)
- Total Quiz Score / Max Score


## Testing

- `tsc --noEmit` and `vite build` both pass clean.
- Tested live against a real course with 6 enrolled students: triggered the export, confirmed the "Registration details exported successfully" toast, and read the actual downloaded CSV to verify contents — name, email, dates, status, and progress % all matched the on-screen table exactly.
- Found one pre-existing data gap while testing (not introduced by this change, not fixed here): the per-content-type breakdown columns come from `enrollment.contentCounts`, which `EnrollmentController`'s bulk list endpoint passes through unprocessed from the stored enrollment document. For enrollments where that field isn't populated, those columns correctly show 0 rather than throwing — the single-student detail endpoint (`getStudentProgressDetail`) has a defensive normalization/fallback block for this exact field for the same reason, which the bulk list endpoint doesn't have. Flagging in case it's worth a follow-up, but it's outside the scope of this export feature.