### PR TITLE
feat(teacher): add Student Registration Details export above Student Contacts

### DIFF
--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -50,7 +50,7 @@ import { useCourseStore } from "@/store/course-store"
 import type { EnrolledUser, EnrollmentDetails } from "@/types/course.types"
 import { useAuthStore } from "@/store/auth-store"
 import { EnrollmentRole } from "@/types/invite.types"
-import { generateExcel, generateStudentContactsExcel, type ExcelExportOptions } from "@/lib/excel-export"
+import { generateExcel, generateStudentContactsExcel, generateStudentRegistrationDetailsCsv, type ExcelExportOptions, type StudentRegistrationDetailData } from "@/lib/excel-export"
 import {
   downloadGuruSetuFeedbackExport,
   isGuruSetuPilotCourse,
@@ -438,6 +438,7 @@ function CourseEnrollments() {
   const [isSearching, setIsSearching] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isExportingStudentContacts, setIsExportingStudentContacts] = useState(false);
+  const [isExportingStudentRegistrationDetails, setIsExportingStudentRegistrationDetails] = useState(false);
   const [isExportingGuruSetuFeedback, setIsExportingGuruSetuFeedback] = useState(false);
   const [quizExportOptions, setQuizExportOptions] = useState<ExcelExportOptions>({
     includeAttempts: true,
@@ -890,7 +891,7 @@ function CourseEnrollments() {
     debouncedSearch,
     sortBy,
     sortOrder,
-    isExportingStudentContacts,
+    isExportingStudentContacts || isExportingStudentRegistrationDetails,
     'STUDENT',
     statusTab,
     cohort,
@@ -976,6 +977,59 @@ function CourseEnrollments() {
     }
   };
 
+  const handleExportStudentRegistrationDetails = async () => {
+    if (!courseId || !versionId) {
+      toast.error('Course ID or Version ID is missing');
+      return;
+    }
+
+    if (!totalDocuments) {
+      toast.warning('No students found to export');
+      return;
+    }
+
+    const enrollments = exportEnrollmentsData?.enrollments || [];
+
+    if (!enrollments.length) {
+      toast.warning('No students found to export');
+      return;
+    }
+
+    try {
+      const formattedData: StudentRegistrationDetailData[] = enrollments.map((enrollment: any) => ({
+        name:
+          `${enrollment?.user?.firstName ?? ''} ${enrollment?.user?.lastName ?? ''}`.trim() ||
+          'Unknown User',
+        email: enrollment?.user?.email || '',
+        gender: enrollment?.user?.gender || '',
+        country: enrollment?.user?.country || '',
+        state: enrollment?.user?.state || '',
+        city: enrollment?.user?.city || '',
+      }));
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '_');
+      const statusLabel = enrollmentTab === 'ACTIVE' ? 'active' : 'inactive';
+      const courseLabel = sanitizeFilenamePart(course?.name || 'course');
+      const cohortName = cohort
+        ? (version as any)?.cohortDetails?.find((item: any) => item.id === cohort)?.name
+        : null;
+      const cohortLabel = cohortName
+        ? `${sanitizeFilenamePart(cohortName)}_`
+        : '';
+      const filename = `${courseLabel}_${cohortLabel}${statusLabel}_student_registration_details_${timestamp}.csv`;
+
+      generateStudentRegistrationDetailsCsv(formattedData, filename);
+      toast.success('Student registration details exported successfully');
+    } catch (error) {
+      console.error('Error exporting student registration details:', error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to export student registration details',
+      );
+    }
+  };
+
   const handleExportGuruSetuFeedback = async () => {
     if (!courseId || !versionId) {
       toast.error('Course ID or Version ID is missing');
@@ -1040,6 +1094,12 @@ function CourseEnrollments() {
       handleExportStudentContacts().finally(() => setIsExportingStudentContacts(false));
     }
   }, [isExportingStudentContacts, isLoadingStudentContacts, exportEnrollmentsData]);
+
+  useEffect(() => {
+    if (isExportingStudentRegistrationDetails && !isLoadingStudentContacts) {
+      handleExportStudentRegistrationDetails().finally(() => setIsExportingStudentRegistrationDetails(false));
+    }
+  }, [isExportingStudentRegistrationDetails, isLoadingStudentContacts, exportEnrollmentsData]);
 
   const handleResetProgress = (user: EnrolledUser) => {
     setSelectedUser(user)
@@ -1627,8 +1687,10 @@ function CourseEnrollments() {
                   sortOrder={sortOrder}
                   isLoadingQuizScores={isLoadingQuizScores}
                   setIsExporting={setIsExporting}
-                  isExportingStudentContacts={isLoadingStudentContacts}
+                  isExportingStudentContacts={isExportingStudentContacts && isLoadingStudentContacts}
                   setIsExportingStudentContacts={setIsExportingStudentContacts}
+                  isExportingStudentRegistrationDetails={isExportingStudentRegistrationDetails && isLoadingStudentContacts}
+                  setIsExportingStudentRegistrationDetails={setIsExportingStudentRegistrationDetails}
                   isExportingGuruSetuFeedback={isExportingGuruSetuFeedback}
                   onExportGuruSetuFeedback={handleExportGuruSetuFeedback}
                   isGuruSetuCourse={isGuruSetuCourse}
@@ -1674,8 +1736,10 @@ function CourseEnrollments() {
                   sortOrder={sortOrder}
                   isLoadingQuizScores={isLoadingQuizScores}
                   setIsExporting={setIsExporting}
-                  isExportingStudentContacts={isLoadingStudentContacts}
+                  isExportingStudentContacts={isExportingStudentContacts && isLoadingStudentContacts}
                   setIsExportingStudentContacts={setIsExportingStudentContacts}
+                  isExportingStudentRegistrationDetails={isExportingStudentRegistrationDetails && isLoadingStudentContacts}
+                  setIsExportingStudentRegistrationDetails={setIsExportingStudentRegistrationDetails}
                   isExportingGuruSetuFeedback={isExportingGuruSetuFeedback}
                   onExportGuruSetuFeedback={handleExportGuruSetuFeedback}
                   isGuruSetuCourse={isGuruSetuCourse}
@@ -3023,6 +3087,8 @@ interface EnrollmentsTableProps {
   setIsExporting: (exporting: boolean) => void;
   isExportingStudentContacts: boolean;
   setIsExportingStudentContacts: (exporting: boolean) => void;
+  isExportingStudentRegistrationDetails: boolean;
+  setIsExportingStudentRegistrationDetails: (exporting: boolean) => void;
   isExportingGuruSetuFeedback: boolean;
   onExportGuruSetuFeedback: () => void;
   isGuruSetuCourse: boolean;
@@ -3071,6 +3137,8 @@ function EnrollmentsTable({
   setIsExporting,
   isExportingStudentContacts,
   setIsExportingStudentContacts,
+  isExportingStudentRegistrationDetails,
+  setIsExportingStudentRegistrationDetails,
   isExportingGuruSetuFeedback,
   onExportGuruSetuFeedback,
   isGuruSetuCourse,
@@ -3263,7 +3331,16 @@ function EnrollmentsTable({
                 )}
               </DropdownMenuItem>
 
-              <DropdownMenuItem onClick={() => setIsExportingStudentContacts(true)} disabled={isExportingStudentContacts || enrollmentsLoading || isSearching}>
+              <DropdownMenuItem onClick={() => setIsExportingStudentRegistrationDetails(true)} disabled={isExportingStudentContacts || isExportingStudentRegistrationDetails || enrollmentsLoading || isSearching}>
+                {isExportingStudentRegistrationDetails ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Download className="h-4 w-4" />
+                )}
+                <span>{isExportingStudentRegistrationDetails ? "Exporting..." : "Export Student Registration Details"}</span>
+              </DropdownMenuItem>
+
+              <DropdownMenuItem onClick={() => setIsExportingStudentContacts(true)} disabled={isExportingStudentContacts || isExportingStudentRegistrationDetails || enrollmentsLoading || isSearching}>
                 {isExportingStudentContacts ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (

--- a/frontend/src/lib/excel-export.ts
+++ b/frontend/src/lib/excel-export.ts
@@ -5,6 +5,15 @@ export interface StudentContactData {
   email: string;
 }
 
+export interface StudentRegistrationDetailData {
+  name: string;
+  email: string;
+  gender?: string;
+  country?: string;
+  state?: string;
+  city?: string;
+}
+
 interface QuestionScore {
   questionId: string;
   score: number;
@@ -571,4 +580,38 @@ export function generateStudentContactsExcel(
 
   XLSX.utils.book_append_sheet(workbook, worksheet, 'Students');
   XLSX.writeFile(workbook, filename);
+}
+
+export function generateStudentRegistrationDetailsCsv(
+  data: StudentRegistrationDetailData[],
+  filename: string = 'student_registration_details.csv'
+): void {
+  const header = ['S.No.', 'Name', 'Email', 'Gender', 'Country', 'State', 'City'];
+
+  const rows = data.map((student, index) => [
+    index + 1,
+    student.name || 'Unknown User',
+    student.email || '',
+    student.gender || '',
+    student.country || '',
+    student.state || '',
+    student.city || '',
+  ]);
+
+  if (!rows.length) {
+    console.warn('No student registration data to export');
+    return;
+  }
+
+  const worksheet = XLSX.utils.aoa_to_sheet([header, ...rows]);
+  const csv = XLSX.utils.sheet_to_csv(worksheet);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
## Summary

Adds a new "Export Student Registration Details" action to the enrollments page's export menu, positioned above the existing "Export Student Contacts" — pulling the profile fields a student fills in on their own profile page (gender, country, state, city) alongside name/email.

No new API call: the bulk enrollments endpoint already joins the full user document per row (for name/email), so gender/country/state/city ride along in the same response — this just surfaces fields that were already being fetched.



## Testing

`tsc --noEmit` passes clean.