### PR TITLE
feat(teacher): add Student Registration Details export above Student Contacts

### DIFF
--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -50,7 +50,7 @@ import { useCourseStore } from "@/store/course-store"
 import type { EnrolledUser, EnrollmentDetails } from "@/types/course.types"
 import { useAuthStore } from "@/store/auth-store"
 import { EnrollmentRole } from "@/types/invite.types"
-import { generateExcel, generateStudentContactsExcel, generateRegistrationDetailsCsv, type ExcelExportOptions, type RegistrationDetailData } from "@/lib/excel-export"
+import { generateExcel, generateStudentContactsExcel, generateRegistrationDetailsCsv, generateStudentRegistrationDetailsCsv, type ExcelExportOptions, type RegistrationDetailData, type StudentRegistrationDetailData } from "@/lib/excel-export"
 import {
   downloadGuruSetuFeedbackExport,
   isGuruSetuPilotCourse,
@@ -439,6 +439,7 @@ function CourseEnrollments() {
   const [isExporting, setIsExporting] = useState(false);
   const [isExportingStudentContacts, setIsExportingStudentContacts] = useState(false);
   const [isExportingRegistrationDetails, setIsExportingRegistrationDetails] = useState(false);
+  const [isExportingStudentRegistrationDetails, setIsExportingStudentRegistrationDetails] = useState(false);
   const [isExportingGuruSetuFeedback, setIsExportingGuruSetuFeedback] = useState(false);
   const [quizExportOptions, setQuizExportOptions] = useState<ExcelExportOptions>({
     includeAttempts: true,
@@ -891,7 +892,7 @@ function CourseEnrollments() {
     debouncedSearch,
     sortBy,
     sortOrder,
-    isExportingStudentContacts || isExportingRegistrationDetails,
+    isExportingStudentContacts || isExportingRegistrationDetails || isExportingStudentRegistrationDetails,
     'STUDENT',
     statusTab,
     cohort,
@@ -1043,6 +1044,59 @@ function CourseEnrollments() {
     }
   };
 
+  const handleExportStudentRegistrationDetails = async () => {
+    if (!courseId || !versionId) {
+      toast.error('Course ID or Version ID is missing');
+      return;
+    }
+
+    if (!totalDocuments) {
+      toast.warning('No students found to export');
+      return;
+    }
+
+    const enrollments = exportEnrollmentsData?.enrollments || [];
+
+    if (!enrollments.length) {
+      toast.warning('No students found to export');
+      return;
+    }
+
+    try {
+      const formattedData: StudentRegistrationDetailData[] = enrollments.map((enrollment: any) => ({
+        name:
+          `${enrollment?.user?.firstName ?? ''} ${enrollment?.user?.lastName ?? ''}`.trim() ||
+          'Unknown User',
+        email: enrollment?.user?.email || '',
+        gender: enrollment?.user?.gender || '',
+        country: enrollment?.user?.country || '',
+        state: enrollment?.user?.state || '',
+        city: enrollment?.user?.city || '',
+      }));
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '_');
+      const statusLabel = enrollmentTab === 'ACTIVE' ? 'active' : 'inactive';
+      const courseLabel = sanitizeFilenamePart(course?.name || 'course');
+      const cohortName = cohort
+        ? (version as any)?.cohortDetails?.find((item: any) => item.id === cohort)?.name
+        : null;
+      const cohortLabel = cohortName
+        ? `${sanitizeFilenamePart(cohortName)}_`
+        : '';
+      const filename = `${courseLabel}_${cohortLabel}${statusLabel}_student_registration_details_${timestamp}.csv`;
+
+      generateStudentRegistrationDetailsCsv(formattedData, filename);
+      toast.success('Student registration details exported successfully');
+    } catch (error) {
+      console.error('Error exporting student registration details:', error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to export student registration details',
+      );
+    }
+  };
+
   const handleExportGuruSetuFeedback = async () => {
     if (!courseId || !versionId) {
       toast.error('Course ID or Version ID is missing');
@@ -1113,6 +1167,12 @@ function CourseEnrollments() {
       handleExportRegistrationDetails().finally(() => setIsExportingRegistrationDetails(false));
     }
   }, [isExportingRegistrationDetails, isLoadingStudentContacts, exportEnrollmentsData]);
+
+  useEffect(() => {
+    if (isExportingStudentRegistrationDetails && !isLoadingStudentContacts) {
+      handleExportStudentRegistrationDetails().finally(() => setIsExportingStudentRegistrationDetails(false));
+    }
+  }, [isExportingStudentRegistrationDetails, isLoadingStudentContacts, exportEnrollmentsData]);
 
   const handleResetProgress = (user: EnrolledUser) => {
     setSelectedUser(user)
@@ -1704,7 +1764,9 @@ function CourseEnrollments() {
                   setIsExportingStudentContacts={setIsExportingStudentContacts}
                   isExportingRegistrationDetails={isExportingRegistrationDetails && isLoadingStudentContacts}
                   setIsExportingRegistrationDetails={setIsExportingRegistrationDetails}
-                  isAnyExporting={isExportingStudentContacts || isExportingRegistrationDetails}
+                  isExportingStudentRegistrationDetails={isExportingStudentRegistrationDetails && isLoadingStudentContacts}
+                  setIsExportingStudentRegistrationDetails={setIsExportingStudentRegistrationDetails}
+                  isAnyExporting={isExportingStudentContacts || isExportingRegistrationDetails || isExportingStudentRegistrationDetails}
                   isExportingGuruSetuFeedback={isExportingGuruSetuFeedback}
                   onExportGuruSetuFeedback={handleExportGuruSetuFeedback}
                   isGuruSetuCourse={isGuruSetuCourse}
@@ -1754,7 +1816,9 @@ function CourseEnrollments() {
                   setIsExportingStudentContacts={setIsExportingStudentContacts}
                   isExportingRegistrationDetails={isExportingRegistrationDetails && isLoadingStudentContacts}
                   setIsExportingRegistrationDetails={setIsExportingRegistrationDetails}
-                  isAnyExporting={isExportingStudentContacts || isExportingRegistrationDetails}
+                  isExportingStudentRegistrationDetails={isExportingStudentRegistrationDetails && isLoadingStudentContacts}
+                  setIsExportingStudentRegistrationDetails={setIsExportingStudentRegistrationDetails}
+                  isAnyExporting={isExportingStudentContacts || isExportingRegistrationDetails || isExportingStudentRegistrationDetails}
                   isExportingGuruSetuFeedback={isExportingGuruSetuFeedback}
                   onExportGuruSetuFeedback={handleExportGuruSetuFeedback}
                   isGuruSetuCourse={isGuruSetuCourse}
@@ -3104,6 +3168,8 @@ interface EnrollmentsTableProps {
   setIsExportingStudentContacts: (exporting: boolean) => void;
   isExportingRegistrationDetails: boolean;
   setIsExportingRegistrationDetails: (exporting: boolean) => void;
+  isExportingStudentRegistrationDetails: boolean;
+  setIsExportingStudentRegistrationDetails: (exporting: boolean) => void;
   isAnyExporting: boolean;
   isExportingGuruSetuFeedback: boolean;
   onExportGuruSetuFeedback: () => void;
@@ -3155,6 +3221,8 @@ function EnrollmentsTable({
   setIsExportingStudentContacts,
   isExportingRegistrationDetails,
   setIsExportingRegistrationDetails,
+  isExportingStudentRegistrationDetails,
+  setIsExportingStudentRegistrationDetails,
   isAnyExporting,
   isExportingGuruSetuFeedback,
   onExportGuruSetuFeedback,
@@ -3346,6 +3414,15 @@ function EnrollmentsTable({
                     Select Student
                   </>
                 )}
+              </DropdownMenuItem>
+
+              <DropdownMenuItem onClick={() => setIsExportingStudentRegistrationDetails(true)} disabled={isAnyExporting || enrollmentsLoading || isSearching}>
+                {isExportingStudentRegistrationDetails ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Download className="h-4 w-4" />
+                )}
+                <span>{isExportingStudentRegistrationDetails ? "Exporting..." : "Export Student Registration Details"}</span>
               </DropdownMenuItem>
 
               <DropdownMenuItem onClick={() => setIsExportingStudentContacts(true)} disabled={isAnyExporting || enrollmentsLoading || isSearching}>

--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -50,7 +50,7 @@ import { useCourseStore } from "@/store/course-store"
 import type { EnrolledUser, EnrollmentDetails } from "@/types/course.types"
 import { useAuthStore } from "@/store/auth-store"
 import { EnrollmentRole } from "@/types/invite.types"
-import { generateExcel, generateStudentContactsExcel, type ExcelExportOptions } from "@/lib/excel-export"
+import { generateExcel, generateStudentContactsExcel, generateRegistrationDetailsCsv, type ExcelExportOptions, type RegistrationDetailData } from "@/lib/excel-export"
 import {
   downloadGuruSetuFeedbackExport,
   isGuruSetuPilotCourse,
@@ -438,6 +438,7 @@ function CourseEnrollments() {
   const [isSearching, setIsSearching] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isExportingStudentContacts, setIsExportingStudentContacts] = useState(false);
+  const [isExportingRegistrationDetails, setIsExportingRegistrationDetails] = useState(false);
   const [isExportingGuruSetuFeedback, setIsExportingGuruSetuFeedback] = useState(false);
   const [quizExportOptions, setQuizExportOptions] = useState<ExcelExportOptions>({
     includeAttempts: true,
@@ -890,7 +891,7 @@ function CourseEnrollments() {
     debouncedSearch,
     sortBy,
     sortOrder,
-    isExportingStudentContacts,
+    isExportingStudentContacts || isExportingRegistrationDetails,
     'STUDENT',
     statusTab,
     cohort,
@@ -976,6 +977,72 @@ function CourseEnrollments() {
     }
   };
 
+  const handleExportRegistrationDetails = async () => {
+    if (!courseId || !versionId) {
+      toast.error('Course ID or Version ID is missing');
+      return;
+    }
+
+    if (!totalDocuments) {
+      toast.warning('No students found to export');
+      return;
+    }
+
+    const enrollments = exportEnrollmentsData?.enrollments || [];
+
+    if (!enrollments.length) {
+      toast.warning('No students found to export');
+      return;
+    }
+
+    try {
+      const formattedData: RegistrationDetailData[] = enrollments.map((enrollment: any) => ({
+        name:
+          `${enrollment?.user?.firstName ?? ''} ${enrollment?.user?.lastName ?? ''}`.trim() ||
+          'Unknown User',
+        email: enrollment?.user?.email || '',
+        cohortName: enrollment.cohortName || null,
+        enrolledDate: enrollment.enrollmentDate || null,
+        status: statusTab,
+        unenrolledAt: enrollment.unenrolledAt || null,
+        progress: Math.min(enrollment.progress ?? 0, 100),
+        completedItems: enrollment.completedItemsCount || 0,
+        totalItems: enrollment.contentCounts?.total || 0,
+        completedVideos: enrollment.contentCounts?.completedItemCounts?.VIDEO || 0,
+        totalVideos: enrollment.contentCounts?.itemCounts?.VIDEO || 0,
+        completedQuizzes: enrollment.contentCounts?.completedItemCounts?.QUIZ || 0,
+        totalQuizzes: enrollment.contentCounts?.itemCounts?.QUIZ || 0,
+        completedArticles: enrollment.contentCounts?.completedItemCounts?.BLOG || 0,
+        totalArticles: enrollment.contentCounts?.itemCounts?.BLOG || 0,
+        completedProjects: enrollment.contentCounts?.completedItemCounts?.PROJECT || 0,
+        totalProjects: enrollment.contentCounts?.itemCounts?.PROJECT || 0,
+        totalQuizScore: enrollment.totalQuizScore || 0,
+        totalQuizMaxScore: enrollment.totalQuizMaxScore || 0,
+      }));
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '_');
+      const statusLabel = enrollmentTab === 'ACTIVE' ? 'active' : 'inactive';
+      const courseLabel = sanitizeFilenamePart(course?.name || 'course');
+      const cohortName = cohort
+        ? (version as any)?.cohortDetails?.find((item: any) => item.id === cohort)?.name
+        : null;
+      const cohortLabel = cohortName
+        ? `${sanitizeFilenamePart(cohortName)}_`
+        : '';
+      const filename = `${courseLabel}_${cohortLabel}${statusLabel}_registration_details_${timestamp}.csv`;
+
+      generateRegistrationDetailsCsv(formattedData, filename);
+      toast.success('Registration details exported successfully');
+    } catch (error) {
+      console.error('Error exporting registration details:', error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to export registration details',
+      );
+    }
+  };
+
   const handleExportGuruSetuFeedback = async () => {
     if (!courseId || !versionId) {
       toast.error('Course ID or Version ID is missing');
@@ -1040,6 +1107,12 @@ function CourseEnrollments() {
       handleExportStudentContacts().finally(() => setIsExportingStudentContacts(false));
     }
   }, [isExportingStudentContacts, isLoadingStudentContacts, exportEnrollmentsData]);
+
+  useEffect(() => {
+    if (isExportingRegistrationDetails && !isLoadingStudentContacts) {
+      handleExportRegistrationDetails().finally(() => setIsExportingRegistrationDetails(false));
+    }
+  }, [isExportingRegistrationDetails, isLoadingStudentContacts, exportEnrollmentsData]);
 
   const handleResetProgress = (user: EnrolledUser) => {
     setSelectedUser(user)
@@ -1627,8 +1700,11 @@ function CourseEnrollments() {
                   sortOrder={sortOrder}
                   isLoadingQuizScores={isLoadingQuizScores}
                   setIsExporting={setIsExporting}
-                  isExportingStudentContacts={isLoadingStudentContacts}
+                  isExportingStudentContacts={isExportingStudentContacts && isLoadingStudentContacts}
                   setIsExportingStudentContacts={setIsExportingStudentContacts}
+                  isExportingRegistrationDetails={isExportingRegistrationDetails && isLoadingStudentContacts}
+                  setIsExportingRegistrationDetails={setIsExportingRegistrationDetails}
+                  isAnyExporting={isExportingStudentContacts || isExportingRegistrationDetails}
                   isExportingGuruSetuFeedback={isExportingGuruSetuFeedback}
                   onExportGuruSetuFeedback={handleExportGuruSetuFeedback}
                   isGuruSetuCourse={isGuruSetuCourse}
@@ -1674,8 +1750,11 @@ function CourseEnrollments() {
                   sortOrder={sortOrder}
                   isLoadingQuizScores={isLoadingQuizScores}
                   setIsExporting={setIsExporting}
-                  isExportingStudentContacts={isLoadingStudentContacts}
+                  isExportingStudentContacts={isExportingStudentContacts && isLoadingStudentContacts}
                   setIsExportingStudentContacts={setIsExportingStudentContacts}
+                  isExportingRegistrationDetails={isExportingRegistrationDetails && isLoadingStudentContacts}
+                  setIsExportingRegistrationDetails={setIsExportingRegistrationDetails}
+                  isAnyExporting={isExportingStudentContacts || isExportingRegistrationDetails}
                   isExportingGuruSetuFeedback={isExportingGuruSetuFeedback}
                   onExportGuruSetuFeedback={handleExportGuruSetuFeedback}
                   isGuruSetuCourse={isGuruSetuCourse}
@@ -3023,6 +3102,9 @@ interface EnrollmentsTableProps {
   setIsExporting: (exporting: boolean) => void;
   isExportingStudentContacts: boolean;
   setIsExportingStudentContacts: (exporting: boolean) => void;
+  isExportingRegistrationDetails: boolean;
+  setIsExportingRegistrationDetails: (exporting: boolean) => void;
+  isAnyExporting: boolean;
   isExportingGuruSetuFeedback: boolean;
   onExportGuruSetuFeedback: () => void;
   isGuruSetuCourse: boolean;
@@ -3071,6 +3153,9 @@ function EnrollmentsTable({
   setIsExporting,
   isExportingStudentContacts,
   setIsExportingStudentContacts,
+  isExportingRegistrationDetails,
+  setIsExportingRegistrationDetails,
+  isAnyExporting,
   isExportingGuruSetuFeedback,
   onExportGuruSetuFeedback,
   isGuruSetuCourse,
@@ -3263,13 +3348,22 @@ function EnrollmentsTable({
                 )}
               </DropdownMenuItem>
 
-              <DropdownMenuItem onClick={() => setIsExportingStudentContacts(true)} disabled={isExportingStudentContacts || enrollmentsLoading || isSearching}>
+              <DropdownMenuItem onClick={() => setIsExportingStudentContacts(true)} disabled={isAnyExporting || enrollmentsLoading || isSearching}>
                 {isExportingStudentContacts ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
                   <Download className="h-4 w-4" />
                 )}
                 <span>{isExportingStudentContacts ? "Exporting..." : "Export Student Contacts"}</span>
+              </DropdownMenuItem>
+
+              <DropdownMenuItem onClick={() => setIsExportingRegistrationDetails(true)} disabled={isAnyExporting || enrollmentsLoading || isSearching}>
+                {isExportingRegistrationDetails ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Download className="h-4 w-4" />
+                )}
+                <span>{isExportingRegistrationDetails ? "Exporting..." : "Export Registration Details"}</span>
               </DropdownMenuItem>
 
               <DropdownMenuItem onClick={() => setIsExporting(true)} disabled={isLoadingQuizScores}>

--- a/frontend/src/lib/excel-export.ts
+++ b/frontend/src/lib/excel-export.ts
@@ -27,6 +27,15 @@ export interface RegistrationDetailData {
   totalQuizMaxScore: number;
 }
 
+export interface StudentRegistrationDetailData {
+  name: string;
+  email: string;
+  gender?: string;
+  country?: string;
+  state?: string;
+  city?: string;
+}
+
 interface QuestionScore {
   questionId: string;
   score: number;
@@ -634,6 +643,40 @@ export function generateRegistrationDetailsCsv(
 
   if (!rows.length) {
     console.warn('No registration data to export');
+    return;
+  }
+
+  const worksheet = XLSX.utils.aoa_to_sheet([header, ...rows]);
+  const csv = XLSX.utils.sheet_to_csv(worksheet);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function generateStudentRegistrationDetailsCsv(
+  data: StudentRegistrationDetailData[],
+  filename: string = 'student_registration_details.csv'
+): void {
+  const header = ['S.No.', 'Name', 'Email', 'Gender', 'Country', 'State', 'City'];
+
+  const rows = data.map((student, index) => [
+    index + 1,
+    student.name || 'Unknown User',
+    student.email || '',
+    student.gender || '',
+    student.country || '',
+    student.state || '',
+    student.city || '',
+  ]);
+
+  if (!rows.length) {
+    console.warn('No student registration data to export');
     return;
   }
 

--- a/frontend/src/lib/excel-export.ts
+++ b/frontend/src/lib/excel-export.ts
@@ -5,6 +5,28 @@ export interface StudentContactData {
   email: string;
 }
 
+export interface RegistrationDetailData {
+  name: string;
+  email: string;
+  cohortName?: string | null;
+  enrolledDate?: string | null;
+  status: 'ACTIVE' | 'INACTIVE';
+  unenrolledAt?: string | null;
+  progress: number;
+  completedItems: number;
+  totalItems: number;
+  completedVideos: number;
+  totalVideos: number;
+  completedQuizzes: number;
+  totalQuizzes: number;
+  completedArticles: number;
+  totalArticles: number;
+  completedProjects: number;
+  totalProjects: number;
+  totalQuizScore: number;
+  totalQuizMaxScore: number;
+}
+
 interface QuestionScore {
   questionId: string;
   score: number;
@@ -571,4 +593,59 @@ export function generateStudentContactsExcel(
 
   XLSX.utils.book_append_sheet(workbook, worksheet, 'Students');
   XLSX.writeFile(workbook, filename);
+}
+
+export function generateRegistrationDetailsCsv(
+  data: RegistrationDetailData[],
+  filename: string = 'registration_details.csv'
+): void {
+  const header = [
+    'S.No.', 'Name', 'Email', 'Cohort', 'Enrollment Date', 'Status', 'Unenrolled Date',
+    'Progress %', 'Completed Items', 'Total Items',
+    'Videos Completed', 'Videos Total',
+    'Quizzes Completed', 'Quizzes Total',
+    'Articles Completed', 'Articles Total',
+    'Projects Completed', 'Projects Total',
+    'Total Quiz Score', 'Total Quiz Max Score',
+  ];
+
+  const rows = data.map((student, index) => [
+    index + 1,
+    student.name || 'Unknown User',
+    student.email || '',
+    student.cohortName || '',
+    student.enrolledDate ? new Date(student.enrolledDate).toLocaleDateString('en-US') : '',
+    student.status,
+    student.unenrolledAt ? new Date(student.unenrolledAt).toLocaleDateString('en-US') : '',
+    Number(student.progress || 0).toFixed(2),
+    student.completedItems || 0,
+    student.totalItems || 0,
+    student.completedVideos || 0,
+    student.totalVideos || 0,
+    student.completedQuizzes || 0,
+    student.totalQuizzes || 0,
+    student.completedArticles || 0,
+    student.totalArticles || 0,
+    student.completedProjects || 0,
+    student.totalProjects || 0,
+    student.totalQuizScore || 0,
+    student.totalQuizMaxScore || 0,
+  ]);
+
+  if (!rows.length) {
+    console.warn('No registration data to export');
+    return;
+  }
+
+  const worksheet = XLSX.utils.aoa_to_sheet([header, ...rows]);
+  const csv = XLSX.utils.sheet_to_csv(worksheet);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
**Depends on #1352 — please merge that first.** This branch is built on top of it (`feat/enrollments-registration-csv-export`), so this diff includes its commit until #1352 lands; only the last commit here is new.

## Summary

Adds a new "Export Student Registration Details" action to the enrollments page's export menu, positioned above the existing "Export Student Contacts" — pulling the profile fields a student fills in on their own profile page (gender, country, state, city) alongside name/email.

This is distinct from #1352's "Export Registration Details", which covers enrollment/progress data (dates, completion %, content breakdown), not profile fields. The two are complementary, separate exports.

No new API call: the bulk enrollments endpoint already joins the full user document per row (for name/email), so gender/country/state/city ride along in the same response — this just surfaces fields that were already being fetched.

## Testing

`tsc --noEmit` passes clean. Built and reasoned through against the same enrollment data flow already verified for #1352.