### PR TITLE
fix(progress): include cohort-scoped students in the public leaderboard

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -5230,11 +5230,16 @@ class ProgressService extends BaseService {
       throw new BadRequestError(`Invalid courseVersionId: ${courseVersionId}`);
     }
 
-    // Get all progress records for this course version
+    // Get all progress records for this course version. This is the public,
+    // cohort-agnostic leaderboard, so it must include cohort-scoped progress
+    // too — not just the cohort-less legacy case.
     const progressRecords =
       await this.progressRepository.getAllProgressForCourseVersion(
         courseId,
         courseVersionId,
+        undefined,
+        undefined,
+        true,
       );
 
     if (!progressRecords) {
@@ -5243,10 +5248,15 @@ class ProgressService extends BaseService {
       );
     }
 
-    // Get all enrollments to fetch completion percentages
+    // Get all enrollments to fetch completion percentages. This is the
+    // public, cohort-agnostic leaderboard, so it must include cohort-scoped
+    // enrollments too — not just the cohort-less legacy case.
     const enrollments = await this.enrollmentRepo.getEnrollmentsByCourseVersion(
       courseId,
       courseVersionId,
+      undefined,
+      undefined,
+      true,
     );
 
     if (!enrollments || enrollments.length === 0) {

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -3936,6 +3936,12 @@ export class EnrollmentRepository {
     courseVersionId: string,
     cohortId?: string,
     session?: ClientSession,
+    // When no cohortId is given, default to the no-cohort-only enrollments
+    // (matches existing callers that scope a single cohort or the legacy,
+    // cohort-less case). Pass true to include every cohort instead — for
+    // callers, like the public leaderboard, that want every enrolled student
+    // regardless of cohort.
+    allCohorts = false,
   ): Promise<IEnrollment[]> {
     try {
       await this.init();
@@ -3952,7 +3958,9 @@ export class EnrollmentRepository {
             isDeleted: { $ne: true },
             ...(cohortId
               ? { cohortId: new ObjectId(cohortId) }
-              : { cohortId: null }),
+              : allCohorts
+                ? {}
+                : { cohortId: null }),
           },
           { session },
         )

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -1050,6 +1050,12 @@ class ProgressRepository {
     courseVersionId: string,
     cohortId?: string,
     session?: ClientSession,
+    // When no cohortId is given, default to the no-cohort-only records
+    // (matches existing callers that scope a single cohort or the legacy,
+    // cohort-less case). Pass true to include every cohort instead — for
+    // callers, like the public leaderboard, that want every student
+    // regardless of cohort.
+    allCohorts = false,
   ): Promise<IProgress[]> {
     await this.init();
     const progressRecords = await this.progressCollection
@@ -1057,7 +1063,11 @@ class ProgressRepository {
         {
           courseId: { $in: [new ObjectId(courseId), courseId] },
           courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
-          ...(cohortId ? this.cohortIdMatch(cohortId) : {cohortId: null}),
+          ...(cohortId
+            ? this.cohortIdMatch(cohortId)
+            : allCohorts
+              ? {}
+              : {cohortId: null}),
         },
         { session },
       )


### PR DESCRIPTION
`getLeaderboardNoAuth` (the public, unauthenticated leaderboard endpoint) called `getEnrollmentsByCourseVersion` and `getAllProgressForCourseVersion` without a `cohortId`. Both repository methods default an omitted `cohortId` to `{cohortId: null}` in their query — matching only the legacy, cohort-less records. For cohort-based courses this silently excluded most or all students, so the endpoint returned "No enrollments found" (400) even for courses with thousands of active enrollments.

Confirmed directly against production data: for one affected course (1,899 enrollments), the query matched 0 records before this fix and 250 after (the remainder correctly excluded by the pre-existing, working `status: ACTIVE` filter — 1,625 of that course's enrollments are `INACTIVE` and are intentionally not shown on the leaderboard).

Fix: added an opt-in `allCohorts` flag to both repository methods, defaulting to `false` so every existing caller — including the authed `getLeaderboard`, which already threads `cohortId` through correctly — keeps its current behavior unchanged. Only `getLeaderboardNoAuth` passes `allCohorts: true`, since the public leaderboard should show every enrolled student regardless of cohort.

**Verified:**
- Full backend typecheck passes clean.
- All existing tests pass (`ProgressService.leaderboard.test.ts`, `EnrollmentRepository.courseCompletions/cohortDeletion/versionStats/bulkRecomputeCohort.test.ts` — 24 tests, all green).
- 5 pre-existing failures elsewhere (`ProgressService.stopItemEnrollment.test.ts` and others, `isItemCompleted is not a function`) reproduced identically on `main` before this change — unrelated, not introduced by this fix.
- Simulated the fixed query directly against production data to confirm the enrollment count goes from 0 to the correct non-zero value.
