### PR TITLE
feat(teacher): show item creation timestamp in the manage-course panel

### DIFF
--- a/frontend/src/app/pages/teacher/teacher-course-page.tsx
+++ b/frontend/src/app/pages/teacher/teacher-course-page.tsx
@@ -105,6 +105,15 @@ const getItemIcon = (type: string) => {
   }
 };
 
+// Items (video/quiz/blog) don't carry their own createdAt field, but their
+// Mongo ObjectId does: the first 4 bytes are a big-endian Unix timestamp set
+// at generation time, and item _ids are generated once, at creation.
+function getCreatedAtFromObjectId(id?: string | null): Date | null {
+  if (!id || id.length < 8) return null;
+  const seconds = parseInt(id.substring(0, 8), 16);
+  return Number.isNaN(seconds) ? null : new Date(seconds * 1000);
+}
+
 interface LabelOptions {
   itemId: string;
   itemType: "VIDEO" | "QUIZ" | "BLOG" | "PROJECT" | "FEEDBACK" | "REFLECTION";
@@ -2925,6 +2934,18 @@ function TeacherCourseContent() {
                             {selectedEntity.data?.updatedAt
                               ? new Date(selectedEntity.data.updatedAt).toLocaleString()
                               : "N/A"}
+                          </div>
+                        </div>
+                      )}
+
+                      {selectedEntity.type === "item" && (
+                        <div className="flex gap-6 text-xs text-muted-foreground">
+                          <div>
+                            <span className="font-semibold">Created:</span>{" "}
+                            {(() => {
+                              const createdAt = getCreatedAtFromObjectId(selectedItemData?.item?._id);
+                              return createdAt ? createdAt.toLocaleString() : "N/A";
+                            })()}
                           </div>
                         </div>
                       )}


### PR DESCRIPTION
## Summary

The course editor's edit panel already shows "Created / Updated" timestamps when a teacher selects a module or section, using data the API already returns for those. Items (video/quiz/blog) were left out of that display even though a teacher browsing course content would find the same information just as useful there — e.g. confirming when a video was actually added to the course.

Items don't carry their own `createdAt` field the way modules/sections do (`VideoItem`/`QuizItem`/`BlogItem` have no such field). Rather than a schema change, this reads the timestamp already embedded in every item's Mongo ObjectId — the first 4 bytes are a big-endian Unix timestamp set at generation time, and an item's `_id` is generated once, at creation, and never changes. No "Updated" line is shown for items, since there's genuinely no `updatedAt` to read.

## Testing

- `tsc --noEmit` passes clean.
