### PR TITLE
fix(frontend): detect method from Request objects too, not just options (main-v1 backport)

### DIFF
--- a/frontend/src/lib/openapi.ts
+++ b/frontend/src/lib/openapi.ts
@@ -36,7 +36,13 @@ export const fetchClient = createFetchClient<paths>({
      * intentionally-empty responses in this API; GET bodies are never re-read
      * here, avoiding the double-buffering cost for the large ones.
      */
-    const method = (options?.method ?? 'GET').toUpperCase();
+    // openapi-fetch bundles the method onto `url` itself (as a Request) for
+    // some calls -- PATCH /users/edit is one -- in which case `options.method`
+    // is null and this used to silently read as GET, skipping the fix below
+    // for exactly the empty-body responses it exists to handle.
+    const method = (
+      (url instanceof Request ? url.method : options?.method) ?? 'GET'
+    ).toUpperCase();
     if (response.ok && response.status !== 204 && method !== 'GET') {
       const text = await response.clone().text();
       if (text.length === 0) {


### PR DESCRIPTION
Backport of #1358 to \`main-v1\`.

## Summary

Every profile update (any field, any account role) silently "failed" client-side — even though the backend saved it correctly every time. Confirmed via live Render logs: \`PATCH /api/users/edit\` consistently returned \`200\`, but the app still showed "Failed to update profile."

\`fetchClient\`'s custom \`fetch\` wrapper (\`frontend/src/lib/openapi.ts\`) has an existing fix for backend endpoints that intentionally return an empty \`200\` body (\`@OnUndefined(200)\`) — without it, \`openapi-fetch\` tries to \`.json()\`-parse the empty body and throws. That fix is gated on the request method not being \`GET\`, read via \`options?.method\`.

The bug: \`openapi-fetch\` sometimes calls this wrapper with the entire request bundled as a \`Request\` object passed as \`url\`, rather than a separate \`url\` string + \`options\`. \`PATCH /users/edit\` is one such call. In that shape, \`options.method\` is \`null\`, so the method check silently defaulted to \`'GET'\` and skipped the empty-body fix entirely — for exactly the request it was supposed to cover.

## Fix

Read the method off \`url.method\` when \`url\` is a \`Request\` instance, falling back to \`options?.method\` otherwise.

## Testing

Same as #1358: reproduced and root-caused live via Render logs and an instrumented \`window.fetch\`, confirmed the fix resolves it. \`tsc --noEmit\` passes clean. Cherry-picked cleanly with no conflicts.