### PR TITLE
fix(frontend): detect method from Request objects too, not just options

### DIFF
--- a/frontend/src/lib/openapi.ts
+++ b/frontend/src/lib/openapi.ts
@@ -36,7 +36,13 @@ export const fetchClient = createFetchClient<paths>({
      * intentionally-empty responses in this API; GET bodies are never re-read
      * here, avoiding the double-buffering cost for the large ones.
      */
-    const method = (options?.method ?? 'GET').toUpperCase();
+    // openapi-fetch bundles the method onto `url` itself (as a Request) for
+    // some calls -- PATCH /users/edit is one -- in which case `options.method`
+    // is null and this used to silently read as GET, skipping the fix below
+    // for exactly the empty-body responses it exists to handle.
+    const method = (
+      (url instanceof Request ? url.method : options?.method) ?? 'GET'
+    ).toUpperCase();
     if (response.ok && response.status !== 204 && method !== 'GET') {
       const text = await response.clone().text();
       if (text.length === 0) {


### PR DESCRIPTION
## Summary

Every profile update (any field, any account role) silently "failed" client-side — even though the backend saved it correctly every time. Confirmed via live Render logs: `PATCH /api/users/edit` consistently returned `200`, but the app still showed "Failed to update profile."

Root cause is in `fetchClient`'s custom `fetch` wrapper (`frontend/src/lib/openapi.ts`). It has an existing fix (a prior commit) for backend endpoints that intentionally return an empty `200` body (`@OnUndefined(200)`) — without it, `openapi-fetch` tries to `.json()`-parse the empty body and throws. That fix is gated on the request method not being `GET`, read via `options?.method`.

The bug: `openapi-fetch` sometimes calls this wrapper with the entire request bundled as a `Request` object passed as `url`, rather than a separate `url` string + `options`. `PATCH /users/edit` is one such call. In that shape, `options.method` is `null`, so the method check silently defaulted to `'GET'` and skipped the empty-body fix entirely — for exactly the request it was supposed to cover.

## Fix

Read the method off `url.method` when `url` is a `Request` instance, falling back to `options?.method` otherwise.

## Testing

Reproduced and root-caused live: instrumented `window.fetch` in the browser console to confirm `options.method` was `null` while `url.method` was correctly `"PATCH"` for this exact call. After the fix, redeployed and confirmed a real profile save now shows "Profile updated successfully" instead of the false failure. `tsc --noEmit` passes clean.