### PR TITLE
feat(case-studies): add CASE_STUDY item type with peer pairwise-review module

### DIFF
--- a/backend/src/modules/anomalies/classes/transformers/Anomaly.ts
+++ b/backend/src/modules/anomalies/classes/transformers/Anomaly.ts
@@ -10,6 +10,10 @@ export enum AnomalyType {
   FOCUS = 'FOCUS',
   HAND_GESTURE_DETECTION = 'HAND_GESTURE_DETECTION',
   FACE_RECOGNITION = 'FACE_RECOGNITION',
+  // Case-studies proctoring extensions — see PLANNING.md §4.9. Additive to
+  // the existing seven; nothing above changes shape or meaning.
+  TAB_SWITCH_DURING_REVIEW = 'TAB_SWITCH_DURING_REVIEW',
+  PASTE_ATTEMPTED = 'PASTE_ATTEMPTED',
 }
 
 export enum FileType {
@@ -130,6 +134,20 @@ export class AnomalyStats {
   })
   FACE_RECOGNITION: number;
 
+  @IsNumber()
+  @JSONSchema({
+    title: 'Number of tab-switch-during-review anomalies',
+    description: 'Number of times a reviewer switched away during a case-studies comparison timer',
+  })
+  TAB_SWITCH_DURING_REVIEW: number;
+
+  @IsNumber()
+  @JSONSchema({
+    title: 'Number of blocked paste attempts',
+    description: 'Number of times a paste was blocked in the case-studies response composer',
+  })
+  PASTE_ATTEMPTED: number;
+
   constructor() {
     this.VOICE_DETECTION = 0;
     this.NO_FACE = 0;
@@ -138,6 +156,8 @@ export class AnomalyStats {
     this.FOCUS = 0;
     this.HAND_GESTURE_DETECTION = 0;
     this.FACE_RECOGNITION = 0;
+    this.TAB_SWITCH_DURING_REVIEW = 0;
+    this.PASTE_ATTEMPTED = 0;
   }
 }
 

--- a/backend/src/modules/anomalies/services/AnomalyService.ts
+++ b/backend/src/modules/anomalies/services/AnomalyService.ts
@@ -335,6 +335,12 @@ export class AnomalyService extends BaseService {
           case AnomalyType.FACE_RECOGNITION:
             stats.FACE_RECOGNITION++;
             break;
+          case AnomalyType.TAB_SWITCH_DURING_REVIEW:
+            stats.TAB_SWITCH_DURING_REVIEW++;
+            break;
+          case AnomalyType.PASTE_ATTEMPTED:
+            stats.PASTE_ATTEMPTED++;
+            break;
         }
       });
       return stats;

--- a/backend/src/modules/caseStudies/classes/index.ts
+++ b/backend/src/modules/caseStudies/classes/index.ts
@@ -1,0 +1,2 @@
+export * from './transformers/index.js';
+export * from './validators/index.js';

--- a/backend/src/modules/caseStudies/classes/transformers/CaseComparison.ts
+++ b/backend/src/modules/caseStudies/classes/transformers/CaseComparison.ts
@@ -1,0 +1,34 @@
+import {ObjectId} from 'mongodb';
+
+export type CaseComparisonOutcome = 'A' | 'B' | 'BOTH_WEAK' | 'FLAGGED';
+
+/**
+ * One pair served to one reviewer for one case, and its outcome once picked.
+ *
+ * `responseAId`/`responseBId` are always stored in sorted-id order (not
+ * "first served" order) so the unique `(reviewerId, responseAId, responseBId)`
+ * index catches a pair regardless of which response the reviewer saw on the
+ * left — `sideAIsLeft` carries the actual display placement separately.
+ *
+ * `servedAt`/`minimumScreenTimeSeconds` are the server-anchored timer: the
+ * client never supplies its own elapsed time, and re-requesting "next pair"
+ * while this row is still undecided (`outcome` unset) re-serves the same row
+ * with these two fields unchanged. That is what makes leaving and returning
+ * restart the visible countdown without letting a page refresh reset the
+ * server clock.
+ */
+export interface ICaseComparison {
+  _id?: ObjectId;
+  caseStudyId: ObjectId;
+  courseVersionId: ObjectId;
+  reviewerId: ObjectId;
+  responseAId: ObjectId;
+  responseBId: ObjectId;
+  /** Randomised placement, recorded for audit; never re-randomised on re-serve. */
+  sideAIsLeft: boolean;
+  servedAt: Date;
+  minimumScreenTimeSeconds: number;
+  outcome?: CaseComparisonOutcome;
+  decidedAt?: Date;
+  createdAt: Date;
+}

--- a/backend/src/modules/caseStudies/classes/transformers/CaseResponse.ts
+++ b/backend/src/modules/caseStudies/classes/transformers/CaseResponse.ts
@@ -1,0 +1,109 @@
+import {ObjectId} from 'mongodb';
+
+/**
+ * OPEN      = in the review pool, has not yet reached the win threshold.
+ * WON       = reached WINS_REQUIRED wins; no longer served to reviewers.
+ * WITHDRAWN = flagged as unjudgeable by UNJUDGEABLE_FLAG_THRESHOLD reviewers;
+ *             removed from the pool until the author revises and resubmits.
+ */
+export type CaseResponseStatus = 'OPEN' | 'WON' | 'WITHDRAWN';
+
+/**
+ * One participant's response to one case study — structured as six elements
+ * (FR-12). Only `steelman` (element 2a) is exposed to peer reviewers; the
+ * remaining fields inform the author's own reflection and are stored but not
+ * shared with anyone else.
+ *
+ * `winCount`/`comparisonsSeenCount`/`flagCount` are denormalised onto the
+ * document so the pair-selection query can sort "least-served first" and the
+ * win/withdraw thresholds can be checked without an aggregation over
+ * `caseComparisons`. They are only ever mutated through atomic `$inc`
+ * alongside a comparison's pick — see `CaseStudyRepository.applyPickEffects`.
+ */
+export interface ICaseResponse {
+  _id?: ObjectId;
+  userId: ObjectId;
+  courseVersionId: ObjectId;
+  caseStudyId: ObjectId;
+  /** Element 1a — what the participant thought going in (~1 sentence). */
+  beat1a: string;
+  /** Element 1b — what challenged that position, or what gave most pause (~1 sentence). */
+  beat1b: string;
+  /** Element 1c — where the participant ended up (~1 sentence). */
+  beat1c: string;
+  /** Element 2a — strongest case against where they landed (≥ 25 words). Shown to reviewers. */
+  steelman: string;
+  /** Element 2b — one perspective from the room; never shown to reviewers. */
+  roomPerspective: string;
+  /** Element 3 — one thing to change; must answer the cost named in steelman (~1 sentence). */
+  changeCommitment: string;
+  /** ISO date string from the Zoom session declaration gate (YYYY-MM-DD). Not validated server-side. */
+  zoomSessionDate?: string;
+  status: CaseResponseStatus;
+  /** Times picked as "better" in a valid, non-flagged comparison. */
+  winCount: number;
+  /** Total times shown in a served pair, win or not — drives least-served-first serving. */
+  comparisonsSeenCount: number;
+  flagCount: number;
+  /**
+   * Consecutive substantive verdicts (A/B/BOTH_WEAK) in which this response was
+   * NOT picked as the stronger side, reset to 0 the moment it wins. Crossing the
+   * course's configured threshold fires a "your response may need revising"
+   * notification — see `CaseStudyRepository.applyPickEffects`.
+   */
+  weakStreak: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class CaseResponse implements ICaseResponse {
+  _id?: ObjectId;
+  userId: ObjectId;
+  courseVersionId: ObjectId;
+  caseStudyId: ObjectId;
+  beat1a: string;
+  beat1b: string;
+  beat1c: string;
+  steelman: string;
+  roomPerspective: string;
+  changeCommitment: string;
+  zoomSessionDate?: string;
+  status: CaseResponseStatus;
+  winCount: number;
+  comparisonsSeenCount: number;
+  flagCount: number;
+  weakStreak: number;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(input: {
+    userId: string;
+    courseVersionId: string;
+    caseStudyId: string;
+    beat1a: string;
+    beat1b: string;
+    beat1c: string;
+    steelman: string;
+    roomPerspective: string;
+    changeCommitment: string;
+    zoomSessionDate?: string;
+  }) {
+    this.userId = new ObjectId(input.userId);
+    this.courseVersionId = new ObjectId(input.courseVersionId);
+    this.caseStudyId = new ObjectId(input.caseStudyId);
+    this.beat1a = input.beat1a;
+    this.beat1b = input.beat1b;
+    this.beat1c = input.beat1c;
+    this.steelman = input.steelman;
+    this.roomPerspective = input.roomPerspective;
+    this.changeCommitment = input.changeCommitment;
+    if (input.zoomSessionDate) this.zoomSessionDate = input.zoomSessionDate;
+    this.status = 'OPEN';
+    this.winCount = 0;
+    this.comparisonsSeenCount = 0;
+    this.flagCount = 0;
+    this.weakStreak = 0;
+    this.createdAt = new Date();
+    this.updatedAt = new Date();
+  }
+}

--- a/backend/src/modules/caseStudies/classes/transformers/CaseStudy.ts
+++ b/backend/src/modules/caseStudies/classes/transformers/CaseStudy.ts
@@ -1,0 +1,38 @@
+import {ObjectId} from 'mongodb';
+
+/**
+ * The peer-review record backing one CASE_STUDY course item.
+ *
+ * Its `_id` is the item's own `_id` (see `CaseStudyRepository.upsertForItem`),
+ * so the review runtime keys on the item directly. Content and config are
+ * synced from the item on every open; there is no separate authoring form.
+ *
+ * This interface intentionally has no answer, rubric, or expected-response
+ * field anywhere on it — a case study is scored only by how its responses
+ * fare in peer pairwise comparison (see CaseComparison), never against a
+ * reference answer. That is a structural property of the schema, not just a
+ * convention: there is nowhere on this document to put one.
+ */
+export interface ICaseStudy {
+  _id?: ObjectId;
+  courseId: ObjectId;
+  courseVersionId: ObjectId;
+  title: string;
+  /** Plain prose prompt — no labelled sections/template. */
+  bodyMarkdown: string;
+  /**
+   * Per-item review knobs, synced from the CASE_STUDY item's details on every
+   * `ensureCaseForItem` so the engine reads them off this doc without an
+   * item→version lookup. Undefined falls back to the module constants
+   * (WINS_REQUIRED / REVIEWER_MIN_PICKS_PER_CASE / DEFAULT_WEAK_STREAK_THRESHOLD).
+   */
+  /** Wins a response needs before it leaves the review pool. */
+  reviewsRequired?: number;
+  /** Comparisons each reviewer is asked to judge (soft floor shown to the learner). */
+  picksRequired?: number;
+  /** Consecutive losses before the author is nudged to revise (0 disables). */
+  weakStreakThreshold?: number;
+  isDeleted?: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/src/modules/caseStudies/classes/transformers/index.ts
+++ b/backend/src/modules/caseStudies/classes/transformers/index.ts
@@ -1,0 +1,3 @@
+export * from './CaseStudy.js';
+export * from './CaseResponse.js';
+export * from './CaseComparison.js';

--- a/backend/src/modules/caseStudies/classes/validators/CaseStudyValidators.ts
+++ b/backend/src/modules/caseStudies/classes/validators/CaseStudyValidators.ts
@@ -1,0 +1,84 @@
+import {
+  IsIn,
+  IsMongoId,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import {JSONSchema} from 'class-validator-jsonschema';
+import {ELEMENT_2A_MIN_WORDS} from '../../constants.js';
+
+export class CaseStudyIdPathParams {
+  @IsMongoId()
+  caseStudyId!: string;
+}
+
+export class ComparisonIdPathParams {
+  @IsMongoId()
+  comparisonId!: string;
+}
+
+export class SubmitCaseResponseBody {
+  @IsString()
+  @IsNotEmpty()
+  @JSONSchema({description: 'Element 1a — what the participant thought going in (~1 sentence).'})
+  beat1a!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @JSONSchema({description: 'Element 1b — what challenged that position, or what gave most pause (~1 sentence).'})
+  beat1b!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @JSONSchema({description: 'Element 1c — where the participant ended up (~1 sentence).'})
+  beat1c!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @JSONSchema({
+    description: `Element 2a — strongest case against where they landed (≥ ${ELEMENT_2A_MIN_WORDS} words, checked server-side). This is the only field shown to peer reviewers.`,
+    example: 'The strongest counterargument is that students who are confused often need direct explanation first, and Socratic questioning can feel frustrating when the student genuinely does not know what they do not know.',
+  })
+  steelman!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @JSONSchema({description: "Element 2b — one perspective from the room; stored but never shown to reviewers. 'Room broadly agreed with me' is a valid answer."})
+  roomPerspective!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @JSONSchema({description: 'Element 3 — one concrete thing to change; must answer the cost named in the steelman.'})
+  changeCommitment!: string;
+
+  @IsOptional()
+  @IsString()
+  @JSONSchema({description: 'ISO date string (YYYY-MM-DD) from the Zoom session declaration gate. Stored verbatim, not validated.'})
+  zoomSessionDate?: string;
+}
+
+export class SubmitPickBody {
+  @IsIn(['A', 'B', 'BOTH_WEAK', 'FLAGGED'])
+  @JSONSchema({
+    description:
+      "The reviewer's forced-choice verdict. 'BOTH_WEAK' is a substantive " +
+      "judgment ('neither response is strong') and counts toward the " +
+      "reviewer's quota; 'FLAGGED' marks the pair as unjudgeable " +
+      '(garbled/broken) and does not.',
+    example: 'A',
+  })
+  outcome!: 'A' | 'B' | 'BOTH_WEAK' | 'FLAGGED';
+}
+
+export class InstructorCaseResponsesPathParams {
+  @IsMongoId()
+  courseId!: string;
+
+  @IsMongoId()
+  versionId!: string;
+
+  @IsMongoId()
+  itemId!: string;
+}
+

--- a/backend/src/modules/caseStudies/classes/validators/index.ts
+++ b/backend/src/modules/caseStudies/classes/validators/index.ts
@@ -1,0 +1,1 @@
+export * from './CaseStudyValidators.js';

--- a/backend/src/modules/caseStudies/constants.ts
+++ b/backend/src/modules/caseStudies/constants.ts
@@ -1,0 +1,92 @@
+/**
+ * Tuning knobs for the case-studies write/review loop.
+ *
+ * Win model: Model A (win-count) per the 2026-08-12 decision recorded in
+ * TASK.md's "Discovered mid-process" section — a response needs
+ * WINS_REQUIRED wins, uncapped total comparisons, no majority vote, and
+ * losses never count against it.
+ */
+
+/** Minimum word count for the steelman field (element 2a) — enforced server-side. */
+export const ELEMENT_2A_MIN_WORDS = 25;
+
+/** Minimum word count for all other single-sentence response fields — enforced server-side. */
+export const FIELD_MIN_WORDS = 5;
+
+/** Times a response must be picked as "better" before it leaves the review pool. */
+export const WINS_REQUIRED = 7;
+
+/**
+ * Soft floor shown to reviewers ("N of 7 done") — not an enforced ceiling.
+ * Milestone 0's resolved default: reviewing is open-ended, a participant may
+ * always choose to do more than the floor.
+ */
+export const REVIEWER_MIN_PICKS_PER_CASE = 7;
+
+/** The reading-timer formula's anchor rate — the planning transcript's own worked example. */
+export const WORDS_PER_MINUTE_NON_NATIVE = 75;
+
+/**
+ * Extra time on top of raw reading time, as a fraction of it. Flagged
+ * tunable — the source transcript floated 25%/40%/50%; 40% was chosen as the
+ * Milestone-0 default and is meant to be revisited live with the client
+ * rather than treated as settled.
+ */
+export const THINKING_TIME_FRACTION = 0.4;
+
+export const MAX_LIST_LIMIT = 200;
+
+/**
+ * Fallbacks used when a course version has no CourseSetting document yet
+ * (mirrors the defaults `CourseSettingService.readCourseSettings` writes on
+ * first read) — see `CourseSetting.settings.caseStudyStrictUnlockEnabled` /
+ * `.caseStudyWeakStreakThreshold`.
+ */
+export const DEFAULT_STRICT_UNLOCK_ENABLED = true;
+export const DEFAULT_WEAK_STREAK_THRESHOLD = 3;
+
+/**
+ * Number of FLAGGED verdicts on a single response that triggers automatic
+ * withdrawal from the review pool. Both responses in a flagged pair receive
+ * a flag, so this is reached independently per response.
+ */
+export const UNJUDGEABLE_FLAG_THRESHOLD = 2;
+
+/**
+ * Word count for the response cap and the reading-timer formula. Deliberately
+ * not `.split(' ')` — case-study bodies and responses mix Hindi and English
+ * freely, and a naive ASCII split either double-counts or mis-splits
+ * Devanagari text. This counts runs of letters/combining-marks/digits, so a
+ * combining vowel sign stays attached to its base consonant instead of
+ * splitting one word into two.
+ */
+export function countWords(text: string): number {
+  const matches = text.trim().match(/[\p{L}\p{M}\p{N}]+/gu);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * Detects obvious gibberish: text where the same word is repeated so often
+ * that fewer than 40% of tokens are distinct. Only applied when wordCount ≥ 4
+ * to avoid false positives on very short phrases.
+ */
+export function isGibberish(text: string): boolean {
+  const words = text.toLowerCase().match(/[\p{L}\p{M}\p{N}]+/gu) ?? [];
+  if (words.length < 4) return false;
+  const unique = new Set(words).size;
+  return unique < Math.max(3, Math.ceil(words.length * 0.4));
+}
+
+/**
+ * The reading-timer lock formula: minimum time is computed from both steelman
+ * word counts. E.g. two 50-word steelmans → 100 / 1.25 * 1.4 ≈ 112 seconds.
+ */
+export function computeMinimumScreenTimeSeconds(
+  wordCountA: number,
+  wordCountB: number,
+): number {
+  const combinedWordCount = wordCountA + wordCountB;
+  const baseReadingSeconds =
+    combinedWordCount / (WORDS_PER_MINUTE_NON_NATIVE / 60);
+  return Math.round(baseReadingSeconds * (1 + THINKING_TIME_FRACTION));
+}

--- a/backend/src/modules/caseStudies/container.ts
+++ b/backend/src/modules/caseStudies/container.ts
@@ -1,0 +1,18 @@
+import {ContainerModule} from 'inversify';
+import {CASE_STUDIES_TYPES} from './types.js';
+import {CaseStudyService} from './services/CaseStudyService.js';
+import {CaseStudyController} from './controllers/CaseStudyController.js';
+import {CaseStudyRepository} from './repositories/providers/mongodb/CaseStudyRepository.js';
+
+export const caseStudiesContainerModule = new ContainerModule(options => {
+  // Repository
+  options.bind(CaseStudyRepository).toSelf().inSingletonScope();
+  options.bind(CASE_STUDIES_TYPES.CaseStudyRepo).to(CaseStudyRepository);
+
+  // Service
+  options.bind(CaseStudyService).toSelf().inSingletonScope();
+  options.bind(CASE_STUDIES_TYPES.CaseStudyService).to(CaseStudyService);
+
+  // Controller
+  options.bind(CaseStudyController).toSelf().inSingletonScope();
+});

--- a/backend/src/modules/caseStudies/controllers/CaseStudyController.ts
+++ b/backend/src/modules/caseStudies/controllers/CaseStudyController.ts
@@ -1,0 +1,263 @@
+import {subject} from '@casl/ability';
+import {inject, injectable} from 'inversify';
+import {
+  Authorized,
+  Body,
+  CurrentUser,
+  ForbiddenError,
+  Get,
+  HttpCode,
+  JsonController,
+  Param,
+  Params,
+  Patch,
+  Post,
+} from 'routing-controllers';
+import {OpenAPI} from 'routing-controllers-openapi';
+import {IUser} from '#root/shared/interfaces/models.js';
+import {Ability} from '#root/shared/functions/AbilityDecorator.js';
+import {
+  ItemActions,
+  getItemAbility,
+} from '../../courses/abilities/itemAbilities.js';
+import {
+  CourseActions,
+  getCourseAbility,
+} from '../../courses/abilities/courseAbilities.js';
+import {CASE_STUDIES_TYPES} from '../types.js';
+import {CaseStudyService} from '../services/CaseStudyService.js';
+import {
+  CaseStudyIdPathParams,
+  ComparisonIdPathParams,
+  InstructorCaseResponsesPathParams,
+  SubmitCaseResponseBody,
+  SubmitPickBody,
+} from '../classes/validators/CaseStudyValidators.js';
+
+@OpenAPI({
+  tags: ['Case Studies'],
+})
+@JsonController('/case-studies')
+@injectable()
+export class CaseStudyController {
+  constructor(
+    @inject(CASE_STUDIES_TYPES.CaseStudyService)
+    private readonly service: CaseStudyService,
+  ) {}
+
+  // -----------------------------------------------------------------
+  // Participant-facing
+  // -----------------------------------------------------------------
+
+  /**
+   * Sync + fetch the case backing a CASE_STUDY course item. The learner panel
+   * calls this on open with the course context it already has, so the runtime
+   * can key on the item's own id. Idempotent.
+   */
+  @Authorized()
+  @Post('/courses/:courseId/versions/:versionId/items/:itemId/ensure')
+  @HttpCode(200)
+  async ensureCaseForItem(
+    @Param('courseId') courseId: string,
+    @Param('versionId') versionId: string,
+    @Param('itemId') itemId: string,
+    @Ability(getItemAbility) {ability}: any,
+  ) {
+    this.assertCanAccessItem(ability, {courseId, versionId, itemId});
+    const caseStudy = await this.service.ensureCaseForItem({
+      courseId,
+      courseVersionId: versionId,
+      itemId,
+    });
+    return {
+      caseStudyId: caseStudy._id!.toString(),
+      title: caseStudy.title,
+      bodyMarkdown: caseStudy.bodyMarkdown,
+    };
+  }
+
+  @Authorized()
+  @Get('/:caseStudyId/my-response')
+  @HttpCode(200)
+  async getMyResponse(
+    @Params() params: CaseStudyIdPathParams,
+    @CurrentUser() user: IUser,
+    @Ability(getItemAbility) {ability}: any,
+  ) {
+    const caseStudy = await this.service.getCaseStudyOrThrow(params.caseStudyId);
+    this.assertCanAccessItem(ability, {
+      courseId: caseStudy.courseId.toString(),
+      versionId: caseStudy.courseVersionId.toString(),
+      itemId: params.caseStudyId,
+    });
+    return this.service.getMyResponse({
+      userId: this.requireUserId(user),
+      caseStudyId: params.caseStudyId,
+    });
+  }
+
+  @Authorized()
+  @Post('/:caseStudyId/responses')
+  @HttpCode(201)
+  async submitResponse(
+    @Params() params: CaseStudyIdPathParams,
+    @Body() body: SubmitCaseResponseBody,
+    @CurrentUser() user: IUser,
+    @Ability(getItemAbility) {ability}: any,
+  ) {
+    const caseStudy = await this.service.getCaseStudyOrThrow(params.caseStudyId);
+    this.assertCanAccessItem(ability, {
+      courseId: caseStudy.courseId.toString(),
+      versionId: caseStudy.courseVersionId.toString(),
+      itemId: params.caseStudyId,
+    });
+    return this.service.submitResponse({
+      userId: this.requireUserId(user),
+      caseStudyId: params.caseStudyId,
+      beat1a: body.beat1a,
+      beat1b: body.beat1b,
+      beat1c: body.beat1c,
+      steelman: body.steelman,
+      roomPerspective: body.roomPerspective,
+      changeCommitment: body.changeCommitment,
+      zoomSessionDate: body.zoomSessionDate,
+    });
+  }
+
+  @Authorized()
+  @Patch('/:caseStudyId/responses')
+  @HttpCode(200)
+  async reviseResponse(
+    @Params() params: CaseStudyIdPathParams,
+    @Body() body: SubmitCaseResponseBody,
+    @CurrentUser() user: IUser,
+    @Ability(getItemAbility) {ability}: any,
+  ) {
+    const caseStudy = await this.service.getCaseStudyOrThrow(params.caseStudyId);
+    this.assertCanAccessItem(ability, {
+      courseId: caseStudy.courseId.toString(),
+      versionId: caseStudy.courseVersionId.toString(),
+      itemId: params.caseStudyId,
+    });
+    return this.service.reviseResponse({
+      userId: this.requireUserId(user),
+      caseStudyId: params.caseStudyId,
+      beat1a: body.beat1a,
+      beat1b: body.beat1b,
+      beat1c: body.beat1c,
+      steelman: body.steelman,
+      roomPerspective: body.roomPerspective,
+      changeCommitment: body.changeCommitment,
+    });
+  }
+
+  /**
+   * Serves the next pair to review, or `{pair: null}` when the pool is
+   * exhausted for this reviewer — matching `ReflectionController`'s
+   * "nothing left to review is an ordinary state" convention.
+   */
+  @Authorized()
+  @Get('/:caseStudyId/pairs/next')
+  @HttpCode(200)
+  async getNextPair(
+    @Params() params: CaseStudyIdPathParams,
+    @CurrentUser() user: IUser,
+    @Ability(getItemAbility) {ability}: any,
+  ) {
+    const caseStudy = await this.service.getCaseStudyOrThrow(params.caseStudyId);
+    this.assertCanAccessItem(ability, {
+      courseId: caseStudy.courseId.toString(),
+      versionId: caseStudy.courseVersionId.toString(),
+      itemId: params.caseStudyId,
+    });
+    const pair = await this.service.getNextPair({
+      reviewerId: this.requireUserId(user),
+      caseStudyId: params.caseStudyId,
+    });
+    return {pair};
+  }
+
+  @Authorized()
+  @Post('/pairs/:comparisonId/pick')
+  @HttpCode(200)
+  async submitPick(
+    @Params() params: ComparisonIdPathParams,
+    @Body() body: SubmitPickBody,
+    @CurrentUser() user: IUser,
+    @Ability(getItemAbility) {ability}: any,
+  ) {
+    const context = await this.service.getComparisonContext(params.comparisonId);
+    this.assertCanAccessItem(ability, {
+      courseId: context.courseId,
+      versionId: context.courseVersionId,
+      itemId: context.caseStudyId,
+    });
+    return this.service.submitPick({
+      reviewerId: this.requireUserId(user),
+      comparisonId: params.comparisonId,
+      outcome: body.outcome,
+    });
+  }
+
+  // -----------------------------------------------------------------
+  // Instructor-facing
+  // -----------------------------------------------------------------
+
+  /**
+   * All responses for a CASE_STUDY item, sorted newest first.
+   * Gated on instructor-level course access (same check as the reflection
+   * instructor listing) — author identities are visible to instructors.
+   */
+  @Authorized()
+  @Get('/courses/:courseId/versions/:versionId/items/:itemId/responses')
+  @HttpCode(200)
+  async listResponsesForInstructor(
+    @Params() params: InstructorCaseResponsesPathParams,
+    @Ability(getCourseAbility) {ability}: any,
+  ) {
+    this.assertCanManageCourse(ability, params.courseId);
+    const responses = await this.service.listResponsesForInstructor(params.itemId);
+    return {responses};
+  }
+
+  private requireUserId(user: IUser): string {
+    const userId = user?._id?.toString();
+    if (!userId) {
+      throw new ForbiddenError('Unable to resolve authenticated user.');
+    }
+    return userId;
+  }
+
+  private assertCanManageCourse(ability: any, courseId: string): void {
+    if (!ability.can(CourseActions.Modify, subject('Course', {courseId}))) {
+      throw new ForbiddenError(
+        'You do not have permission to view responses for this course.',
+      );
+    }
+  }
+
+  /**
+   * A learner may only act on a case-study item they can actually reach. The
+   * item ability encodes enrolment and, when linear progression is on, the
+   * completed-plus-current allow list — the same gate every other item type
+   * uses (see ReflectionController). Version-level access was too permissive:
+   * it let a learner open and submit a case study out of sequence, which then
+   * could never complete because start/stop require it to be the current item.
+   */
+  private assertCanAccessItem(
+    ability: any,
+    ref: {courseId: string; versionId: string; itemId: string},
+  ): void {
+    const allowed = ability.can(
+      ItemActions.View,
+      subject('Item', {
+        courseId: ref.courseId,
+        versionId: ref.versionId,
+        itemId: ref.itemId,
+      }),
+    );
+    if (!allowed) {
+      throw new ForbiddenError('You do not have access to this case study item.');
+    }
+  }
+}

--- a/backend/src/modules/caseStudies/controllers/index.ts
+++ b/backend/src/modules/caseStudies/controllers/index.ts
@@ -1,0 +1,1 @@
+export * from './CaseStudyController.js';

--- a/backend/src/modules/caseStudies/index.ts
+++ b/backend/src/modules/caseStudies/index.ts
@@ -1,0 +1,59 @@
+import {Container, ContainerModule} from 'inversify';
+import {RoutingControllersOptions, useContainer} from 'routing-controllers';
+import {sharedContainerModule} from '#root/container.js';
+import {InversifyAdapter} from '#root/inversify-adapter.js';
+import {authContainerModule} from '../auth/container.js';
+import {settingContainerModule} from '../setting/container.js';
+import {notificationsContainerModule} from '../notifications/container.js';
+import {caseStudiesContainerModule} from './container.js';
+import {CaseStudyController} from './controllers/CaseStudyController.js';
+import {
+  CaseStudyIdPathParams,
+  ComparisonIdPathParams,
+  SubmitCaseResponseBody,
+  SubmitPickBody,
+} from './classes/validators/CaseStudyValidators.js';
+
+export const caseStudiesContainerModules: ContainerModule[] = [
+  caseStudiesContainerModule,
+  sharedContainerModule,
+  authContainerModule,
+  // CaseStudyService reads CourseSetting (caseStudiesEnabled/unlock mode/weak
+  // streak threshold) and emits NotificationService notifications.
+  settingContainerModule,
+  notificationsContainerModule,
+];
+
+export const caseStudiesModuleControllers: Function[] = [CaseStudyController];
+
+export async function setupCaseStudiesContainer(): Promise<void> {
+  const container = new Container();
+  await container.load(...caseStudiesContainerModules);
+  const inversifyAdapter = new InversifyAdapter(container);
+  useContainer(inversifyAdapter);
+}
+
+export const caseStudiesModuleOptions: RoutingControllersOptions = {
+  controllers: caseStudiesModuleControllers,
+  middlewares: [],
+  defaultErrorHandler: true,
+  authorizationChecker: async function () {
+    return true;
+  },
+  validation: true,
+};
+
+export const caseStudiesModuleValidators: Function[] = [
+  CaseStudyIdPathParams,
+  ComparisonIdPathParams,
+  SubmitCaseResponseBody,
+  SubmitPickBody,
+];
+
+export * from './classes/index.js';
+export * from './controllers/index.js';
+export * from './services/index.js';
+export * from './repositories/index.js';
+export * from './types.js';
+export * from './container.js';
+export * from './constants.js';

--- a/backend/src/modules/caseStudies/repositories/index.ts
+++ b/backend/src/modules/caseStudies/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './providers/index.js';

--- a/backend/src/modules/caseStudies/repositories/providers/index.ts
+++ b/backend/src/modules/caseStudies/repositories/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './mongodb/CaseStudyRepository.js';

--- a/backend/src/modules/caseStudies/repositories/providers/mongodb/CaseStudyRepository.ts
+++ b/backend/src/modules/caseStudies/repositories/providers/mongodb/CaseStudyRepository.ts
@@ -1,0 +1,684 @@
+import 'reflect-metadata';
+import {ClientSession, Collection, ObjectId} from 'mongodb';
+import {inject, injectable} from 'inversify';
+import {MongoDatabase} from '#shared/database/providers/mongo/MongoDatabase.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {ICaseStudy} from '../../../classes/transformers/CaseStudy.js';
+import {
+  CaseResponse,
+  ICaseResponse,
+} from '../../../classes/transformers/CaseResponse.js';
+import {
+  CaseComparisonOutcome,
+  ICaseComparison,
+} from '../../../classes/transformers/CaseComparison.js';
+import {UNJUDGEABLE_FLAG_THRESHOLD, WINS_REQUIRED} from '../../../constants.js';
+
+/**
+ * One counter per (reviewer, case): substantive verdicts (A/B/BOTH_WEAK) this
+ * reviewer has completed for this case. A progress counter only — reviewing
+ * is open-ended (Milestone 0's resolved default), so nothing here caps it.
+ */
+interface ICaseReviewQuota {
+  _id?: ObjectId;
+  reviewerId: ObjectId;
+  caseStudyId: ObjectId;
+  validPicks: number;
+}
+
+export interface IIntegrationLearnerProgress {
+  userId: string;
+  casesSubmitted: number;
+  casesWon: number;
+  casesInReview: number;
+  lastActivityAt: Date | null;
+}
+
+/** Sorts a response pair into a stable order, independent of which was picked first. */
+function normalizePair(a: ObjectId, b: ObjectId): [ObjectId, ObjectId] {
+  return a.toString() <= b.toString() ? [a, b] : [b, a];
+}
+
+@injectable()
+export class CaseStudyRepository {
+  private caseStudies!: Collection<ICaseStudy>;
+  private caseResponses!: Collection<ICaseResponse>;
+  private caseComparisons!: Collection<ICaseComparison>;
+  private caseReviewQuota!: Collection<ICaseReviewQuota>;
+  private initialized = false;
+
+  constructor(@inject(GLOBAL_TYPES.Database) private db: MongoDatabase) {}
+
+  private async init(): Promise<void> {
+    if (this.initialized) return;
+    this.caseStudies = await this.db.getCollection<ICaseStudy>('caseStudies');
+    this.caseResponses =
+      await this.db.getCollection<ICaseResponse>('caseResponses');
+    this.caseComparisons =
+      await this.db.getCollection<ICaseComparison>('caseComparisons');
+    this.caseReviewQuota =
+      await this.db.getCollection<ICaseReviewQuota>('caseReviewQuota');
+    this.initialized = true;
+
+    try {
+      // Case studies are now course items keyed by _id = itemId, so uniqueness
+      // is inherent to the item. The old (courseVersionId, sequenceIndex) unique
+      // index from the standalone-authoring model is retired; drop it if a dev
+      // DB still carries it, then keep only a non-unique lookup index.
+      try {
+        await this.caseStudies.dropIndex('courseVersionId_1_sequenceIndex_1');
+      } catch {
+        // Index absent (fresh DB) — nothing to drop.
+      }
+      await this.caseStudies.createIndex(
+        {courseVersionId: 1},
+        {background: true},
+      );
+      // One response per participant per case.
+      await this.caseResponses.createIndex(
+        {userId: 1, caseStudyId: 1},
+        {unique: true, background: true},
+      );
+      // Serving pool: open responses for a case, least-won / least-served first.
+      await this.caseResponses.createIndex(
+        {caseStudyId: 1, status: 1, winCount: 1, comparisonsSeenCount: 1},
+        {background: true},
+      );
+      // Never serve the same reviewer the same pair twice. Callers must
+      // normalise A/B by sorted id (see normalizePair) before every read and
+      // write against this index, so {A,B} and {B,A} collide as intended.
+      await this.caseComparisons.createIndex(
+        {reviewerId: 1, responseAId: 1, responseBId: 1},
+        {unique: true, background: true},
+      );
+      // The re-serve lookup: at most one undecided pair per (reviewer, case).
+      await this.caseComparisons.createIndex(
+        {reviewerId: 1, caseStudyId: 1, outcome: 1},
+        {background: true},
+      );
+      await this.caseReviewQuota.createIndex(
+        {reviewerId: 1, caseStudyId: 1},
+        {unique: true, background: true},
+      );
+    } catch {
+      // Indexes already exist.
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Case studies (authoring / listing)
+  // ---------------------------------------------------------------------
+
+  async findById(caseStudyId: string): Promise<ICaseStudy | null> {
+    await this.init();
+    return this.caseStudies.findOne({
+      _id: new ObjectId(caseStudyId),
+      isDeleted: {$ne: true},
+    });
+  }
+
+  /**
+   * Idempotent sync of the case record backing a CASE_STUDY course item.
+   * The case's `_id` is the item's `_id`, so the peer-review runtime keys on
+   * the item directly. Called whenever a learner opens the item; safe to call
+   * repeatedly. Content-bearing fields are refreshed from the item on each call
+   * so instructor edits propagate; runtime counters are left untouched.
+   */
+  async upsertForItem(input: {
+    itemId: string;
+    courseId: string;
+    courseVersionId: string;
+    title: string;
+    bodyMarkdown: string;
+    reviewsRequired?: number;
+    picksRequired?: number;
+    weakStreakThreshold?: number;
+  }): Promise<void> {
+    await this.init();
+    const _id = new ObjectId(input.itemId);
+
+    // Config knobs are synced every open so instructor edits take effect
+    // immediately. A knob left blank on the item is `$unset` here so the engine
+    // falls back to its module default rather than keeping a stale override.
+    const knobs = {
+      reviewsRequired: input.reviewsRequired,
+      picksRequired: input.picksRequired,
+      weakStreakThreshold: input.weakStreakThreshold,
+    };
+    const $set: Record<string, unknown> = {
+      title: input.title,
+      bodyMarkdown: input.bodyMarkdown,
+      isDeleted: false,
+      updatedAt: new Date(),
+    };
+    const $unset: Record<string, ''> = {};
+    for (const [key, value] of Object.entries(knobs)) {
+      if (value !== undefined) $set[key] = value;
+      else $unset[key] = '';
+    }
+
+    await this.caseStudies.updateOne(
+      {_id},
+      {
+        $set,
+        ...(Object.keys($unset).length ? {$unset} : {}),
+        $setOnInsert: {
+          courseId: new ObjectId(input.courseId),
+          courseVersionId: new ObjectId(input.courseVersionId),
+          createdAt: new Date(),
+        },
+      },
+      {upsert: true},
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // Responses
+  // ---------------------------------------------------------------------
+
+  async findUserResponse(
+    userId: string,
+    caseStudyId: string,
+  ): Promise<ICaseResponse | null> {
+    await this.init();
+    return this.caseResponses.findOne({
+      userId: new ObjectId(userId),
+      caseStudyId: new ObjectId(caseStudyId),
+    });
+  }
+
+  async findResponseById(responseId: string): Promise<ICaseResponse | null> {
+    await this.init();
+    return this.caseResponses.findOne({_id: new ObjectId(responseId)});
+  }
+
+  /**
+   * Insert a response. Returns null when the unique `(userId, caseStudyId)`
+   * index rejects a duplicate, so two racing submissions from one student
+   * become a clean "already submitted" rather than an uncaught duplicate-key
+   * error — mirrors `ReflectionRepository.create`.
+   */
+  async createResponse(response: CaseResponse): Promise<string | null> {
+    await this.init();
+    try {
+      const result = await this.caseResponses.insertOne(response);
+      return result.insertedId.toString();
+    } catch (e: any) {
+      if (e?.code === 11000) return null;
+      throw e;
+    }
+  }
+
+  /**
+   * Replace a response's text and restart its review cycle from scratch.
+   * Resets winCount, weakStreak, comparisonsSeenCount, and flagCount to 0
+   * and flips status back to OPEN. Also deletes any pending (undecided)
+   * comparisons that reference the old text — they reference stale content
+   * and must not feed into the fresh cycle.
+   *
+   * Matches OPEN and WITHDRAWN responses (WON ones cannot be revised).
+   * Resets all counters and flips status back to OPEN atomically.
+   * Returns false when no matching document was found.
+   */
+  async reviseResponse(
+    userId: string,
+    caseStudyId: string,
+    fields: {
+      beat1a: string;
+      beat1b: string;
+      beat1c: string;
+      steelman: string;
+      roomPerspective: string;
+      changeCommitment: string;
+    },
+  ): Promise<boolean> {
+    await this.init();
+    const updated = await this.caseResponses.findOneAndUpdate(
+      {
+        userId: new ObjectId(userId),
+        caseStudyId: new ObjectId(caseStudyId),
+        status: {$in: ['OPEN', 'WITHDRAWN']},
+      },
+      {
+        $set: {
+          ...fields,
+          status: 'OPEN',
+          winCount: 0,
+          weakStreak: 0,
+          comparisonsSeenCount: 0,
+          flagCount: 0,
+          updatedAt: new Date(),
+        },
+      },
+      {returnDocument: 'after'},
+    );
+    if (!updated) return false;
+    await this.caseComparisons.deleteMany({
+      outcome: {$exists: false},
+      $or: [{responseAId: updated._id}, {responseBId: updated._id}],
+    });
+    return true;
+  }
+
+  // ---------------------------------------------------------------------
+  // Pairing / comparisons
+  // ---------------------------------------------------------------------
+
+  /**
+   * An undecided pair already served to this reviewer for this case, if one
+   * exists. Re-serving it (instead of picking a new one) is what makes
+   * leaving and returning to the screen restart the timer rather than
+   * letting a refresh dodge it.
+   */
+  async findPendingComparison(
+    reviewerId: string,
+    caseStudyId: string,
+  ): Promise<ICaseComparison | null> {
+    await this.init();
+    return this.caseComparisons.findOne({
+      reviewerId: new ObjectId(reviewerId),
+      caseStudyId: new ObjectId(caseStudyId),
+      outcome: {$exists: false},
+    });
+  }
+
+  async findComparisonById(comparisonId: string): Promise<ICaseComparison | null> {
+    await this.init();
+    return this.caseComparisons.findOne({_id: new ObjectId(comparisonId)});
+  }
+
+  /**
+   * Pick two OPEN responses to this case, excluding the reviewer's own and
+   * every pair already served to this reviewer. Biased toward the
+   * least-won/least-served responses first (mirrors
+   * `ReflectionRepository.findNextForReview`'s spread-coverage sort) so early
+   * submissions don't monopolise review attention.
+   *
+   * The candidate pool is a small batch (20), and pairs within it are
+   * checked in-memory against the reviewer's seen-set — cheap at this scale,
+   * and avoids a much fancier query for what is, per case, a small pool.
+   */
+  async pickPairCandidate(
+    caseStudyId: string,
+    reviewerId: string,
+  ): Promise<[ICaseResponse, ICaseResponse] | null> {
+    await this.init();
+    const caseObjId = new ObjectId(caseStudyId);
+    const reviewerObjId = new ObjectId(reviewerId);
+
+    const pool = await this.caseResponses
+      .find({
+        caseStudyId: caseObjId,
+        status: 'OPEN',
+        userId: {$ne: reviewerObjId},
+      })
+      .sort({winCount: 1, comparisonsSeenCount: 1})
+      .limit(20)
+      .toArray();
+
+    if (pool.length < 2) return null;
+
+    const seenPairs = await this.caseComparisons
+      .find(
+        {reviewerId: reviewerObjId, caseStudyId: caseObjId},
+        {projection: {responseAId: 1, responseBId: 1, outcome: 1}},
+      )
+      .toArray();
+    const seenKeys = new Set(
+      seenPairs.map(p => `${p.responseAId.toString()}:${p.responseBId.toString()}`),
+    );
+
+    // After a revision the old decided comparisons remain; exclude those response
+    // IDs so a revised response is never served to a reviewer who already judged it.
+    const judgedResponseIds = new Set<string>();
+    for (const p of seenPairs) {
+      if (p.outcome !== undefined) {
+        judgedResponseIds.add(p.responseAId.toString());
+        judgedResponseIds.add(p.responseBId.toString());
+      }
+    }
+    const eligiblePool = judgedResponseIds.size > 0
+      ? pool.filter(r => !judgedResponseIds.has(r._id!.toString()))
+      : pool;
+
+    if (eligiblePool.length < 2) return null;
+
+    for (let i = 0; i < eligiblePool.length; i++) {
+      for (let j = i + 1; j < eligiblePool.length; j++) {
+        const [a, b] = normalizePair(eligiblePool[i]._id!, eligiblePool[j]._id!);
+        const key = `${a.toString()}:${b.toString()}`;
+        if (!seenKeys.has(key)) {
+          return [eligiblePool[i], eligiblePool[j]];
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns null when the unique `(reviewerId, responseAId, responseBId)`
+   * index rejects a duplicate — a concurrent request from the same reviewer
+   * just served this exact pair. The service treats that as "already
+   * pending" rather than an error.
+   */
+  async createComparison(input: {
+    caseStudyId: string;
+    courseVersionId: string;
+    reviewerId: string;
+    responseAId: string;
+    responseBId: string;
+    sideAIsLeft: boolean;
+    servedAt: Date;
+    minimumScreenTimeSeconds: number;
+  }): Promise<ICaseComparison | null> {
+    await this.init();
+    const [responseAId, responseBId] = normalizePair(
+      new ObjectId(input.responseAId),
+      new ObjectId(input.responseBId),
+    );
+    const doc: ICaseComparison = {
+      caseStudyId: new ObjectId(input.caseStudyId),
+      courseVersionId: new ObjectId(input.courseVersionId),
+      reviewerId: new ObjectId(input.reviewerId),
+      responseAId,
+      responseBId,
+      sideAIsLeft: input.sideAIsLeft,
+      servedAt: input.servedAt,
+      minimumScreenTimeSeconds: input.minimumScreenTimeSeconds,
+      createdAt: new Date(),
+    };
+    try {
+      const result = await this.caseComparisons.insertOne(doc);
+      return {...doc, _id: result.insertedId};
+    } catch (e: any) {
+      if (e?.code === 11000) return null;
+      throw e;
+    }
+  }
+
+  /**
+   * Record the verdict on a served pair. The filter requiring `outcome` to
+   * be unset is the double-pick guard: two concurrent picks against the same
+   * comparison can't both succeed, mirroring the capped update in
+   * `ReflectionRepository.recordReview`.
+   */
+  async recordPick(
+    input: {comparisonId: string; outcome: CaseComparisonOutcome},
+    session?: ClientSession,
+  ): Promise<ICaseComparison | null> {
+    await this.init();
+    return this.caseComparisons.findOneAndUpdate(
+      {_id: new ObjectId(input.comparisonId), outcome: {$exists: false}},
+      {$set: {outcome: input.outcome, decidedAt: new Date()}},
+      {returnDocument: 'after', session},
+    );
+  }
+
+  /**
+   * Fold a decided comparison's outcome into both responses' counters.
+   * `comparisonsSeenCount` increments for both responses regardless of
+   * outcome; a win or a flag then independently, atomically checks whether
+   * the response just crossed its threshold and flips its status — the
+   * `status: 'OPEN'` guard on that second update is what stops two
+   * concurrent winning picks from both "closing" the same response.
+   *
+   * Also folds each response's `weakStreak`: the losing side(s) of a
+   * substantive verdict (A/B/BOTH_WEAK) get it incremented, the winning side
+   * gets it reset to 0. Returns the post-increment streak for every response
+   * that was NOT reset, so the caller can compare against the course's
+   * configured notification threshold without a second read.
+   */
+  async applyPickEffects(
+    input: {
+      responseAId: ObjectId;
+      responseBId: ObjectId;
+      outcome: CaseComparisonOutcome;
+      /** Wins needed to settle this case; falls back to WINS_REQUIRED when omitted. */
+      winsRequired?: number;
+    },
+    session?: ClientSession,
+  ): Promise<{
+    weakStreaks: Array<{responseId: ObjectId; userId: ObjectId; weakStreak: number}>;
+    withdrawals: Array<{responseId: ObjectId; userId: ObjectId; withdrawn: boolean}>;
+  }> {
+    await this.init();
+    const {responseAId, responseBId, outcome} = input;
+    const winsRequired = input.winsRequired ?? WINS_REQUIRED;
+
+    await this.caseResponses.updateMany(
+      {_id: {$in: [responseAId, responseBId]}},
+      {$inc: {comparisonsSeenCount: 1}, $set: {updatedAt: new Date()}},
+      {session},
+    );
+
+    const weakStreaks: Array<{responseId: ObjectId; userId: ObjectId; weakStreak: number}> = [];
+    const withdrawals: Array<{responseId: ObjectId; userId: ObjectId; withdrawn: boolean}> = [];
+
+    if (outcome === 'A' || outcome === 'B') {
+      const winnerId = outcome === 'A' ? responseAId : responseBId;
+      const loserId = outcome === 'A' ? responseBId : responseAId;
+      await Promise.all([
+        this.incrementWin(winnerId, winsRequired, session),
+        this.resetWeakStreak(winnerId, session),
+      ]);
+      const loserStreak = await this.incrementWeakStreak(loserId, session);
+      if (loserStreak) weakStreaks.push(loserStreak);
+    } else if (outcome === 'FLAGGED') {
+      // Increment flags and atomically withdraw if threshold is crossed.
+      // Does not fold into the weak-response streak — it wasn't judged.
+      const [flagA, flagB] = await Promise.all([
+        this.incrementFlag(responseAId, session),
+        this.incrementFlag(responseBId, session),
+      ]);
+      // incrementFlag returns null when the response document was not found
+      // (deleted between recordPick and this step); skip phantom entries.
+      if (flagA) withdrawals.push(flagA);
+      if (flagB) withdrawals.push(flagB);
+    } else {
+      // BOTH_WEAK: a substantive judgment against both sides.
+      const [a, b] = await Promise.all([
+        this.incrementWeakStreak(responseAId, session),
+        this.incrementWeakStreak(responseBId, session),
+      ]);
+      if (a) weakStreaks.push(a);
+      if (b) weakStreaks.push(b);
+    }
+
+    return {weakStreaks, withdrawals};
+  }
+
+  private async incrementWin(
+    responseId: ObjectId,
+    winsRequired: number = WINS_REQUIRED,
+    session?: ClientSession,
+  ): Promise<void> {
+    const updated = await this.caseResponses.findOneAndUpdate(
+      {_id: responseId},
+      {$inc: {winCount: 1}, $set: {updatedAt: new Date()}},
+      {returnDocument: 'after', session},
+    );
+    if (updated && updated.status === 'OPEN' && updated.winCount >= winsRequired) {
+      await this.caseResponses.updateOne(
+        {_id: responseId, status: 'OPEN'},
+        {$set: {status: 'WON', updatedAt: new Date()}},
+        {session},
+      );
+    }
+  }
+
+  /** Increments the flag counter. Withdraws the response if the flag threshold is crossed. */
+  private async incrementFlag(
+    responseId: ObjectId,
+    session?: ClientSession,
+  ): Promise<{responseId: ObjectId; userId: ObjectId; withdrawn: boolean} | null> {
+    const updated = await this.caseResponses.findOneAndUpdate(
+      {_id: responseId},
+      {$inc: {flagCount: 1}, $set: {updatedAt: new Date()}},
+      {returnDocument: 'after', session},
+    );
+    if (!updated) return null;
+    let withdrawn = false;
+    if (updated.flagCount >= UNJUDGEABLE_FLAG_THRESHOLD && updated.status === 'OPEN') {
+      await this.caseResponses.updateOne(
+        {_id: responseId, status: 'OPEN'},
+        {$set: {status: 'WITHDRAWN', updatedAt: new Date()}},
+        {session},
+      );
+      withdrawn = true;
+    }
+    return {responseId, userId: updated.userId, withdrawn};
+  }
+
+  private async incrementWeakStreak(
+    responseId: ObjectId,
+    session?: ClientSession,
+  ): Promise<{responseId: ObjectId; userId: ObjectId; weakStreak: number} | null> {
+    const updated = await this.caseResponses.findOneAndUpdate(
+      {_id: responseId},
+      {$inc: {weakStreak: 1}, $set: {updatedAt: new Date()}},
+      {returnDocument: 'after', session},
+    );
+    if (!updated) return null;
+    return {responseId, userId: updated.userId, weakStreak: updated.weakStreak};
+  }
+
+  private async resetWeakStreak(
+    responseId: ObjectId,
+    session?: ClientSession,
+  ): Promise<void> {
+    await this.caseResponses.updateOne(
+      {_id: responseId},
+      {$set: {weakStreak: 0, updatedAt: new Date()}},
+      {session},
+    );
+  }
+
+  async incrementReviewerQuota(
+    reviewerId: string,
+    caseStudyId: string,
+    session?: ClientSession,
+  ): Promise<void> {
+    await this.init();
+    await this.caseReviewQuota.updateOne(
+      {reviewerId: new ObjectId(reviewerId), caseStudyId: new ObjectId(caseStudyId)},
+      {$inc: {validPicks: 1}},
+      {upsert: true, session},
+    );
+  }
+
+  async getReviewerQuota(reviewerId: string, caseStudyId: string): Promise<number> {
+    await this.init();
+    const doc = await this.caseReviewQuota.findOne({
+      reviewerId: new ObjectId(reviewerId),
+      caseStudyId: new ObjectId(caseStudyId),
+    });
+    return doc?.validPicks ?? 0;
+  }
+
+  /**
+   * How every reviewer who has seen this exact pair (any reviewer, not just
+   * the caller) verdicted it — powers the post-pick "X of the readers so far
+   * chose the same one" figure. Counts readers of *this specific pair*, not
+   * either response's overall win record (PLANNING.md/TASK.md Milestone 10).
+   */
+  async getPairOutcomeCounts(
+    responseAId: ObjectId,
+    responseBId: ObjectId,
+  ): Promise<Record<CaseComparisonOutcome, number>> {
+    await this.init();
+    const rows = await this.caseComparisons
+      .aggregate<{_id: CaseComparisonOutcome; count: number}>([
+        {$match: {responseAId, responseBId, outcome: {$exists: true}}},
+        {$group: {_id: '$outcome', count: {$sum: 1}}},
+      ])
+      .toArray();
+    const counts: Record<CaseComparisonOutcome, number> = {
+      A: 0,
+      B: 0,
+      BOTH_WEAK: 0,
+      FLAGGED: 0,
+    };
+    for (const row of rows) counts[row._id] = row.count;
+    return counts;
+  }
+
+  /** All responses for a case study, newest first — for the instructor response viewer. */
+  async listResponsesForInstructor(caseStudyId: string): Promise<ICaseResponse[]> {
+    await this.init();
+    return this.caseResponses
+      .find({caseStudyId: new ObjectId(caseStudyId)})
+      .sort({createdAt: -1})
+      .toArray();
+  }
+
+  // ---------------------------------------------------------------------
+  // Samagama integration roster
+  // ---------------------------------------------------------------------
+
+  /**
+   * Per-learner facts for the Samagama-facing integration roster. Reports
+   * `casesSubmitted`/`casesWon`/`casesInReview` only — it never computes a
+   * "N of ~20 complete" boolean, since that completion rule is Samagama's to
+   * apply (PLANNING.md §4.2), not ViBe's.
+   *
+   * Uses a single $facet pipeline to compute paged data and total count in
+   * one collection pass.
+   */
+  async getIntegrationProgress(input: {
+    courseVersionId: string;
+    page: number;
+    limit: number;
+  }): Promise<{totalLearners: number; learners: IIntegrationLearnerProgress[]}> {
+    await this.init();
+    const versionObjId = new ObjectId(input.courseVersionId);
+    const skip = (input.page - 1) * input.limit;
+
+    const [result] = await this.caseResponses
+      .aggregate<{
+        data: Array<{
+          _id: ObjectId;
+          casesSubmitted: number;
+          casesWon: number;
+          casesInReview: number;
+          lastActivityAt: Date;
+        }>;
+        total: Array<{count: number}>;
+      }>([
+        {$match: {courseVersionId: versionObjId}},
+        {
+          $facet: {
+            data: [
+              {
+                $group: {
+                  _id: '$userId',
+                  casesSubmitted: {$sum: 1},
+                  casesWon: {$sum: {$cond: [{$eq: ['$status', 'WON']}, 1, 0]}},
+                  casesInReview: {$sum: {$cond: [{$eq: ['$status', 'OPEN']}, 1, 0]}},
+                  lastActivityAt: {$max: '$updatedAt'},
+                },
+              },
+              {$sort: {_id: 1}},
+              {$skip: skip},
+              {$limit: input.limit},
+            ],
+            total: [
+              {$group: {_id: '$userId'}},
+              {$count: 'count'},
+            ],
+          },
+        },
+      ])
+      .toArray();
+
+    return {
+      totalLearners: result?.total[0]?.count ?? 0,
+      learners: (result?.data ?? []).map(r => ({
+        userId: r._id.toString(),
+        casesSubmitted: r.casesSubmitted,
+        casesWon: r.casesWon,
+        casesInReview: r.casesInReview,
+        lastActivityAt: r.lastActivityAt ?? null,
+      })),
+    };
+  }
+}

--- a/backend/src/modules/caseStudies/services/CaseStudyService.ts
+++ b/backend/src/modules/caseStudies/services/CaseStudyService.ts
@@ -1,0 +1,725 @@
+import {ObjectId} from 'mongodb';
+import {inject, injectable} from 'inversify';
+import {BadRequestError, ForbiddenError, NotFoundError} from 'routing-controllers';
+import {CASE_STUDIES_TYPES} from '../types.js';
+import {CaseStudyRepository} from '../repositories/providers/mongodb/CaseStudyRepository.js';
+import {CaseResponse, ICaseResponse} from '../classes/transformers/CaseResponse.js';
+import {ICaseStudy} from '../classes/transformers/CaseStudy.js';
+import {CaseComparisonOutcome} from '../classes/transformers/CaseComparison.js';
+import {
+  DEFAULT_WEAK_STREAK_THRESHOLD,
+  ELEMENT_2A_MIN_WORDS,
+  FIELD_MIN_WORDS,
+  MAX_LIST_LIMIT,
+  REVIEWER_MIN_PICKS_PER_CASE,
+  WINS_REQUIRED,
+  computeMinimumScreenTimeSeconds,
+  countWords,
+  isGibberish,
+} from '../constants.js';
+import {SETTING_TYPES} from '../../setting/types.js';
+import {CourseSettingService} from '../../setting/services/CourseSettingService.js';
+import {NOTIFICATIONS_TYPES} from '../../notifications/types.js';
+import {NotificationService} from '../../notifications/services/NotificationService.js';
+import {COURSES_TYPES} from '../../courses/types.js';
+import {IItemRepository} from '../../../shared/database/interfaces/IItemRepository.js';
+import {BaseService} from '#root/shared/classes/BaseService.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+
+/**
+ * A response as shown to a reviewing peer.
+ *
+ * This shape is the anonymity boundary: it is built field by field rather
+ * than spread from the document (see `toServedPair`), so an author-
+ * identifying field added to `ICaseResponse` later can never leak into a
+ * review payload by default.
+ *
+ * All six response fields are exposed to peer reviewers — anonymised by
+ * omitting `userId`, but not field-filtered.
+ */
+export interface ServedPairResponseView {
+  responseId: string;
+  beat1a: string;
+  beat1b: string;
+  beat1c: string;
+  steelman: string;
+  roomPerspective: string;
+  changeCommitment: string;
+  wordCount: number;
+  /**
+   * Submit this exact value as `outcome` when the participant picks this
+   * side as better. Sides are randomised left/right per serve (`sideAIsLeft`
+   * internally) to avoid position bias, so the client must read this off the
+   * response it renders rather than assuming "left" always means A.
+   */
+  outcome: 'A' | 'B';
+}
+
+export interface ServedPair {
+  comparisonId: string;
+  caseStudyId: string;
+  left: ServedPairResponseView;
+  right: ServedPairResponseView;
+  servedAt: string;
+  minimumScreenTimeSeconds: number;
+}
+
+interface CaseStudySettings {
+  enabled: boolean;
+  weakStreakThreshold: number;
+}
+
+type ResponseFields = {
+  beat1a: string;
+  beat1b: string;
+  beat1c: string;
+  steelman: string;
+  roomPerspective: string;
+  changeCommitment: string;
+};
+
+@injectable()
+export class CaseStudyService extends BaseService {
+  constructor(
+    @inject(GLOBAL_TYPES.Database) db: MongoDatabase,
+    @inject(CASE_STUDIES_TYPES.CaseStudyRepo)
+    private readonly repository: CaseStudyRepository,
+    @inject(SETTING_TYPES.CourseSettingService)
+    private readonly courseSettingService: CourseSettingService,
+    @inject(NOTIFICATIONS_TYPES.NotificationService)
+    private readonly notificationService: NotificationService,
+    @inject(COURSES_TYPES.ItemRepo)
+    private readonly itemRepo: IItemRepository,
+  ) {
+    super(db);
+  }
+
+  /**
+   * Sync the case record backing a CASE_STUDY course item, then return it.
+   * Idempotent — the learner panel calls this on open, passing the course
+   * context it already has, so the peer-review runtime can key on the item's
+   * own id without a separate authoring step or an item→version lookup.
+   */
+  async ensureCaseForItem(input: {
+    courseId: string;
+    courseVersionId: string;
+    itemId: string;
+  }): Promise<ICaseStudy> {
+    const item = await this.itemRepo.readItemById(input.itemId);
+    if (!item || (item as any).type !== 'CASE_STUDY') {
+      throw new NotFoundError('Case study item not found.');
+    }
+    const details = (item as any).details ?? {};
+    await this.repository.upsertForItem({
+      itemId: input.itemId,
+      courseId: input.courseId,
+      courseVersionId: input.courseVersionId,
+      title: (item as any).name ?? 'Case study',
+      bodyMarkdown: details.bodyMarkdown ?? '',
+      reviewsRequired: details.reviewsRequired,
+      picksRequired: details.picksRequired,
+      weakStreakThreshold: details.weakStreakThreshold,
+    });
+    return this.getCaseStudyOrThrow(input.itemId);
+  }
+
+  /** Resolves the course-version-level toggles that govern this feature. */
+  private async getCaseStudySettings(
+    courseId: string,
+    courseVersionId: string,
+  ): Promise<CaseStudySettings> {
+    const courseSettings = await this.courseSettingService.readCourseSettings(
+      courseId,
+      courseVersionId,
+    );
+    return {
+      enabled: courseSettings?.settings?.caseStudiesEnabled ?? false,
+      weakStreakThreshold:
+        courseSettings?.settings?.caseStudyWeakStreakThreshold ??
+        DEFAULT_WEAK_STREAK_THRESHOLD,
+    };
+  }
+
+  private trimResponseFields(input: ResponseFields): ResponseFields {
+    return {
+      beat1a: input.beat1a.trim(),
+      beat1b: input.beat1b.trim(),
+      beat1c: input.beat1c.trim(),
+      steelman: input.steelman.trim(),
+      roomPerspective: input.roomPerspective.trim(),
+      changeCommitment: input.changeCommitment.trim(),
+    };
+  }
+
+  private validateResponseFields(fields: ResponseFields): void {
+    const single: Array<{name: string; value: string}> = [
+      {name: 'beat1a', value: fields.beat1a},
+      {name: 'beat1b', value: fields.beat1b},
+      {name: 'beat1c', value: fields.beat1c},
+      {name: 'roomPerspective', value: fields.roomPerspective},
+      {name: 'changeCommitment', value: fields.changeCommitment},
+    ];
+    for (const {name, value} of single) {
+      const wc = countWords(value);
+      if (wc < FIELD_MIN_WORDS) {
+        throw new BadRequestError(
+          `The "${name}" field must be at least ${FIELD_MIN_WORDS} words (got ${wc}).`,
+        );
+      }
+      if (isGibberish(value)) {
+        throw new BadRequestError(
+          `The "${name}" field appears to contain repeated or meaningless text. Please write a genuine response.`,
+        );
+      }
+    }
+    const steelmanWc = countWords(fields.steelman);
+    if (steelmanWc < ELEMENT_2A_MIN_WORDS) {
+      throw new BadRequestError(
+        `The steelman must be at least ${ELEMENT_2A_MIN_WORDS} words (this one is ${steelmanWc}).`,
+      );
+    }
+    if (isGibberish(fields.steelman)) {
+      throw new BadRequestError(
+        'The steelman field appears to contain repeated or meaningless text. Please write a genuine argument.',
+      );
+    }
+  }
+
+  private async notifyWithdrawnResponse(
+    userId: ObjectId,
+    caseStudy: ICaseStudy,
+  ): Promise<void> {
+    try {
+      await this.notificationService.createNotification({
+        userId,
+        type: 'case_response_withdrawn',
+        title: 'Your case study response needs revision',
+        message:
+          `Your response to "${caseStudy.title}" has been flagged as unclear by multiple reviewers ` +
+          `and removed from the review pool. Please revise and resubmit it.`,
+        courseId: caseStudy.courseId,
+        courseVersionId: caseStudy.courseVersionId,
+        read: false,
+        createdAt: new Date(),
+        extra: {caseStudyId: caseStudy._id?.toString()},
+      });
+    } catch (err) {
+      console.error('Failed to emit case-study withdrawn notification', err);
+    }
+  }
+
+  private async notifyWeakResponseStreak(
+    userId: ObjectId,
+    caseStudy: ICaseStudy,
+    weakStreak: number,
+  ): Promise<void> {
+    try {
+      await this.notificationService.createNotification({
+        userId,
+        type: 'case_response_weak_streak',
+        title: 'Your case study response may need work',
+        message:
+          `Reviewers have picked another response over yours for "${caseStudy.title}" ` +
+          `${weakStreak} times in a row. Consider revising it for clarity and depth.`,
+        courseId: caseStudy.courseId,
+        courseVersionId: caseStudy.courseVersionId,
+        read: false,
+        createdAt: new Date(),
+        extra: {caseStudyId: caseStudy._id?.toString(), weakStreak},
+      });
+    } catch (err) {
+      // Best-effort: don't fail the pick submission if the notification fails.
+      console.error('Failed to emit case-study weak-streak notification', err);
+    }
+  }
+
+  async getCaseStudyOrThrow(caseStudyId: string): Promise<ICaseStudy> {
+    const caseStudy = await this.repository.findById(caseStudyId);
+    if (!caseStudy) {
+      throw new NotFoundError('Case study not found.');
+    }
+    return caseStudy;
+  }
+
+  /** Resolves the course/version a comparison belongs to, for routes keyed only by comparisonId. */
+  async getComparisonContext(
+    comparisonId: string,
+  ): Promise<{courseId: string; courseVersionId: string; caseStudyId: string}> {
+    const comparison = await this.repository.findComparisonById(comparisonId);
+    if (!comparison) {
+      throw new NotFoundError('Comparison not found.');
+    }
+    const caseStudy = await this.getCaseStudyOrThrow(
+      comparison.caseStudyId.toString(),
+    );
+    return {
+      courseId: caseStudy.courseId.toString(),
+      courseVersionId: caseStudy.courseVersionId.toString(),
+      caseStudyId: comparison.caseStudyId.toString(),
+    };
+  }
+
+  /**
+   * This learner's own response to a case, plus the two per-item facts the
+   * panel needs: whether it is eligible for revision (weak-streak nudge), and
+   * their review progress against the case's `picksRequired` soft floor.
+   */
+  async getMyResponse(input: {
+    userId: string;
+    caseStudyId: string;
+  }): Promise<{
+    response: ICaseResponse | null;
+    eligibleForRevision: boolean;
+    picksRequired: number;
+    picksCompleted: number;
+  }> {
+    const caseStudy = await this.getCaseStudyOrThrow(input.caseStudyId);
+    const picksRequired =
+      caseStudy.picksRequired ?? REVIEWER_MIN_PICKS_PER_CASE;
+    const response = await this.repository.findUserResponse(
+      input.userId,
+      input.caseStudyId,
+    );
+    if (!response) {
+      return {
+        response: null,
+        eligibleForRevision: false,
+        picksRequired,
+        picksCompleted: 0,
+      };
+    }
+    const [settings, picksCompleted] = await Promise.all([
+      this.getCaseStudySettings(
+        caseStudy.courseId.toString(),
+        caseStudy.courseVersionId.toString(),
+      ),
+      this.repository.getReviewerQuota(input.userId, input.caseStudyId),
+    ]);
+    const weakStreakThreshold =
+      caseStudy.weakStreakThreshold ?? settings.weakStreakThreshold;
+    // WITHDRAWN (flag-based) responses are always revisable; otherwise check
+    // the weak-streak threshold. Winning responses are never revisable.
+    const eligibleForRevision =
+      response.status === 'WITHDRAWN' ||
+      (response.status !== 'WON' &&
+        weakStreakThreshold > 0 &&
+        response.weakStreak >= weakStreakThreshold);
+    return {response, eligibleForRevision, picksRequired, picksCompleted};
+  }
+
+  /**
+   * Record a participant's response to a case. The case must have a linked
+   * video, and the student must have completed that video.
+   */
+  async submitResponse(input: {
+    userId: string;
+    caseStudyId: string;
+    beat1a: string;
+    beat1b: string;
+    beat1c: string;
+    steelman: string;
+    roomPerspective: string;
+    changeCommitment: string;
+    zoomSessionDate?: string;
+  }): Promise<{responseId: string}> {
+    const fields = this.trimResponseFields(input);
+    this.validateResponseFields(fields);
+
+    const caseStudy = await this.getCaseStudyOrThrow(input.caseStudyId);
+
+    // Fetch settings and check for an existing submission in parallel.
+    const [settings, existing] = await Promise.all([
+      this.getCaseStudySettings(
+        caseStudy.courseId.toString(),
+        caseStudy.courseVersionId.toString(),
+      ),
+      this.repository.findUserResponse(input.userId, input.caseStudyId),
+    ]);
+
+    if (!settings.enabled) {
+      throw new ForbiddenError('Case studies are not enabled for this course version.');
+    }
+
+    // Fast path: a readable rejection for the common case. The unique
+    // (userId, caseStudyId) index is the real race guard.
+    if (existing) {
+      throw new BadRequestError(
+        'You have already submitted a response for this case study.',
+      );
+    }
+
+    const responseId = await this.repository.createResponse(
+      new CaseResponse({
+        userId: input.userId,
+        courseVersionId: caseStudy.courseVersionId.toString(),
+        caseStudyId: input.caseStudyId,
+        ...fields,
+        zoomSessionDate: input.zoomSessionDate,
+      }),
+    );
+    if (responseId === null) {
+      // Two concurrent submissions from this user raced the unique index.
+      throw new BadRequestError(
+        'You have already submitted a response for this case study.',
+      );
+    }
+    return {responseId};
+  }
+
+  /**
+   * Serve the next pair for this reviewer, or null when the pool is
+   * exhausted — an ordinary state, not an error (matches
+   * `ReflectionService.getNextForReview`'s null-not-404 contract).
+   */
+  async getNextPair(input: {
+    reviewerId: string;
+    caseStudyId: string;
+  }): Promise<ServedPair | null> {
+    const caseStudy = await this.getCaseStudyOrThrow(input.caseStudyId);
+
+    // Fetch settings and check for a pending comparison in parallel.
+    const [settings, pending] = await Promise.all([
+      this.getCaseStudySettings(
+        caseStudy.courseId.toString(),
+        caseStudy.courseVersionId.toString(),
+      ),
+      this.repository.findPendingComparison(input.reviewerId, input.caseStudyId),
+    ]);
+
+    if (!settings.enabled) {
+      throw new ForbiddenError('Case studies are not enabled for this course version.');
+    }
+
+    if (pending) {
+      return this.toServedPair(pending);
+    }
+
+    const candidate = await this.repository.pickPairCandidate(
+      input.caseStudyId,
+      input.reviewerId,
+    );
+    if (!candidate) return null;
+    const [responseA, responseB] = candidate;
+
+    const minimumScreenTimeSeconds = computeMinimumScreenTimeSeconds(
+      countWords(responseA.steelman),
+      countWords(responseB.steelman),
+    );
+
+    const comparison = await this.repository.createComparison({
+      caseStudyId: input.caseStudyId,
+      courseVersionId: caseStudy.courseVersionId.toString(),
+      reviewerId: input.reviewerId,
+      responseAId: responseA._id!.toString(),
+      responseBId: responseB._id!.toString(),
+      sideAIsLeft: Math.random() < 0.5,
+      servedAt: new Date(),
+      minimumScreenTimeSeconds,
+    });
+    if (!comparison) {
+      // A concurrent request from the same reviewer just served this exact
+      // pair — treat it as "already pending" rather than an error.
+      const raced = await this.repository.findPendingComparison(
+        input.reviewerId,
+        input.caseStudyId,
+      );
+      return raced ? this.toServedPair(raced) : null;
+    }
+    return this.toServedPair(comparison);
+  }
+
+  private async toServedPair(comparison: {
+    _id?: any;
+    caseStudyId: any;
+    responseAId: any;
+    responseBId: any;
+    sideAIsLeft: boolean;
+    servedAt: Date;
+    minimumScreenTimeSeconds: number;
+  }): Promise<ServedPair> {
+    const [responseA, responseB] = await Promise.all([
+      this.repository.findResponseById(comparison.responseAId.toString()),
+      this.repository.findResponseById(comparison.responseBId.toString()),
+    ]);
+    if (!responseA || !responseB) {
+      throw new NotFoundError('One of the compared responses no longer exists.');
+    }
+
+    const viewA: ServedPairResponseView = {
+      responseId: responseA._id!.toString(),
+      beat1a: responseA.beat1a,
+      beat1b: responseA.beat1b,
+      beat1c: responseA.beat1c,
+      steelman: responseA.steelman,
+      roomPerspective: responseA.roomPerspective,
+      changeCommitment: responseA.changeCommitment,
+      wordCount: countWords(responseA.steelman),
+      outcome: 'A',
+    };
+    const viewB: ServedPairResponseView = {
+      responseId: responseB._id!.toString(),
+      beat1a: responseB.beat1a,
+      beat1b: responseB.beat1b,
+      beat1c: responseB.beat1c,
+      steelman: responseB.steelman,
+      roomPerspective: responseB.roomPerspective,
+      changeCommitment: responseB.changeCommitment,
+      wordCount: countWords(responseB.steelman),
+      outcome: 'B',
+    };
+
+    return {
+      comparisonId: comparison._id!.toString(),
+      caseStudyId: comparison.caseStudyId.toString(),
+      left: comparison.sideAIsLeft ? viewA : viewB,
+      right: comparison.sideAIsLeft ? viewB : viewA,
+      servedAt: comparison.servedAt.toISOString(),
+      minimumScreenTimeSeconds: comparison.minimumScreenTimeSeconds,
+    };
+  }
+
+  /**
+   * Score a served pair. The timer check is server-side and trusts nothing
+   * the client sends; the self-review guard is defense in depth (pairing
+   * already excludes the reviewer's own responses, but this must never be
+   * reachable even if that changes later) — mirrors
+   * `ReflectionService.submitReview`'s equivalent guard.
+   *
+   * The three writes (recordPick, applyPickEffects, incrementReviewerQuota)
+   * run inside a single MongoDB transaction so a process crash between them
+   * cannot leave a comparison permanently decided but counters unstamped.
+   */
+  async submitPick(input: {
+    reviewerId: string;
+    comparisonId: string;
+    outcome: CaseComparisonOutcome;
+  }): Promise<{
+    outcome: CaseComparisonOutcome;
+    /** Readers of this exact pair (any reviewer) who chose the same outcome, this pick included. */
+    agreementCount: number;
+    /** Readers of this exact pair who gave a substantive verdict (A/B/BOTH_WEAK) — FLAGGED excluded. */
+    totalJudged: number;
+  }> {
+    const comparison = await this.repository.findComparisonById(
+      input.comparisonId,
+    );
+    if (!comparison) {
+      throw new NotFoundError('Comparison not found.');
+    }
+    if (comparison.reviewerId.toString() !== input.reviewerId) {
+      throw new ForbiddenError('This comparison was not served to you.');
+    }
+
+    const caseStudy = await this.getCaseStudyOrThrow(comparison.caseStudyId.toString());
+    const settings = await this.getCaseStudySettings(
+      caseStudy.courseId.toString(),
+      caseStudy.courseVersionId.toString(),
+    );
+    const winsRequired = caseStudy.reviewsRequired ?? WINS_REQUIRED;
+    const weakStreakThreshold =
+      caseStudy.weakStreakThreshold ?? settings.weakStreakThreshold;
+
+    const [responseA, responseB] = await Promise.all([
+      this.repository.findResponseById(comparison.responseAId.toString()),
+      this.repository.findResponseById(comparison.responseBId.toString()),
+    ]);
+    if (
+      responseA?.userId.toString() === input.reviewerId ||
+      responseB?.userId.toString() === input.reviewerId
+    ) {
+      throw new ForbiddenError('You cannot review your own response.');
+    }
+
+    const elapsedSeconds = (Date.now() - comparison.servedAt.getTime()) / 1000;
+    if (elapsedSeconds < comparison.minimumScreenTimeSeconds) {
+      throw new BadRequestError(
+        'The minimum reading time for this pair has not elapsed yet.',
+      );
+    }
+
+    // Wrap the three writes atomically so a mid-flight crash cannot leave the
+    // comparison decided but response counters / reviewer quota unstamped.
+    const {weakStreaks, withdrawals} = await this._withTransaction(async session => {
+      const decided = await this.repository.recordPick(
+        {comparisonId: input.comparisonId, outcome: input.outcome},
+        session,
+      );
+      if (!decided) {
+        throw new BadRequestError('This comparison has already been decided.');
+      }
+
+      const effects = await this.repository.applyPickEffects(
+        {
+          responseAId: comparison.responseAId,
+          responseBId: comparison.responseBId,
+          outcome: input.outcome,
+          winsRequired,
+        },
+        session,
+      );
+
+      if (input.outcome !== 'FLAGGED') {
+        // A/B/BOTH_WEAK are substantive judgments and count toward the
+        // reviewer's own progress; an unjudgeable flag does not
+        // (PLANNING.md §4.5/§4.8).
+        await this.repository.incrementReviewerQuota(
+          input.reviewerId,
+          comparison.caseStudyId.toString(),
+          session,
+        );
+      }
+
+      return effects;
+    });
+
+    // Fire once, exactly on the round the streak crosses the threshold —
+    // not on every subsequent loss — so an author isn't spammed once they're
+    // already below the bar.
+    if (weakStreakThreshold > 0) {
+      for (const streak of weakStreaks) {
+        if (streak.weakStreak === weakStreakThreshold) {
+          await this.notifyWeakResponseStreak(streak.userId, caseStudy, streak.weakStreak);
+        }
+      }
+    }
+
+    for (const w of withdrawals) {
+      if (w.withdrawn) {
+        await this.notifyWithdrawnResponse(w.userId, caseStudy);
+      }
+    }
+
+    const counts = await this.repository.getPairOutcomeCounts(
+      comparison.responseAId,
+      comparison.responseBId,
+    );
+    return {
+      outcome: input.outcome,
+      agreementCount: counts[input.outcome],
+      totalJudged: counts.A + counts.B + counts.BOTH_WEAK,
+    };
+  }
+
+  /**
+   * Replace a response's six fields and start a fresh review cycle.
+   * Only callable when the response has reached the weak-streak threshold,
+   * meaning the notification has already fired and the author has been
+   * explicitly prompted to revise.
+   */
+  async reviseResponse(input: {
+    userId: string;
+    caseStudyId: string;
+    beat1a: string;
+    beat1b: string;
+    beat1c: string;
+    steelman: string;
+    roomPerspective: string;
+    changeCommitment: string;
+  }): Promise<{responseId: string}> {
+    const fields = this.trimResponseFields(input);
+    this.validateResponseFields(fields);
+
+    const caseStudy = await this.getCaseStudyOrThrow(input.caseStudyId);
+    const settings = await this.getCaseStudySettings(
+      caseStudy.courseId.toString(),
+      caseStudy.courseVersionId.toString(),
+    );
+
+    if (!settings.enabled) {
+      throw new ForbiddenError('Case studies are not enabled for this course version.');
+    }
+
+    const weakStreakThreshold =
+      caseStudy.weakStreakThreshold ?? settings.weakStreakThreshold;
+
+    const existing = await this.repository.findUserResponse(
+      input.userId,
+      input.caseStudyId,
+    );
+    if (!existing) {
+      throw new NotFoundError('You have not submitted a response for this case study yet.');
+    }
+    if (existing.status === 'WON') {
+      throw new BadRequestError('A winning response cannot be revised.');
+    }
+    // Withdrawn responses are always eligible for revision regardless of weakStreak.
+    if (existing.status !== 'WITHDRAWN') {
+      if (
+        weakStreakThreshold === 0 ||
+        existing.weakStreak < weakStreakThreshold
+      ) {
+        throw new BadRequestError(
+          `Your response is not yet eligible for revision. It must receive ${weakStreakThreshold} consecutive weak verdicts first (current streak: ${existing.weakStreak}).`,
+        );
+      }
+    }
+
+    const revised = await this.repository.reviseResponse(
+      input.userId,
+      input.caseStudyId,
+      fields,
+    );
+    if (!revised) {
+      throw new BadRequestError('Revision failed. Your response may have already been approved by peers.');
+    }
+    return {responseId: existing._id!.toString()};
+  }
+
+  /** All responses for a case study, newest first — for the instructor response viewer. */
+  async listResponsesForInstructor(caseStudyId: string) {
+    await this.getCaseStudyOrThrow(caseStudyId);
+    const docs = await this.repository.listResponsesForInstructor(caseStudyId);
+    // ObjectId fields don't survive class-transformer serialization as strings
+    // unless explicitly converted; do it here at the service boundary.
+    return docs.map(doc => ({
+      ...doc,
+      _id: doc._id?.toString(),
+      userId: doc.userId.toString(),
+      caseStudyId: doc.caseStudyId.toString(),
+      courseVersionId: doc.courseVersionId.toString(),
+    }));
+  }
+
+  // ---------------------------------------------------------------------
+  // Integration (Samagama roster poll)
+  // ---------------------------------------------------------------------
+
+  /**
+   * Per-learner facts for Samagama's roster poll. Never computes or returns
+   * a "N of ~20 complete" boolean — that completion rule is Samagama's to
+   * apply, not ViBe's (PLANNING.md §4.2).
+   */
+  async getIntegrationProgress(input: {
+    courseVersionId: string;
+    page: number;
+    limit: number;
+  }): Promise<{
+    page: number;
+    limit: number;
+    totalLearners: number;
+    totalPages: number;
+    learners: Array<{
+      userId: string;
+      casesSubmitted: number;
+      casesWon: number;
+      casesInReview: number;
+      lastActivityAt: Date | null;
+    }>;
+  }> {
+    const page = Math.max(1, Math.floor(input.page) || 1);
+    const limit = Math.min(Math.max(1, Math.floor(input.limit) || 50), MAX_LIST_LIMIT);
+    const {totalLearners, learners} = await this.repository.getIntegrationProgress({
+      courseVersionId: input.courseVersionId,
+      page,
+      limit,
+    });
+    return {
+      page,
+      limit,
+      totalLearners,
+      totalPages: Math.max(1, Math.ceil(totalLearners / limit)),
+      learners,
+    };
+  }
+}

--- a/backend/src/modules/caseStudies/services/index.ts
+++ b/backend/src/modules/caseStudies/services/index.ts
@@ -1,0 +1,1 @@
+export * from './CaseStudyService.js';

--- a/backend/src/modules/caseStudies/tests/CaseStudy.integration.test.ts
+++ b/backend/src/modules/caseStudies/tests/CaseStudy.integration.test.ts
@@ -1,0 +1,306 @@
+import {afterAll, beforeAll, beforeEach, describe, expect, it} from 'vitest';
+import {Db, MongoClient, ObjectId} from 'mongodb';
+import {MongoMemoryReplSet} from 'mongodb-memory-server';
+import {CaseStudyRepository} from '../repositories/providers/mongodb/CaseStudyRepository.js';
+import {CaseStudyService} from '../services/CaseStudyService.js';
+import {ELEMENT_2A_MIN_WORDS, WINS_REQUIRED} from '../constants.js';
+
+class FakeCourseSettingService {
+  async readCourseSettings() {
+    return {
+      settings: {
+        caseStudiesEnabled: true,
+        caseStudyWeakStreakThreshold: 3,
+      },
+    };
+  }
+}
+
+class FakeNotificationService {
+  async createNotification() {}
+}
+
+/** Returns a CASE_STUDY item shape for ensureCaseForItem. */
+class FakeItemRepository {
+  async readItemById() {
+    return {type: 'CASE_STUDY', name: 'Case', details: {bodyMarkdown: 'A prompt.'}} as any;
+  }
+}
+
+/**
+ * End-to-end coverage against a real MongoDB.
+ *
+ * The unit suite drives the service through an in-memory fake, so the actual
+ * queries — the atomic findOneAndUpdate win/flag guards, the two unique-index
+ * races (duplicate submission, duplicate served pair), and the quota counter
+ * under concurrent picks — are only exercised here.
+ *
+ * A replica set (not a standalone) is used because the repository is written
+ * to be safe under concurrent writes, and only a replica set exposes the
+ * behaviour that would break if it were not.
+ */
+
+class TestDb {
+  constructor(private db: Db, private mongoClient: MongoClient) {}
+  async getCollection<T>(name: string) {
+    return this.db.collection<T>(name) as any;
+  }
+  async getClient() {
+    return this.mongoClient;
+  }
+}
+
+let mongo: MongoMemoryReplSet;
+let client: MongoClient;
+let db: Db;
+let repo: CaseStudyRepository;
+let service: CaseStudyService;
+
+const COURSE = new ObjectId().toString();
+const VERSION = new ObjectId().toString();
+
+const VALID_STEELMAN = Array.from({length: ELEMENT_2A_MIN_WORDS}, (_, i) => `word${i}`).join(' ');
+const LONG_STEELMAN = Array.from({length: 50}, (_, i) => `word${i}`).join(' ');
+
+/**
+ * Seed a case the way production does: a CASE_STUDY item is opened, which syncs
+ * its backing case record keyed on the item's own id. The returned id is both
+ * the itemId and the caseStudyId.
+ */
+async function seedCase(_sequenceIndex: number): Promise<string> {
+  const itemId = new ObjectId().toString();
+  await service.ensureCaseForItem({
+    courseId: COURSE,
+    courseVersionId: VERSION,
+    itemId,
+  });
+  return itemId;
+}
+
+function makeFields(steelman = VALID_STEELMAN) {
+  return {
+    beat1a: 'What I thought going in.',
+    beat1b: 'What challenged it during the discussion.',
+    beat1c: 'Where I finally ended up landing.',
+    steelman,
+    roomPerspective: 'One perspective from the room.',
+    changeCommitment: 'One thing I will change.',
+  };
+}
+
+async function submit(caseStudyId: string, userId = new ObjectId().toString(), steelman = VALID_STEELMAN) {
+  return service.submitResponse({userId, caseStudyId, ...makeFields(steelman)});
+}
+
+/** Back-date a comparison's servedAt so its reading timer has already cleared. */
+async function clearTimer(comparisonId: string) {
+  await db
+    .collection('caseComparisons')
+    .updateOne(
+      {_id: new ObjectId(comparisonId)},
+      {$set: {servedAt: new Date(Date.now() - 999_000)}},
+    );
+}
+
+beforeAll(async () => {
+  mongo = await MongoMemoryReplSet.create({replSet: {count: 1}});
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db('caseStudiesTest');
+
+  const testDb = new TestDb(db, client) as any;
+  repo = new CaseStudyRepository(testDb);
+  service = new CaseStudyService(
+    testDb,
+    repo,
+    new FakeCourseSettingService() as never,
+    new FakeNotificationService() as never,
+    new FakeItemRepository() as never,
+  );
+}, 60_000);
+
+afterAll(async () => {
+  await client?.close();
+  await mongo?.stop();
+});
+
+beforeEach(async () => {
+  const cols = await db.collections();
+  await Promise.all(cols.map(c => c.deleteMany({})));
+});
+
+describe('case studies — real MongoDB', () => {
+  it('rejects a duplicate submission race with a clean error, not a crash', async () => {
+    const caseId = await seedCase(1);
+    const user = new ObjectId().toString();
+
+    const results = await Promise.allSettled([submit(caseId, user), submit(caseId, user)]);
+    const ok = results.filter(r => r.status === 'fulfilled');
+    const rejected = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[];
+
+    expect(ok).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(String(rejected[0].reason?.message)).toMatch(/already submitted/i);
+
+    const count = await db
+      .collection('caseResponses')
+      .countDocuments({userId: new ObjectId(user)});
+    expect(count).toBe(1);
+  });
+
+  it('never serves the same reviewer the same pair twice, even under a concurrent race', async () => {
+    const caseId = await seedCase(1);
+    await submit(caseId, new ObjectId().toString());
+    await submit(caseId, new ObjectId().toString());
+    const reviewer = new ObjectId().toString();
+
+    const [pairA, pairB] = await Promise.all([
+      service.getNextPair({reviewerId: reviewer, caseStudyId: caseId}),
+      service.getNextPair({reviewerId: reviewer, caseStudyId: caseId}),
+    ]);
+    expect(pairA?.comparisonId).toBe(pairB?.comparisonId);
+
+    const comparisonCount = await db
+      .collection('caseComparisons')
+      .countDocuments({reviewerId: new ObjectId(reviewer)});
+    expect(comparisonCount).toBe(1);
+  });
+
+  it('re-serves the same pending pair with its original servedAt on a second request', async () => {
+    const caseId = await seedCase(1);
+    await submit(caseId, new ObjectId().toString());
+    await submit(caseId, new ObjectId().toString());
+    const reviewer = new ObjectId().toString();
+
+    const first = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    const second = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    expect(second?.comparisonId).toBe(first?.comparisonId);
+    expect(second?.servedAt).toBe(first?.servedAt);
+  });
+
+  it('rejects a pick before the server-computed minimum reading time elapses', async () => {
+    const caseId = await seedCase(1);
+    // Long steelmans → higher word count → positive minimumScreenTimeSeconds.
+    await submit(caseId, new ObjectId().toString(), LONG_STEELMAN);
+    await submit(caseId, new ObjectId().toString(), LONG_STEELMAN);
+    const reviewer = new ObjectId().toString();
+
+    const pair = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    expect(pair!.minimumScreenTimeSeconds).toBeGreaterThan(0);
+
+    await expect(
+      service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome: 'A'}),
+    ).rejects.toThrow(/reading time/i);
+  });
+
+  it('holds a reviewer to exactly one accepted pick per served pair under a concurrent double-pick race', async () => {
+    const caseId = await seedCase(1);
+    await submit(caseId, new ObjectId().toString());
+    await submit(caseId, new ObjectId().toString());
+    const reviewer = new ObjectId().toString();
+
+    const pair = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    await clearTimer(pair!.comparisonId);
+
+    const results = await Promise.allSettled([
+      service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome: 'A'}),
+      service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome: 'B'}),
+    ]);
+    const accepted = results.filter(r => r.status === 'fulfilled').length;
+    expect(accepted).toBe(1);
+
+    const quota = await repo.getReviewerQuota(reviewer, caseId);
+    expect(quota).toBe(1);
+  });
+
+  it('flips status to WON exactly once even under concurrent winning picks', async () => {
+    const caseId = await seedCase(1);
+    const author = new ObjectId().toString();
+    const {responseId} = await submit(caseId, author);
+    for (let i = 0; i < WINS_REQUIRED + 2; i++) {
+      await submit(caseId, new ObjectId().toString());
+    }
+
+    for (let i = 0; i < WINS_REQUIRED - 1; i++) {
+      const reviewer = new ObjectId().toString();
+      const pair = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+      await clearTimer(pair!.comparisonId);
+      if (pair!.left.responseId === responseId || pair!.right.responseId === responseId) {
+        const outcome = pair!.left.responseId === responseId ? pair!.left.outcome : pair!.right.outcome;
+        await service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome});
+      } else {
+        await service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome: 'BOTH_WEAK'});
+      }
+    }
+
+    const finalReviewers = Array.from({length: 5}, () => new ObjectId().toString());
+    await Promise.allSettled(
+      finalReviewers.map(async reviewerId => {
+        const pair = await service.getNextPair({reviewerId, caseStudyId: caseId});
+        if (!pair) return;
+        await clearTimer(pair.comparisonId);
+        const outcome: 'A' | 'B' | 'BOTH_WEAK' =
+          pair.left.responseId === responseId
+            ? pair.left.outcome
+            : pair.right.responseId === responseId
+              ? pair.right.outcome
+              : 'BOTH_WEAK';
+        await service.submitPick({reviewerId, comparisonId: pair.comparisonId, outcome}).catch(() => {});
+      }),
+    );
+
+    const doc = await db.collection('caseResponses').findOne({_id: new ObjectId(responseId)});
+    if (doc!.winCount >= WINS_REQUIRED) {
+      expect(doc!.status).toBe('WON');
+    }
+  });
+
+  it('does NOT withdraw a response even after multiple FLAGGED verdicts', async () => {
+    const caseId = await seedCase(1);
+    const author = new ObjectId().toString();
+    const {responseId} = await submit(caseId, author);
+    await submit(caseId, new ObjectId().toString());
+
+    for (let i = 0; i < 3; i++) {
+      const reviewer = new ObjectId().toString();
+      const pair = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+      if (!pair) break;
+      await clearTimer(pair!.comparisonId);
+      await service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome: 'FLAGGED'});
+    }
+
+    const doc = await db.collection('caseResponses').findOne({_id: new ObjectId(responseId)});
+    expect(doc?.flagCount).toBeGreaterThan(0);
+    expect(doc?.status).not.toBe('WITHDRAWN');
+  });
+
+  it('exposes all six response fields in the served pair, but never the legacy text field', async () => {
+    const caseId = await seedCase(1);
+    await submit(caseId, new ObjectId().toString());
+    await submit(caseId, new ObjectId().toString());
+    const pair = await service.getNextPair({
+      reviewerId: new ObjectId().toString(),
+      caseStudyId: caseId,
+    });
+    expect(pair!.left).toHaveProperty('steelman');
+    expect(pair!.left).toHaveProperty('beat1a');
+    expect(pair!.left).toHaveProperty('beat1b');
+    expect(pair!.left).toHaveProperty('beat1c');
+    expect(pair!.left).toHaveProperty('roomPerspective');
+    expect(pair!.left).toHaveProperty('changeCommitment');
+    expect(pair!.left).not.toHaveProperty('text');
+  });
+
+  it('reports integration progress facts without a completion boolean', async () => {
+    const caseId = await seedCase(1);
+    const learner = new ObjectId().toString();
+    await submit(caseId, learner);
+
+    const progress = await service.getIntegrationProgress({courseVersionId: VERSION, page: 1, limit: 50});
+    expect(progress.totalLearners).toBe(1);
+    expect(progress.learners[0].casesSubmitted).toBe(1);
+    expect(progress.learners[0].casesInReview).toBe(1);
+    expect(progress.learners[0].casesWon).toBe(0);
+    expect(progress.learners[0]).not.toHaveProperty('completed');
+  });
+});

--- a/backend/src/modules/caseStudies/tests/CaseStudy.integration.test.ts
+++ b/backend/src/modules/caseStudies/tests/CaseStudy.integration.test.ts
@@ -3,7 +3,7 @@ import {Db, MongoClient, ObjectId} from 'mongodb';
 import {MongoMemoryReplSet} from 'mongodb-memory-server';
 import {CaseStudyRepository} from '../repositories/providers/mongodb/CaseStudyRepository.js';
 import {CaseStudyService} from '../services/CaseStudyService.js';
-import {ELEMENT_2A_MIN_WORDS, WINS_REQUIRED} from '../constants.js';
+import {ELEMENT_2A_MIN_WORDS, UNJUDGEABLE_FLAG_THRESHOLD, WINS_REQUIRED} from '../constants.js';
 
 class FakeCourseSettingService {
   async readCourseSettings() {
@@ -255,7 +255,7 @@ describe('case studies — real MongoDB', () => {
     }
   });
 
-  it('does NOT withdraw a response even after multiple FLAGGED verdicts', async () => {
+  it('withdraws a response once FLAGGED verdicts reach UNJUDGEABLE_FLAG_THRESHOLD', async () => {
     const caseId = await seedCase(1);
     const author = new ObjectId().toString();
     const {responseId} = await submit(caseId, author);
@@ -270,8 +270,8 @@ describe('case studies — real MongoDB', () => {
     }
 
     const doc = await db.collection('caseResponses').findOne({_id: new ObjectId(responseId)});
-    expect(doc?.flagCount).toBeGreaterThan(0);
-    expect(doc?.status).not.toBe('WITHDRAWN');
+    expect(doc?.flagCount).toBeGreaterThanOrEqual(UNJUDGEABLE_FLAG_THRESHOLD);
+    expect(doc?.status).toBe('WITHDRAWN');
   });
 
   it('exposes all six response fields in the served pair, but never the legacy text field', async () => {

--- a/backend/src/modules/caseStudies/tests/CaseStudyService.test.ts
+++ b/backend/src/modules/caseStudies/tests/CaseStudyService.test.ts
@@ -1,0 +1,744 @@
+/**
+ * Unit tests for CaseStudyService against an in-memory fake repository.
+ *
+ * These cover the policy the feature lives or dies by — the steelman min-
+ * word check, the video-based unlock, the server-anchored timer, the self-
+ * review guard, and the win/flag thresholds. Mongo-level concurrency (the
+ * unique indexes, the capped findOneAndUpdate) is the repository's contract
+ * and is faked here rather than re-tested — see CaseStudy.integration.test.ts
+ * for that under a real MongoDB.
+ */
+import {beforeEach, describe, expect, it} from 'vitest';
+import {ObjectId} from 'mongodb';
+import {CaseStudyService} from '../services/CaseStudyService.js';
+import type {ICaseStudy} from '../classes/transformers/CaseStudy.js';
+import type {
+  CaseResponseStatus,
+  ICaseResponse,
+} from '../classes/transformers/CaseResponse.js';
+import type {
+  CaseComparisonOutcome,
+  ICaseComparison,
+} from '../classes/transformers/CaseComparison.js';
+import {ELEMENT_2A_MIN_WORDS, WINS_REQUIRED} from '../constants.js';
+
+/** Stands in for CourseSettingService — case studies enabled by default. */
+class FakeCourseSettingService {
+  caseStudiesEnabled = true;
+  caseStudyWeakStreakThreshold = 3;
+
+  async readCourseSettings() {
+    return {
+      settings: {
+        caseStudiesEnabled: this.caseStudiesEnabled,
+        caseStudyWeakStreakThreshold: this.caseStudyWeakStreakThreshold,
+      },
+    };
+  }
+}
+
+/** Stands in for NotificationService — records what would have been sent. */
+class FakeNotificationService {
+  sent: Array<{userId: string; type: string; extra?: Record<string, any>}> = [];
+
+  async createNotification(notification: {userId: any; type: string; extra?: Record<string, any>}) {
+    this.sent.push({userId: notification.userId.toString(), type: notification.type, extra: notification.extra});
+  }
+}
+
+
+const VERSION = new ObjectId().toString();
+const COURSE = new ObjectId().toString();
+
+/** Minimal db stub: makes BaseService._withTransaction just run the callback with a no-op session. */
+const fakeDb = {
+  getClient: async () => ({
+    startSession: () => {
+      let inTx = false;
+      return {
+        startTransaction: () => { inTx = true; },
+        commitTransaction: async () => { inTx = false; },
+        abortTransaction: async () => { inTx = false; },
+        endSession: async () => {},
+        inTransaction: () => inTx,
+      };
+    },
+  }),
+} as any;
+
+function normalizePair(a: ObjectId, b: ObjectId): [ObjectId, ObjectId] {
+  return a.toString() <= b.toString() ? [a, b] : [b, a];
+}
+
+/** Minimal in-memory stand-in for CaseStudyRepository. */
+class FakeRepo {
+  caseStudies: ICaseStudy[] = [];
+  responses: ICaseResponse[] = [];
+  comparisons: ICaseComparison[] = [];
+  quota = new Map<string, number>();
+
+  async findById(caseStudyId: string) {
+    return (
+      this.caseStudies.find(
+        c => c._id!.toString() === caseStudyId && !c.isDeleted,
+      ) ?? null
+    );
+  }
+
+  async listByCourseVersion(courseVersionId: string) {
+    return this.caseStudies.filter(
+      c => c.courseVersionId.toString() === courseVersionId && !c.isDeleted,
+    );
+  }
+
+  async listUserResponsesForVersion(userId: string, courseVersionId: string) {
+    return this.responses.filter(
+      r => r.userId.toString() === userId && r.courseVersionId.toString() === courseVersionId,
+    );
+  }
+
+  async findUserResponse(userId: string, caseStudyId: string) {
+    return (
+      this.responses.find(
+        r => r.userId.toString() === userId && r.caseStudyId.toString() === caseStudyId,
+      ) ?? null
+    );
+  }
+
+  async findResponseById(responseId: string) {
+    return this.responses.find(r => r._id!.toString() === responseId) ?? null;
+  }
+
+  async countUserResponses(userId: string, courseVersionId: string, excludeCaseStudyId?: string) {
+    const responses = await this.listUserResponsesForVersion(userId, courseVersionId);
+    return responses.filter(r => r.caseStudyId.toString() !== excludeCaseStudyId).length;
+  }
+
+  async createResponse(response: ICaseResponse) {
+    const dupe = this.responses.find(
+      r =>
+        r.userId.toString() === response.userId.toString() &&
+        r.caseStudyId.toString() === response.caseStudyId.toString(),
+    );
+    if (dupe) return null;
+    const _id = new ObjectId();
+    this.responses.push({...response, _id});
+    return _id.toString();
+  }
+
+  async reviseResponse(
+    userId: string,
+    caseStudyId: string,
+    fields: {beat1a: string; beat1b: string; beat1c: string; steelman: string; roomPerspective: string; changeCommitment: string},
+  ) {
+    const r = this.responses.find(
+      r => r.userId.toString() === userId && r.caseStudyId.toString() === caseStudyId,
+    );
+    if (!r || r.status === 'WON') return false;
+    Object.assign(r, fields, {status: 'OPEN', winCount: 0, weakStreak: 0, comparisonsSeenCount: 0, flagCount: 0});
+    return true;
+  }
+
+  async findPendingComparison(reviewerId: string, caseStudyId: string) {
+    return (
+      this.comparisons.find(
+        c =>
+          c.reviewerId.toString() === reviewerId &&
+          c.caseStudyId.toString() === caseStudyId &&
+          !c.outcome,
+      ) ?? null
+    );
+  }
+
+  async findComparisonById(comparisonId: string) {
+    return this.comparisons.find(c => c._id!.toString() === comparisonId) ?? null;
+  }
+
+  async pickPairCandidate(caseStudyId: string, reviewerId: string) {
+    const pool = this.responses
+      .filter(
+        r =>
+          r.caseStudyId.toString() === caseStudyId &&
+          r.status === 'OPEN' &&
+          r.userId.toString() !== reviewerId,
+      )
+      .sort((a, b) => a.winCount - b.winCount || a.comparisonsSeenCount - b.comparisonsSeenCount);
+    if (pool.length < 2) return null;
+
+    const seen = new Set(
+      this.comparisons
+        .filter(
+          c => c.reviewerId.toString() === reviewerId && c.caseStudyId.toString() === caseStudyId,
+        )
+        .map(c => `${c.responseAId.toString()}:${c.responseBId.toString()}`),
+    );
+    for (let i = 0; i < pool.length; i++) {
+      for (let j = i + 1; j < pool.length; j++) {
+        const [a, b] = normalizePair(pool[i]._id!, pool[j]._id!);
+        const key = `${a.toString()}:${b.toString()}`;
+        if (!seen.has(key)) return [pool[i], pool[j]] as [ICaseResponse, ICaseResponse];
+      }
+    }
+    return null;
+  }
+
+  async createComparison(input: {
+    caseStudyId: string;
+    courseVersionId: string;
+    reviewerId: string;
+    responseAId: string;
+    responseBId: string;
+    sideAIsLeft: boolean;
+    servedAt: Date;
+    minimumScreenTimeSeconds: number;
+  }) {
+    const [responseAId, responseBId] = normalizePair(
+      new ObjectId(input.responseAId),
+      new ObjectId(input.responseBId),
+    );
+    const dupe = this.comparisons.find(
+      c =>
+        c.reviewerId.toString() === input.reviewerId &&
+        c.responseAId.toString() === responseAId.toString() &&
+        c.responseBId.toString() === responseBId.toString(),
+    );
+    if (dupe) return null;
+    const doc: ICaseComparison = {
+      _id: new ObjectId(),
+      caseStudyId: new ObjectId(input.caseStudyId),
+      courseVersionId: new ObjectId(input.courseVersionId),
+      reviewerId: new ObjectId(input.reviewerId),
+      responseAId,
+      responseBId,
+      sideAIsLeft: input.sideAIsLeft,
+      servedAt: input.servedAt,
+      minimumScreenTimeSeconds: input.minimumScreenTimeSeconds,
+      createdAt: new Date(),
+    };
+    this.comparisons.push(doc);
+    return doc;
+  }
+
+  async recordPick(input: {comparisonId: string; outcome: CaseComparisonOutcome}) {
+    const c = this.comparisons.find(c => c._id!.toString() === input.comparisonId);
+    if (!c || c.outcome) return null;
+    c.outcome = input.outcome;
+    c.decidedAt = new Date();
+    return c;
+  }
+
+  async applyPickEffects(input: {
+    responseAId: ObjectId;
+    responseBId: ObjectId;
+    outcome: CaseComparisonOutcome;
+    winsRequired?: number;
+  }) {
+    const winsRequired = input.winsRequired ?? WINS_REQUIRED;
+    const a = this.responses.find(r => r._id!.toString() === input.responseAId.toString());
+    const b = this.responses.find(r => r._id!.toString() === input.responseBId.toString());
+    if (a) a.comparisonsSeenCount++;
+    if (b) b.comparisonsSeenCount++;
+
+    const weakStreaks: Array<{responseId: ObjectId; userId: ObjectId; weakStreak: number}> = [];
+    const withdrawals: Array<{responseId: ObjectId; userId: ObjectId; withdrawn: boolean}> = [];
+
+    if (input.outcome === 'A' || input.outcome === 'B') {
+      const winner = input.outcome === 'A' ? a : b;
+      const loser = input.outcome === 'A' ? b : a;
+      if (winner) {
+        winner.winCount++;
+        (winner as any).weakStreak = 0;
+        if (winner.status === 'OPEN' && winner.winCount >= winsRequired) {
+          winner.status = 'WON' as CaseResponseStatus;
+        }
+      }
+      if (loser) {
+        (loser as any).weakStreak = ((loser as any).weakStreak ?? 0) + 1;
+        weakStreaks.push({
+          responseId: loser._id!,
+          userId: loser.userId,
+          weakStreak: (loser as any).weakStreak,
+        });
+      }
+    } else if (input.outcome === 'FLAGGED') {
+      for (const r of [a, b]) {
+        if (r) {
+          r.flagCount++;
+          withdrawals.push({responseId: r._id!, userId: r.userId, withdrawn: false});
+        }
+      }
+    } else {
+      // BOTH_WEAK: a substantive judgment against both sides.
+      for (const r of [a, b]) {
+        if (r) {
+          (r as any).weakStreak = ((r as any).weakStreak ?? 0) + 1;
+          weakStreaks.push({responseId: r._id!, userId: r.userId, weakStreak: (r as any).weakStreak});
+        }
+      }
+    }
+
+    return {weakStreaks, withdrawals};
+  }
+
+  async incrementReviewerQuota(reviewerId: string, caseStudyId: string) {
+    const key = `${reviewerId}:${caseStudyId}`;
+    this.quota.set(key, (this.quota.get(key) ?? 0) + 1);
+  }
+
+  async getReviewerQuota(reviewerId: string, caseStudyId: string) {
+    return this.quota.get(`${reviewerId}:${caseStudyId}`) ?? 0;
+  }
+
+  async getPairOutcomeCounts(responseAId: ObjectId, responseBId: ObjectId) {
+    const counts = {A: 0, B: 0, BOTH_WEAK: 0, FLAGGED: 0};
+    for (const c of this.comparisons) {
+      if (
+        c.responseAId.toString() === responseAId.toString() &&
+        c.responseBId.toString() === responseBId.toString() &&
+        c.outcome
+      ) {
+        counts[c.outcome]++;
+      }
+    }
+    return counts;
+  }
+
+  async create(caseStudy: ICaseStudy) {
+    const _id = new ObjectId();
+    this.caseStudies.push({...caseStudy, _id});
+    return _id.toString();
+  }
+
+  async update(caseStudyId: string, patch: Partial<ICaseStudy>) {
+    const c = this.caseStudies.find(c => c._id!.toString() === caseStudyId);
+    if (!c) return false;
+    Object.assign(c, patch);
+    return true;
+  }
+
+  async softDelete(caseStudyId: string) {
+    const c = this.caseStudies.find(c => c._id!.toString() === caseStudyId);
+    if (!c) return false;
+    c.isDeleted = true;
+    return true;
+  }
+
+  async getStats() {
+    return {
+      casesPublished: this.caseStudies.length,
+      totalResponses: this.responses.length,
+      responsesPerCase: [],
+      flaggedCount: this.responses.filter(r => r.flagCount > 0).length,
+      averageComparisonsToWin: null,
+    };
+  }
+
+  async getIntegrationProgress() {
+    return {totalLearners: 0, learners: []};
+  }
+}
+
+let repo: FakeRepo;
+let courseSettings: FakeCourseSettingService;
+let notifications: FakeNotificationService;
+let service: CaseStudyService;
+
+/** Seeds a case study record directly in the fake repo. */
+function seedCase(
+  label: number | string = '',
+  config: {
+    reviewsRequired?: number;
+    picksRequired?: number;
+    weakStreakThreshold?: number;
+  } = {},
+): string {
+  const _id = new ObjectId();
+  repo.caseStudies.push({
+    _id,
+    courseId: new ObjectId(COURSE),
+    courseVersionId: new ObjectId(VERSION),
+    title: `Case ${label}`,
+    bodyMarkdown: 'A prompt.',
+    isDeleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...config,
+  });
+  return _id.toString();
+}
+
+const VALID_STEELMAN = Array.from({length: ELEMENT_2A_MIN_WORDS}, (_, i) => `word${i}`).join(' ');
+
+function makeFields(overrides: Partial<{
+  beat1a: string; beat1b: string; beat1c: string;
+  steelman: string; roomPerspective: string; changeCommitment: string;
+}> = {}) {
+  return {
+    beat1a: 'What I thought going in.',
+    beat1b: 'What challenged it during the discussion.',
+    beat1c: 'Where I finally ended up landing.',
+    steelman: VALID_STEELMAN,
+    roomPerspective: 'One perspective from the room.',
+    changeCommitment: 'One thing I will change.',
+    ...overrides,
+  };
+}
+
+async function submit(caseStudyId: string, userId = new ObjectId().toString(), overrides = {}) {
+  return service.submitResponse({userId, caseStudyId, ...makeFields(overrides)});
+}
+
+beforeEach(() => {
+  repo = new FakeRepo();
+  courseSettings = new FakeCourseSettingService();
+  notifications = new FakeNotificationService();
+  service = new CaseStudyService(
+    fakeDb,
+    repo as never,
+    courseSettings as never,
+    notifications as never,
+    {readItemById: async () => ({type: 'CASE_STUDY', name: 'Case', details: {bodyMarkdown: 'A prompt.'}})} as never,
+  );
+});
+
+describe('submitResponse — steelman word count', () => {
+  it(`accepts steelman with exactly ${ELEMENT_2A_MIN_WORDS} words`, async () => {
+    const caseId = seedCase(1);
+    await expect(submit(caseId)).resolves.toHaveProperty('responseId');
+  });
+
+  it(`rejects steelman with fewer than ${ELEMENT_2A_MIN_WORDS} words`, async () => {
+    const caseId = seedCase(1);
+    await expect(submit(caseId, undefined, {steelman: 'too short'})).rejects.toThrow(/25 words/);
+  });
+
+  it('rejects an empty steelman', async () => {
+    const caseId = seedCase(1);
+    // Whitespace trims to zero words, so the word-count floor rejects it.
+    await expect(submit(caseId, undefined, {steelman: '   '})).rejects.toThrow(/at least 25 words/i);
+  });
+
+  it('counts a mixed Hindi-English steelman by word, not by character or byte', async () => {
+    const caseId = seedCase(1);
+    // 5 Devanagari words + 20 English words = 25 words total
+    const steelman = 'मैं सबसे पहले पूछूंगा छात्र ' +
+      Array.from({length: 20}, (_, i) => `word${i}`).join(' ');
+    const {responseId} = await submit(caseId, undefined, {steelman});
+    expect(responseId).toBeTruthy();
+  });
+});
+
+describe('submitResponse', () => {
+  it('accepts a valid submission (access is gated by the item, not a video unlock)', async () => {
+    const caseId = seedCase(1);
+    await expect(submit(caseId)).resolves.toHaveProperty('responseId');
+  });
+});
+
+describe('submitResponse — duplicates', () => {
+  it('rejects a second submission for the same case by the same user', async () => {
+    const caseId = seedCase(1);
+    const user = new ObjectId().toString();
+    await submit(caseId, user);
+    await expect(submit(caseId, user)).rejects.toThrow(/already submitted/i);
+  });
+
+  it('rejects a concurrent double-submit race with a clean error, not a crash', async () => {
+    const caseId = seedCase(1);
+    const user = new ObjectId().toString();
+    const results = await Promise.allSettled([submit(caseId, user), submit(caseId, user)]);
+    const ok = results.filter(r => r.status === 'fulfilled');
+    const rejected = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[];
+    expect(ok).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(String(rejected[0].reason?.message)).toMatch(/already submitted/i);
+  });
+});
+
+describe('getNextPair / submitPick — timer and self-review', () => {
+  it('rejects a pick attempted before the minimum reading time has elapsed', async () => {
+    const caseId = seedCase(1);
+    const author1 = new ObjectId().toString();
+    const author2 = new ObjectId().toString();
+    await submit(caseId, author1);
+    await submit(caseId, author2);
+
+    const reviewer = new ObjectId().toString();
+    const pair = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    expect(pair).not.toBeNull();
+
+    await expect(
+      service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome: 'A'}),
+    ).rejects.toThrow(/reading time/i);
+  });
+
+  it('accepts a pick once the minimum reading time has elapsed', async () => {
+    const caseId = seedCase(1);
+    const author1 = new ObjectId().toString();
+    const author2 = new ObjectId().toString();
+    await submit(caseId, author1);
+    await submit(caseId, author2);
+
+    const reviewer = new ObjectId().toString();
+    const pair = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    // Back-date servedAt so the timer has already cleared.
+    const comparison = repo.comparisons.find(c => c._id!.toString() === pair!.comparisonId)!;
+    comparison.servedAt = new Date(Date.now() - 999_000);
+
+    const result = await service.submitPick({
+      reviewerId: reviewer,
+      comparisonId: pair!.comparisonId,
+      outcome: 'A',
+    });
+    expect(result.outcome).toBe('A');
+  });
+
+  it('rejects a double-pick on the same comparison', async () => {
+    const caseId = seedCase(1);
+    await submit(caseId, new ObjectId().toString());
+    await submit(caseId, new ObjectId().toString());
+    const reviewer = new ObjectId().toString();
+    const pair = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    const comparison = repo.comparisons.find(c => c._id!.toString() === pair!.comparisonId)!;
+    comparison.servedAt = new Date(Date.now() - 999_000);
+
+    await service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome: 'A'});
+    await expect(
+      service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome: 'B'}),
+    ).rejects.toThrow(/already been decided/i);
+  });
+
+  it('refuses a self-review even if a pair somehow named the reviewer', async () => {
+    const caseId = seedCase(1);
+    const reviewer = new ObjectId().toString();
+    await submit(caseId, reviewer);
+    const other = new ObjectId().toString();
+    await submit(caseId, other);
+
+    const responseByReviewer = repo.responses.find(r => r.userId.toString() === reviewer)!;
+    const responseByOther = repo.responses.find(r => r.userId.toString() === other)!;
+    const comparison = await repo.createComparison({
+      caseStudyId: caseId,
+      courseVersionId: VERSION,
+      reviewerId: reviewer,
+      responseAId: responseByReviewer._id!.toString(),
+      responseBId: responseByOther._id!.toString(),
+      sideAIsLeft: true,
+      servedAt: new Date(Date.now() - 999_000),
+      minimumScreenTimeSeconds: 1,
+    });
+
+    await expect(
+      service.submitPick({reviewerId: reviewer, comparisonId: comparison!._id!.toString(), outcome: 'A'}),
+    ).rejects.toThrow(/cannot review your own/i);
+  });
+
+  it('exposes all six response fields in the served pair', async () => {
+    const caseId = seedCase(1);
+    await submit(caseId, new ObjectId().toString());
+    await submit(caseId, new ObjectId().toString());
+    const pair = await service.getNextPair({
+      reviewerId: new ObjectId().toString(),
+      caseStudyId: caseId,
+    });
+    const expectedKeys = [
+      'beat1a', 'beat1b', 'beat1c', 'changeCommitment', 'outcome',
+      'responseId', 'roomPerspective', 'steelman', 'wordCount',
+    ];
+    expect(Object.keys(pair!.left).sort()).toEqual(expectedKeys);
+    expect(Object.keys(pair!.right).sort()).toEqual(expectedKeys);
+  });
+});
+
+describe('win / flag thresholds', () => {
+  it('settles a response to WON at the per-item reviewsRequired, not the default 7', async () => {
+    // reviewsRequired=1: with exactly one opponent there is only one possible
+    // pair, so a single winning pick must flip the author to WON — proving the
+    // per-item knob overrides WINS_REQUIRED.
+    const caseId = seedCase(1, {reviewsRequired: 1});
+    const author = new ObjectId().toString();
+    const {responseId} = await submit(caseId, author);
+    await submit(caseId, new ObjectId().toString());
+
+    const reviewer = new ObjectId().toString();
+    const pair = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    const comparison = repo.comparisons.find(c => c._id!.toString() === pair!.comparisonId)!;
+    comparison.servedAt = new Date(Date.now() - 999_000);
+    const outcome =
+      pair!.left.responseId === responseId ? pair!.left.outcome : pair!.right.outcome;
+    await service.submitPick({reviewerId: reviewer, comparisonId: pair!.comparisonId, outcome});
+
+    const response = repo.responses.find(r => r._id!.toString() === responseId)!;
+    expect(response.winCount).toBe(1);
+    expect(response.status).toBe('WON');
+  });
+
+  it(`moves a response to WON after ${WINS_REQUIRED} wins`, async () => {
+    const caseId = seedCase(1);
+    const author = new ObjectId().toString();
+    const {responseId} = await submit(caseId, author);
+    // A pool of opponents so pickPairCandidate always has two OPEN candidates.
+    for (let i = 0; i < 3; i++) {
+      await submit(caseId, new ObjectId().toString());
+    }
+
+    for (let i = 0; i < WINS_REQUIRED; i++) {
+      const reviewer = new ObjectId().toString();
+      const pair = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+      if (!pair) break;
+      const comparison = repo.comparisons.find(c => c._id!.toString() === pair.comparisonId)!;
+      comparison.servedAt = new Date(Date.now() - 999_000);
+      const outcome =
+        pair.left.responseId === responseId
+          ? pair.left.outcome
+          : pair.right.responseId === responseId
+            ? pair.right.outcome
+            : null;
+      if (outcome) {
+        await service.submitPick({reviewerId: reviewer, comparisonId: pair.comparisonId, outcome});
+      } else {
+        await service.submitPick({reviewerId: reviewer, comparisonId: pair.comparisonId, outcome: 'BOTH_WEAK'});
+      }
+    }
+
+    const response = repo.responses.find(r => r._id!.toString() === responseId)!;
+    expect(response.winCount).toBeGreaterThanOrEqual(0);
+    if (response.winCount >= WINS_REQUIRED) {
+      expect(response.status).toBe('WON');
+    }
+  });
+
+  it('does not count a FLAGGED verdict toward the reviewer quota, but counts BOTH_WEAK', async () => {
+    const caseId = seedCase(1);
+    await submit(caseId, new ObjectId().toString());
+    await submit(caseId, new ObjectId().toString());
+    const reviewer = new ObjectId().toString();
+
+    const pair1 = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    const c1 = repo.comparisons.find(c => c._id!.toString() === pair1!.comparisonId)!;
+    c1.servedAt = new Date(Date.now() - 999_000);
+    await service.submitPick({reviewerId: reviewer, comparisonId: pair1!.comparisonId, outcome: 'FLAGGED'});
+    expect(await repo.getReviewerQuota(reviewer, caseId)).toBe(0);
+
+    await submit(caseId, new ObjectId().toString());
+    const pair2 = await service.getNextPair({reviewerId: reviewer, caseStudyId: caseId});
+    const c2 = repo.comparisons.find(c => c._id!.toString() === pair2!.comparisonId)!;
+    c2.servedAt = new Date(Date.now() - 999_000);
+    await service.submitPick({reviewerId: reviewer, comparisonId: pair2!.comparisonId, outcome: 'BOTH_WEAK'});
+    expect(await repo.getReviewerQuota(reviewer, caseId)).toBe(1);
+  });
+
+  it('reports how many readers of this exact pair chose the same outcome', async () => {
+    const caseId = seedCase(1);
+    await submit(caseId, new ObjectId().toString());
+    await submit(caseId, new ObjectId().toString());
+
+    const reviewer1 = new ObjectId().toString();
+    const pair1 = await service.getNextPair({reviewerId: reviewer1, caseStudyId: caseId});
+    const c1 = repo.comparisons.find(c => c._id!.toString() === pair1!.comparisonId)!;
+    c1.servedAt = new Date(Date.now() - 999_000);
+    const outcome1 = pair1!.left.outcome;
+    const result1 = await service.submitPick({reviewerId: reviewer1, comparisonId: pair1!.comparisonId, outcome: outcome1});
+    expect(result1.agreementCount).toBe(1);
+    expect(result1.totalJudged).toBe(1);
+
+    const reviewer2 = new ObjectId().toString();
+    const pair2 = await service.getNextPair({reviewerId: reviewer2, caseStudyId: caseId});
+    const ids1 = [pair1!.left.responseId, pair1!.right.responseId].sort();
+    const ids2 = [pair2!.left.responseId, pair2!.right.responseId].sort();
+    expect(ids2).toEqual(ids1);
+
+    const targetResponseId = outcome1 === pair1!.left.outcome ? pair1!.left.responseId : pair1!.right.responseId;
+    const outcome2 =
+      pair2!.left.responseId === targetResponseId ? pair2!.left.outcome : pair2!.right.outcome;
+
+    const c2 = repo.comparisons.find(c => c._id!.toString() === pair2!.comparisonId)!;
+    c2.servedAt = new Date(Date.now() - 999_000);
+    const result2 = await service.submitPick({reviewerId: reviewer2, comparisonId: pair2!.comparisonId, outcome: outcome2});
+    expect(result2.agreementCount).toBe(2);
+    expect(result2.totalJudged).toBe(2);
+  });
+});
+
+describe('weak-response-streak notification', () => {
+  async function loseTo(caseId: string, responseId: string, opponentId: string) {
+    const reviewer = new ObjectId().toString();
+    const comparison = await repo.createComparison({
+      caseStudyId: caseId,
+      courseVersionId: VERSION,
+      reviewerId: reviewer,
+      responseAId: responseId,
+      responseBId: opponentId,
+      sideAIsLeft: true,
+      servedAt: new Date(Date.now() - 999_000),
+      minimumScreenTimeSeconds: 1,
+    });
+    const outcome = comparison!.responseAId.toString() === opponentId ? 'A' : 'B';
+    return service.submitPick({reviewerId: reviewer, comparisonId: comparison!._id!.toString(), outcome});
+  }
+
+  it('notifies the author once the losing streak hits the configured threshold, not before or after', async () => {
+    courseSettings.caseStudyWeakStreakThreshold = 2;
+    const caseId = seedCase(1);
+    const author = new ObjectId().toString();
+    const {responseId} = await submit(caseId, author);
+    const {responseId: opponent1} = await submit(caseId, new ObjectId().toString());
+    const {responseId: opponent2} = await submit(caseId, new ObjectId().toString());
+
+    await loseTo(caseId, responseId, opponent1);
+    expect(
+      notifications.sent.filter(n => n.type === 'case_response_weak_streak' && n.userId === author),
+    ).toHaveLength(0);
+
+    await loseTo(caseId, responseId, opponent2);
+    const weakStreakNotifications = notifications.sent.filter(
+      n => n.type === 'case_response_weak_streak' && n.userId === author,
+    );
+    expect(weakStreakNotifications).toHaveLength(1);
+    expect(weakStreakNotifications[0].extra?.weakStreak).toBe(2);
+  });
+
+  it('resets the streak — and does not renotify — once the response wins', async () => {
+    courseSettings.caseStudyWeakStreakThreshold = 2;
+    const caseId = seedCase(1);
+    const author = new ObjectId().toString();
+    const {responseId} = await submit(caseId, author);
+    const {responseId: opponent1} = await submit(caseId, new ObjectId().toString());
+    const {responseId: opponent2} = await submit(caseId, new ObjectId().toString());
+    const {responseId: opponent3} = await submit(caseId, new ObjectId().toString());
+
+    await loseTo(caseId, responseId, opponent1);
+
+    const winReviewer = new ObjectId().toString();
+    const winComparison = await repo.createComparison({
+      caseStudyId: caseId,
+      courseVersionId: VERSION,
+      reviewerId: winReviewer,
+      responseAId: responseId,
+      responseBId: opponent2,
+      sideAIsLeft: true,
+      servedAt: new Date(Date.now() - 999_000),
+      minimumScreenTimeSeconds: 1,
+    });
+    const winOutcome = winComparison!.responseAId.toString() === responseId ? 'A' : 'B';
+    await service.submitPick({reviewerId: winReviewer, comparisonId: winComparison!._id!.toString(), outcome: winOutcome});
+
+    await loseTo(caseId, responseId, opponent3);
+
+    expect(
+      notifications.sent.filter(n => n.type === 'case_response_weak_streak' && n.userId === author),
+    ).toHaveLength(0);
+  });
+
+  it('does not notify when the threshold is disabled (0)', async () => {
+    courseSettings.caseStudyWeakStreakThreshold = 0;
+    const caseId = seedCase(1);
+    const author = new ObjectId().toString();
+    const {responseId} = await submit(caseId, author);
+    const {responseId: opponent} = await submit(caseId, new ObjectId().toString());
+
+    await loseTo(caseId, responseId, opponent);
+
+    expect(notifications.sent).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/caseStudies/types.ts
+++ b/backend/src/modules/caseStudies/types.ts
@@ -1,0 +1,6 @@
+const CASE_STUDIES_TYPES = {
+  CaseStudyService: Symbol.for('CaseStudyService'),
+  CaseStudyRepo: Symbol.for('CaseStudyRepo'),
+};
+
+export {CASE_STUDIES_TYPES};

--- a/backend/src/modules/courses/classes/transformers/Item.ts
+++ b/backend/src/modules/courses/classes/transformers/Item.ts
@@ -15,6 +15,7 @@ import {
   IBlogDetails,
   IFeedBackFormDetails,
   IReflectionDetails,
+  ICaseStudyDetails,
 } from '#root/shared/interfaces/models.js';
 
 export type Item = QuizItem | VideoItem | BlogItem | ProjectItem;
@@ -192,6 +193,49 @@ class ReflectionItem {
   ) {
     this._id = _id;
     this.type = ItemType.REFLECTION;
+    this.name = name;
+    this.isOptional = isOptional;
+    this.description = description;
+    this.details = details ?? {};
+  }
+}
+
+/**
+ * A peer-reviewed case study placed in a section like any other item, so it
+ * inherits progression, completion and navigation. Holds the case body and the
+ * per-item review-rule knobs; responses and comparisons live in the
+ * caseStudies module.
+ */
+class CaseStudyItem {
+  @Expose()
+  @Transform(ObjectIdToString.transformer, { toPlainOnly: true })
+  @Transform(StringToObjectId.transformer, { toClassOnly: true })
+  _id?: ID;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  description: string;
+
+  @Expose()
+  isOptional: boolean;
+
+  @Expose()
+  type: ItemType = ItemType.CASE_STUDY;
+
+  @Expose()
+  details: ICaseStudyDetails;
+
+  constructor(
+    name: string,
+    description: string,
+    _id: ID,
+    details?: ICaseStudyDetails,
+    isOptional: boolean = false,
+  ) {
+    this._id = _id;
+    this.type = ItemType.CASE_STUDY;
     this.name = name;
     this.isOptional = isOptional;
     this.description = description;
@@ -436,6 +480,14 @@ class ItemBase {
             itemBody.reflectionDetails,
           );
           break;
+        case ItemType.CASE_STUDY:
+          this.itemDetails = new CaseStudyItem(
+            itemBody.name,
+            itemBody.description,
+            this.itemId,
+            itemBody.caseStudyDetails,
+          );
+          break;
         default:
           break;
       }
@@ -534,4 +586,5 @@ export {
   FeedBackFormItem,
   FeedbackSubmissionItem,
   ReflectionItem,
+  CaseStudyItem,
 };

--- a/backend/src/modules/courses/classes/validators/ItemValidators.ts
+++ b/backend/src/modules/courses/classes/validators/ItemValidators.ts
@@ -363,6 +363,54 @@ class ReflectionDetailsPayloadValidator {
   minReviewsToReveal?: number;
 }
 
+class CaseStudyDetailsPayloadValidator {
+  @JSONSchema({
+    description:
+      'The case scenario/prompt shown to the learner (markdown). Required for a usable case.',
+    example: 'A student keeps giving confidently wrong answers in class...',
+    type: 'string',
+  })
+  @IsString()
+  @IsOptional()
+  bodyMarkdown?: string;
+
+  @JSONSchema({
+    description:
+      'Wins a response needs before it leaves the review pool (1-25). Defaults to 7.',
+    example: 7,
+    type: 'integer',
+  })
+  @IsInt()
+  @Min(1)
+  @Max(25)
+  @IsOptional()
+  reviewsRequired?: number;
+
+  @JSONSchema({
+    description:
+      'Comparisons each learner must judge (1-25). Defaults to 7.',
+    example: 7,
+    type: 'integer',
+  })
+  @IsInt()
+  @Min(1)
+  @Max(25)
+  @IsOptional()
+  picksRequired?: number;
+
+  @JSONSchema({
+    description:
+      'Consecutive losses before the author is prompted to revise (0-25, 0 disables). Defaults to 3.',
+    example: 3,
+    type: 'integer',
+  })
+  @IsInt()
+  @Min(0)
+  @Max(25)
+  @IsOptional()
+  weakStreakThreshold?: number;
+}
+
 class CreateItemBody implements Partial<IBaseItem> {
   @JSONSchema({
     description: 'Title of the item',
@@ -407,7 +455,7 @@ class CreateItemBody implements Partial<IBaseItem> {
     description: 'Type of the item: VIDEO, BLOG, or QUIZ',
     example: 'VIDEO',
     type: 'string',
-    enum: ['VIDEO', 'BLOG', 'QUIZ', 'PROJECT', 'FEEDBACK', 'REFLECTION'],
+    enum: ['VIDEO', 'BLOG', 'QUIZ', 'PROJECT', 'FEEDBACK', 'REFLECTION', 'CASE_STUDY'],
   })
   @IsEnum(ItemType)
   @IsNotEmpty()
@@ -471,6 +519,12 @@ class CreateItemBody implements Partial<IBaseItem> {
   @ValidateNested()
   @Type(() => ReflectionDetailsPayloadValidator)
   reflectionDetails?: ReflectionDetailsPayloadValidator;
+
+  @ValidateIf(o => o.type === ItemType.CASE_STUDY)
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CaseStudyDetailsPayloadValidator)
+  caseStudyDetails?: CaseStudyDetailsPayloadValidator;
 }
 
 class UpdateItemBody implements Partial<IBaseItem> {
@@ -517,7 +571,7 @@ class UpdateItemBody implements Partial<IBaseItem> {
     description: 'Type of the item: VIDEO, BLOG, QUIZ or PROJECT',
     example: 'VIDEO',
     type: 'string',
-    enum: ['VIDEO', 'BLOG', 'QUIZ', 'PROJECT', 'FEEDBACK', 'REFLECTION'],
+    enum: ['VIDEO', 'BLOG', 'QUIZ', 'PROJECT', 'FEEDBACK', 'REFLECTION', 'CASE_STUDY'],
   })
   @IsEnum(ItemType)
   @IsNotEmpty()
@@ -575,6 +629,8 @@ class UpdateItemBody implements Partial<IBaseItem> {
         return FeedBackFormPayloadValidator;
       case ItemType.REFLECTION:
         return ReflectionDetailsPayloadValidator;
+      case ItemType.CASE_STUDY:
+        return CaseStudyDetailsPayloadValidator;
       default:
         throw new Error(`Unknown item type: ${itemType}`);
     }
@@ -585,7 +641,8 @@ class UpdateItemBody implements Partial<IBaseItem> {
     | QuizDetailsPayloadValidator
     | ProjectDetailsPayloadValidator
     | FeedBackFormPayloadValidator
-    | ReflectionDetailsPayloadValidator;
+    | ReflectionDetailsPayloadValidator
+    | CaseStudyDetailsPayloadValidator;
 }
 
 class MoveItemBody {
@@ -1169,6 +1226,7 @@ export {
   QuizDetailsPayloadValidator,
   BlogDetailsPayloadValidator,
   ReflectionDetailsPayloadValidator,
+  CaseStudyDetailsPayloadValidator,
   VersionModuleSectionItemParams,
   CourseVersionModuleSectionParams,
   CSVItemBody,

--- a/backend/src/modules/setting/classes/transformers/CourseSetting.ts
+++ b/backend/src/modules/setting/classes/transformers/CourseSetting.ts
@@ -387,6 +387,21 @@ class CourseSetting implements ICourseSetting {
       },
       linearProgressionEnabled: {type: 'boolean'},
       seekForwardEnabled: {type: 'boolean'},
+      hpSystem: {type: 'boolean'},
+      caseStudiesEnabled: {
+        type: 'boolean',
+        description: 'Whether the Case Studies tab is enabled for this course version.',
+      },
+      caseStudyStrictUnlockEnabled: {
+        type: 'boolean',
+        description:
+          'Case-study unlock mode: true requires the previous case to reach the peer-review win threshold before the next unlocks; false unlocks the next case as soon as the previous one has any submitted response.',
+      },
+      caseStudyWeakStreakThreshold: {
+        type: 'integer',
+        description:
+          'Consecutive non-winning peer verdicts on a response before the author is notified it may need revising.',
+      },
       registration: {
         type: 'object',
         description: 'Registration configuration schemas',
@@ -429,6 +444,12 @@ class CourseSetting implements ICourseSetting {
     isPublic?: boolean;
     baseHp?: number;
     randomizeItems?: boolean;
+    /** Gates the Case Studies drawer tab. Default false — additive, no existing course is affected. */
+    caseStudiesEnabled?: boolean;
+    /** Case-study unlock mode. Default false (sequential: next case unlocks on submission, not on winning peer review). */
+    caseStudyStrictUnlockEnabled?: boolean;
+    /** Consecutive non-winning peer verdicts before the author is notified. Default 3. */
+    caseStudyWeakStreakThreshold?: number;
     registration?: {
       jsonSchema?: any;
       uiSchema?: any;
@@ -470,6 +491,12 @@ class CourseSetting implements ICourseSetting {
       isPublic: courseSettingsBody?.settings?.isPublic ?? false,
       baseHp: courseSettingsBody?.settings?.baseHp ?? 0,
       randomizeItems: courseSettingsBody?.settings?.randomizeItems ?? false,
+      caseStudiesEnabled:
+        courseSettingsBody?.settings?.caseStudiesEnabled ?? false,
+      caseStudyStrictUnlockEnabled:
+        courseSettingsBody?.settings?.caseStudyStrictUnlockEnabled ?? true,
+      caseStudyWeakStreakThreshold:
+        courseSettingsBody?.settings?.caseStudyWeakStreakThreshold ?? 3,
       registration: {
         jsonSchema: courseSettingsBody?.settings?.registration?.jsonSchema,
         uiSchema: courseSettingsBody?.settings?.registration?.uiSchema,

--- a/backend/src/modules/setting/classes/validators/CourseSettingValidators.ts
+++ b/backend/src/modules/setting/classes/validators/CourseSettingValidators.ts
@@ -194,6 +194,37 @@ export class SettingsDto {
   hpSystem?: boolean;
 
   @IsOptional()
+  @IsBoolean()
+  @JSONSchema({
+    description: 'Indicates whether the Case Studies tab is enabled for this course version',
+    examples: [true, false],
+    default: false,
+  })
+  caseStudiesEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @JSONSchema({
+    description:
+      'Case-study unlock mode: true requires the previous case to reach the peer-review win threshold before the next unlocks; false unlocks the next case as soon as the previous one has any submitted response.',
+    examples: [true, false],
+    default: false,
+  })
+  caseStudyStrictUnlockEnabled?: boolean;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(20)
+  @JSONSchema({
+    description:
+      'Consecutive non-winning peer verdicts on a case-study response before the author is notified it may need revising.',
+    example: 3,
+    default: 3,
+  })
+  caseStudyWeakStreakThreshold?: number;
+
+  @IsOptional()
   @IsNumber()
   @Min(0)
   @Max(100)
@@ -441,6 +472,37 @@ export class AddCourseProctoringBody {
     default: false,
   })
   hpSystem?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @JSONSchema({
+    description: 'Indicates whether the Case Studies tab is enabled for this course version',
+    examples: [true, false],
+    default: false,
+  })
+  caseStudiesEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @JSONSchema({
+    description:
+      'Case-study unlock mode: true requires the previous case to reach the peer-review win threshold before the next unlocks; false unlocks the next case as soon as the previous one has any submitted response.',
+    examples: [true, false],
+    default: false,
+  })
+  caseStudyStrictUnlockEnabled?: boolean;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(20)
+  @JSONSchema({
+    description:
+      'Consecutive non-winning peer verdicts on a case-study response before the author is notified it may need revising.',
+    example: 3,
+    default: 3,
+  })
+  caseStudyWeakStreakThreshold?: number;
 
   @IsOptional()
   @IsBoolean()

--- a/backend/src/modules/setting/controllers/CourseSettingController.ts
+++ b/backend/src/modules/setting/controllers/CourseSettingController.ts
@@ -132,6 +132,9 @@ export class CourseSettingController {
       baseHp,
       randomizeItems,
       crowdsourcedQuestionSubmissionEnabled,
+      caseStudiesEnabled,
+      caseStudyStrictUnlockEnabled,
+      caseStudyWeakStreakThreshold,
     } = body;
     const userId = user._id.toString();
 
@@ -147,6 +150,9 @@ export class CourseSettingController {
       randomizeItems,
       userId,
       crowdsourcedQuestionSubmissionEnabled ?? false,
+      caseStudiesEnabled ?? false,
+      caseStudyStrictUnlockEnabled ?? true,
+      caseStudyWeakStreakThreshold ?? 3,
     );
 
     setAuditTrail(req, {
@@ -169,6 +175,9 @@ export class CourseSettingController {
           seekForwardEnabled: seekForwardEnabled,
           crowdsourcedQuestionSubmissionEnabled:
             crowdsourcedQuestionSubmissionEnabled ?? false,
+          caseStudiesEnabled: caseStudiesEnabled ?? false,
+          caseStudyStrictUnlockEnabled: caseStudyStrictUnlockEnabled ?? true,
+          caseStudyWeakStreakThreshold: caseStudyWeakStreakThreshold ?? 3,
         },
       },
       outcome: {

--- a/backend/src/modules/setting/services/CourseSettingService.ts
+++ b/backend/src/modules/setting/services/CourseSettingService.ts
@@ -133,6 +133,9 @@ class CourseSettingService extends BaseService {
         settings.timeslots = {isActive: false, slots: []};
         settings.baseHp = 0;
         settings.randomizeItems = false;
+        settings.caseStudiesEnabled = false;
+        settings.caseStudyStrictUnlockEnabled = true;
+        settings.caseStudyWeakStreakThreshold = 3;
 
         const created = await this.createCourseSettings(
           new CourseSetting({
@@ -166,6 +169,9 @@ class CourseSettingService extends BaseService {
     randomizeItems: boolean,
     userId: string,
     crowdsourcedQuestionSubmissionEnabled: boolean = false,
+    caseStudiesEnabled: boolean = false,
+    caseStudyStrictUnlockEnabled: boolean = true,
+    caseStudyWeakStreakThreshold: number = 3,
   ): Promise<boolean> {
     return this._withTransaction(async session => {
       const versionStatus =
@@ -195,6 +201,9 @@ class CourseSettingService extends BaseService {
         settings.randomizeItems = randomizeItems;
         settings.crowdsourcedQuestionSubmissionEnabled =
           crowdsourcedQuestionSubmissionEnabled;
+        settings.caseStudiesEnabled = caseStudiesEnabled;
+        settings.caseStudyStrictUnlockEnabled = caseStudyStrictUnlockEnabled;
+        settings.caseStudyWeakStreakThreshold = caseStudyWeakStreakThreshold;
 
         settings.audit = [
           {
@@ -212,6 +221,9 @@ class CourseSettingService extends BaseService {
                 baseHp,
                 randomizeItems,
                 crowdsourcedQuestionSubmissionEnabled,
+                caseStudiesEnabled,
+                caseStudyStrictUnlockEnabled,
+                caseStudyWeakStreakThreshold,
               },
             },
           },
@@ -248,6 +260,11 @@ class CourseSettingService extends BaseService {
         randomizeItems: courseSettings.settings?.randomizeItems,
         crowdsourcedQuestionSubmissionEnabled:
           courseSettings.settings?.crowdsourcedQuestionSubmissionEnabled,
+        caseStudiesEnabled: courseSettings.settings?.caseStudiesEnabled,
+        caseStudyStrictUnlockEnabled:
+          courseSettings.settings?.caseStudyStrictUnlockEnabled,
+        caseStudyWeakStreakThreshold:
+          courseSettings.settings?.caseStudyWeakStreakThreshold,
       };
 
       const afterState = {
@@ -259,6 +276,9 @@ class CourseSettingService extends BaseService {
         baseHp,
         randomizeItems,
         crowdsourcedQuestionSubmissionEnabled,
+        caseStudiesEnabled,
+        caseStudyStrictUnlockEnabled,
+        caseStudyWeakStreakThreshold,
       };
 
       const audit: AuditingDto = {
@@ -284,6 +304,9 @@ class CourseSettingService extends BaseService {
         audit,
         session,
         crowdsourcedQuestionSubmissionEnabled,
+        caseStudiesEnabled,
+        caseStudyStrictUnlockEnabled,
+        caseStudyWeakStreakThreshold,
       );
 
       if (!result) {

--- a/backend/src/modules/users/controllers/IntegrationController.ts
+++ b/backend/src/modules/users/controllers/IntegrationController.ts
@@ -1,6 +1,8 @@
 import { ApiKeyAuthMiddleware } from '#root/shared/middleware/ApiKeyAuthMiddleware.js';
 import { EnrollmentService } from '#users/services/EnrollmentService.js';
 import { USERS_TYPES } from '#users/types.js';
+import { CASE_STUDIES_TYPES } from '#root/modules/caseStudies/types.js';
+import { CaseStudyService } from '#root/modules/caseStudies/services/CaseStudyService.js';
 import { injectable, inject } from 'inversify';
 import {
   JsonController,
@@ -31,6 +33,8 @@ class IntegrationController {
   constructor(
     @inject(USERS_TYPES.EnrollmentService)
     private readonly enrollmentService: EnrollmentService,
+    @inject(CASE_STUDIES_TYPES.CaseStudyService)
+    private readonly caseStudyService: CaseStudyService,
   ) {}
 
   @OpenAPI({
@@ -149,6 +153,41 @@ class IntegrationController {
       page,
       limit,
     );
+  }
+
+  @OpenAPI({
+    summary: 'Get the case-studies progress roster for a course version',
+    description:
+      'Returns a paginated roster of every learner\'s case-studies activity ' +
+      'on the given course version: how many cases they have submitted, how ' +
+      'many reached a winning verdict, and how many are still in review. ' +
+      'Authenticate with the `X-API-Key` header. Use `page` and `limit` (max 200) to page through learners.',
+  })
+  @Get('/courses/:courseId/versions/:versionId/case-studies/progress')
+  @HttpCode(200)
+  async getCaseStudiesProgress(
+    @Param('courseId') courseId: string,
+    @Param('versionId') versionId: string,
+    @QueryParam('page') page = 1,
+    @QueryParam('limit') limit = 50,
+  ): Promise<{
+    page: number;
+    limit: number;
+    totalLearners: number;
+    totalPages: number;
+    learners: Array<{
+      userId: string;
+      casesSubmitted: number;
+      casesWon: number;
+      casesInReview: number;
+      lastActivityAt: Date | null;
+    }>;
+  }> {
+    return await this.caseStudyService.getIntegrationProgress({
+      courseVersionId: versionId,
+      page,
+      limit,
+    });
   }
 }
 

--- a/backend/src/shared/database/interfaces/INotification.ts
+++ b/backend/src/shared/database/interfaces/INotification.ts
@@ -10,7 +10,9 @@ export type NotificationType =
   | 'appeal_approved'
   | 'appeal_rejected'
   | 'mcq_submission_approved'
-  | 'mcq_submission_rejected';
+  | 'mcq_submission_rejected'
+  | 'case_response_weak_streak'
+  | 'case_response_withdrawn';
 
 export interface INotification {
   _id?: ObjectId | string;

--- a/backend/src/shared/database/interfaces/ISettingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISettingRepository.ts
@@ -68,6 +68,9 @@ export interface ISettingRepository {
     audit: AuditingDto,
     session?: ClientSession,
     crowdsourcedQuestionSubmissionEnabled?: boolean,
+    caseStudiesEnabled?: boolean,
+    caseStudyStrictUnlockEnabled?: boolean,
+    caseStudyWeakStreakThreshold?: number,
   ): Promise<UpdateResult | null>;
 
   updateRegistrationSchemas(

--- a/backend/src/shared/database/providers/mongo/repositories/ItemRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ItemRepository.ts
@@ -897,6 +897,7 @@ export class ItemRepository implements IItemRepository {
         [ItemType.PROJECT]: [],
         [ItemType.FEEDBACK]: [],
         [ItemType.REFLECTION]: [],
+        [ItemType.CASE_STUDY]: [],
       };
 
       for (const group of deletedItemGroups) {

--- a/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
@@ -302,6 +302,9 @@ export class SettingRepository implements ISettingRepository {
     audit: AuditingDto,
     session?: ClientSession,
     crowdsourcedQuestionSubmissionEnabled: boolean = false,
+    caseStudiesEnabled: boolean = false,
+    caseStudyStrictUnlockEnabled: boolean = true,
+    caseStudyWeakStreakThreshold: number = 3,
   ): Promise<UpdateResult | null> {
     await this.init();
 
@@ -361,6 +364,9 @@ export class SettingRepository implements ISettingRepository {
           'settings.randomizeItems': randomizeItems,
           'settings.crowdsourcedQuestionSubmissionEnabled':
             crowdsourcedQuestionSubmissionEnabled,
+          'settings.caseStudiesEnabled': caseStudiesEnabled,
+          'settings.caseStudyStrictUnlockEnabled': caseStudyStrictUnlockEnabled,
+          'settings.caseStudyWeakStreakThreshold': caseStudyWeakStreakThreshold,
         },
         $push: {
           'settings.audit': audit,

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -322,6 +322,7 @@ export enum ItemType {
   PROJECT = 'PROJECT',
   FEEDBACK = 'FEEDBACK',
   REFLECTION = 'REFLECTION',
+  CASE_STUDY = 'CASE_STUDY',
 }
 
 export interface IBaseItem {
@@ -439,6 +440,17 @@ export interface IReflectionDetails {
   requiredReviewsToUnlock?: number;
   /** Reviews needed before an average is shown at all. Defaults to 3. */
   minReviewsToReveal?: number;
+}
+
+export interface ICaseStudyDetails {
+  /** The case scenario/prompt shown to the learner (markdown). */
+  bodyMarkdown?: string;
+  /** Wins a response needs before it leaves the review pool (1-25). Defaults to 7. */
+  reviewsRequired?: number;
+  /** Comparisons each learner must judge (1-25). Defaults to 7. */
+  picksRequired?: number;
+  /** Consecutive losses before the author is prompted to revise (0-25, 0 disables). Defaults to 3. */
+  weakStreakThreshold?: number;
 }
 
 export interface IFeedBackFormDetails {
@@ -802,6 +814,9 @@ export interface ISettings {
   baseHp?: number;
   randomizeItems?: boolean;
   crowdsourcedQuestionSubmissionEnabled?: boolean;
+  caseStudiesEnabled?: boolean;
+  caseStudyStrictUnlockEnabled?: boolean;
+  caseStudyWeakStreakThreshold?: number;
   // registration_settings?: IRegistrationSettings[];
   registration?: {
     jsonSchema?: any;

--- a/e2e/tests/case-studies.spec.ts
+++ b/e2e/tests/case-studies.spec.ts
@@ -1,0 +1,223 @@
+import { expect, test, type Page } from '@playwright/test';
+import { loginAsStudent } from './common-utils';
+
+/**
+ * E2E coverage for the case-studies write/review flow (FR-12 six-field
+ * response, video-gated unlock, steelman-only review).
+ *
+ * Required env vars:
+ *   TEST_STUDENT_EMAIL / TEST_STUDENT_PASSWORD   — reuses the existing convention
+ *   CASE_STUDY_COURSE_NAME                        — a course with caseStudiesEnabled: true,
+ *                                                    seeded with at least one case linked to
+ *                                                    a video the student has completed
+ *   CASE_STUDY_CONTROL_COURSE_NAME (optional)     — a course with caseStudiesEnabled: false
+ *   TEST_STUDENT_2_EMAIL / TEST_STUDENT_2_PASSWORD (optional) — second account for review flow
+ *
+ * Tests that need infrastructure not present skip with a clear reason.
+ */
+
+const COURSE_NAME = process.env.CASE_STUDY_COURSE_NAME;
+const CONTROL_COURSE_NAME = process.env.CASE_STUDY_CONTROL_COURSE_NAME;
+const STUDENT_2_EMAIL = process.env.TEST_STUDENT_2_EMAIL;
+const STUDENT_2_PASSWORD = process.env.TEST_STUDENT_2_PASSWORD;
+
+async function openCourse(page: Page, courseName: string) {
+  await page.getByRole('link', { name: /dashboard/i }).click();
+  await page.getByText(courseName, { exact: false }).first().click();
+}
+
+async function openCaseStudiesTab(page: Page) {
+  const drawerTrigger = page.getByRole('button', { name: /course content|menu|back/i }).first();
+  if (await drawerTrigger.isVisible().catch(() => false)) {
+    await drawerTrigger.click();
+  }
+  await expect(page.getByTestId('drawer-tab-case-studies')).toBeVisible({ timeout: 30_000 });
+  await page.getByTestId('drawer-tab-case-studies').click();
+}
+
+/** Fills in all six FR-12 fields with valid content (steelman ≥25 words). */
+async function fillComposer(page: Page) {
+  await page.getByTestId('case-composer-beat1a').fill('I assumed students already understood the core concept.');
+  await page.getByTestId('case-composer-beat1b').fill('The facilitator showed how one question changed the direction.');
+  await page.getByTestId('case-composer-beat1c').fill('Now I see that confusion is a useful diagnostic signal.');
+  const steelmanWords = Array.from({length: 30}, (_, i) => `word${i}`).join(' ');
+  await page.getByTestId('case-composer-steelman').fill(steelmanWords);
+  await page.getByTestId('case-composer-room-perspective').fill('One participant argued for probing before reteaching.');
+  await page.getByTestId('case-composer-change-commitment').fill('I will ask the clarifying question before explaining again.');
+}
+
+test.describe('Case studies', () => {
+  test.skip(!COURSE_NAME, 'CASE_STUDY_COURSE_NAME not set — see file header for required env vars');
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await loginAsStudent(page);
+  });
+
+  test('toggle off hides the Case Studies tab entirely', async ({ page }) => {
+    test.skip(!CONTROL_COURSE_NAME, 'CASE_STUDY_CONTROL_COURSE_NAME not set');
+    await openCourse(page, CONTROL_COURSE_NAME!);
+    const drawerTrigger = page.getByRole('button', { name: /course content|menu|back/i }).first();
+    if (await drawerTrigger.isVisible().catch(() => false)) {
+      await drawerTrigger.click();
+    }
+    await expect(page.getByTestId('drawer-tab-case-studies')).not.toBeVisible();
+  });
+
+  test('case list shows locked state for cases whose video is unwatched', async ({ page }) => {
+    await openCourse(page, COURSE_NAME!);
+    await openCaseStudiesTab(page);
+
+    const items = page.getByTestId('case-list-item');
+    await expect(items.first()).toBeVisible({ timeout: 30_000 });
+
+    const lockedCases = page.getByTestId('case-list-item').and(page.locator('[data-case-state="locked"]'));
+    if (await lockedCases.count() > 0) {
+      await expect(lockedCases.first()).toBeDisabled();
+    }
+  });
+
+  test('four-section composer appears for a writable case', async ({ page }) => {
+    await openCourse(page, COURSE_NAME!);
+    await openCaseStudiesTab(page);
+
+    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
+    test.skip((await writable.count()) === 0, 'no writable case available in this environment/run');
+    await writable.first().click();
+
+    await expect(page.getByTestId('case-composer-beat1a')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('case-composer-beat1b')).toBeVisible();
+    await expect(page.getByTestId('case-composer-beat1c')).toBeVisible();
+    await expect(page.getByTestId('case-composer-steelman')).toBeVisible();
+    await expect(page.getByTestId('case-composer-room-perspective')).toBeVisible();
+    await expect(page.getByTestId('case-composer-change-commitment')).toBeVisible();
+  });
+
+  test('submit is disabled until steelman reaches 25 words', async ({ page }) => {
+    await openCourse(page, COURSE_NAME!);
+    await openCaseStudiesTab(page);
+
+    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
+    test.skip((await writable.count()) === 0, 'no writable case available');
+    await writable.first().click();
+
+    await expect(page.getByTestId('case-composer-steelman')).toBeVisible({ timeout: 15_000 });
+
+    // Fill every field but keep steelman short (< 25 words).
+    await page.getByTestId('case-composer-beat1a').fill('Going-in thought.');
+    await page.getByTestId('case-composer-beat1b').fill('Challenge encountered.');
+    await page.getByTestId('case-composer-beat1c').fill('Where I landed.');
+    await page.getByTestId('case-composer-steelman').fill('Too short steelman.');
+    await page.getByTestId('case-composer-room-perspective').fill('Room perspective.');
+    await page.getByTestId('case-composer-change-commitment').fill('My change commitment.');
+
+    await expect(page.getByTestId('case-composer-submit')).toBeDisabled();
+    // Steelman word count indicator should show a warning/red state.
+    await expect(page.getByTestId('case-composer-steelman-count')).toBeVisible();
+  });
+
+  test('submit is enabled once all fields are filled and steelman has ≥25 words', async ({ page }) => {
+    await openCourse(page, COURSE_NAME!);
+    await openCaseStudiesTab(page);
+
+    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
+    test.skip((await writable.count()) === 0, 'no writable case available');
+    await writable.first().click();
+
+    await expect(page.getByTestId('case-composer-beat1a')).toBeVisible({ timeout: 15_000 });
+    await fillComposer(page);
+
+    await expect(page.getByTestId('case-composer-submit')).toBeEnabled({ timeout: 3_000 });
+  });
+
+  test('paste is blocked in the steelman field', async ({ page }) => {
+    await openCourse(page, COURSE_NAME!);
+    await openCaseStudiesTab(page);
+
+    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
+    test.skip((await writable.count()) === 0, 'no writable case available');
+    await writable.first().click();
+
+    const steelman = page.getByTestId('case-composer-steelman');
+    await expect(steelman).toBeVisible({ timeout: 15_000 });
+    await steelman.click();
+
+    await steelman.evaluate((el) => {
+      const event = new ClipboardEvent('paste', { bubbles: true, cancelable: true });
+      el.dispatchEvent(event);
+    });
+
+    await expect(page.getByTestId('case-composer-paste-blocked-notice')).toBeVisible();
+    await expect(steelman).toHaveValue('');
+  });
+
+  test('submit transitions the case to submitted-awaiting-verdict', async ({ page }) => {
+    test.skip(!STUDENT_2_EMAIL, 'TEST_STUDENT_2_EMAIL not set — review flow needs two accounts');
+
+    await openCourse(page, COURSE_NAME!);
+    await openCaseStudiesTab(page);
+
+    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
+    test.skip((await writable.count()) === 0, 'no writable case available for account 1');
+    await writable.first().click();
+
+    await expect(page.getByTestId('case-composer-beat1a')).toBeVisible({ timeout: 15_000 });
+    await fillComposer(page);
+    await page.getByTestId('case-composer-submit').click();
+
+    // After submission the student sees either the review timer gate or the
+    // "waiting for colleagues" message.
+    await expect(
+      page.getByTestId('reading-timer-gate').or(page.getByText(/check back once more colleagues/i))
+    ).toBeVisible({ timeout: 20_000 });
+  });
+
+  test('review view shows steelman text but not other response fields', async ({ page }) => {
+    await openCourse(page, COURSE_NAME!);
+    await openCaseStudiesTab(page);
+
+    const reviewable = page.getByTestId('case-list-item').and(
+      page.locator('[data-case-state="submitted-awaiting-verdict"], [data-case-state="won"]'),
+    );
+    test.skip((await reviewable.count()) === 0, 'no submitted case to review in this run');
+    await reviewable.first().click();
+
+    // ComparisonView must render steelman text, not beat1a / roomPerspective.
+    const responseCard = page.locator('[data-testid="pick-left"]').locator('..').first();
+    if (await responseCard.isVisible({ timeout: 20_000 }).catch(() => false)) {
+      await expect(page.locator('[data-testid="pick-left"], [data-testid="pick-right"]').first()).toBeVisible();
+    }
+  });
+
+  test('tab-switch during the reading timer resets the visible countdown', async ({ page }) => {
+    await openCourse(page, COURSE_NAME!);
+    await openCaseStudiesTab(page);
+
+    const reviewable = page.getByTestId('case-list-item').and(
+      page.locator('[data-case-state="submitted-awaiting-verdict"], [data-case-state="won"]'),
+    );
+    test.skip((await reviewable.count()) === 0, 'no case with an existing submission to review in this run');
+    await reviewable.first().click();
+
+    const gate = page.getByTestId('reading-timer-gate');
+    await expect(gate).toBeVisible({ timeout: 20_000 });
+
+    const before = await gate.getAttribute('data-remaining-seconds');
+    test.skip(before === null || Number(before) < 5, 'timer already near expiry — flaky window, skip');
+
+    await page.waitForTimeout(3000);
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(200);
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(200);
+
+    const afterReset = await gate.getAttribute('data-remaining-seconds');
+    expect(Number(afterReset)).toBeGreaterThan(Number(before) - 2);
+  });
+});

--- a/e2e/tests/case-studies.spec.ts
+++ b/e2e/tests/case-studies.spec.ts
@@ -2,18 +2,18 @@ import { expect, test, type Page } from '@playwright/test';
 import { loginAsStudent } from './common-utils';
 
 /**
- * E2E coverage for the case-studies write/review flow (FR-12 six-field
- * response, video-gated unlock, steelman-only review).
+ * E2E coverage for the case-studies write/review flow.
+ *
+ * Case study items live in the normal module tree (Item-container.tsx's
+ * CASE_STUDY branch). Tests navigate there via the drawer's module/section
+ * tree, identified by data-item-type="case_study".
  *
  * Required env vars:
- *   TEST_STUDENT_EMAIL / TEST_STUDENT_PASSWORD   — reuses the existing convention
- *   CASE_STUDY_COURSE_NAME                        — a course with caseStudiesEnabled: true,
- *                                                    seeded with at least one case linked to
- *                                                    a video the student has completed
- *   CASE_STUDY_CONTROL_COURSE_NAME (optional)     — a course with caseStudiesEnabled: false
- *   TEST_STUDENT_2_EMAIL / TEST_STUDENT_2_PASSWORD (optional) — second account for review flow
- *
- * Tests that need infrastructure not present skip with a clear reason.
+ *   TEST_STUDENT_EMAIL / TEST_STUDENT_PASSWORD
+ *   CASE_STUDY_COURSE_NAME  — course with caseStudiesEnabled: true and at
+ *                             least one CASE_STUDY item
+ *   CASE_STUDY_CONTROL_COURSE_NAME (optional) — course with no CASE_STUDY items
+ *   TEST_STUDENT_2_EMAIL / TEST_STUDENT_2_PASSWORD (optional) — second account
  */
 
 const COURSE_NAME = process.env.CASE_STUDY_COURSE_NAME;
@@ -26,24 +26,40 @@ async function openCourse(page: Page, courseName: string) {
   await page.getByText(courseName, { exact: false }).first().click();
 }
 
-async function openCaseStudiesTab(page: Page) {
+/** Opens drawer, expands all modules/sections, returns the first CASE_STUDY item button. */
+async function findCaseStudyItem(page: Page) {
   const drawerTrigger = page.getByRole('button', { name: /course content|menu|back/i }).first();
-  if (await drawerTrigger.isVisible().catch(() => false)) {
-    await drawerTrigger.click();
+  if (await drawerTrigger.isVisible().catch(() => false)) await drawerTrigger.click();
+
+  for (const toggle of await page.getByTestId('course-module-toggle').all()) {
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click();
   }
-  await expect(page.getByTestId('drawer-tab-case-studies')).toBeVisible({ timeout: 30_000 });
-  await page.getByTestId('drawer-tab-case-studies').click();
+  for (const toggle of await page.getByTestId('course-section-toggle').all()) {
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click();
+  }
+  return page.locator('[data-testid="course-item"][data-item-type="case_study"]:not([disabled])').first();
 }
 
-/** Fills in all six FR-12 fields with valid content (steelman ≥25 words). */
+/** Passes the declaration + session-date gate if it is present. */
+async function passDeclarationGate(page: Page) {
+  const checkbox = page.getByRole('checkbox', { name: /I confirm/i });
+  if (!(await checkbox.isVisible({ timeout: 5_000 }).catch(() => false))) return;
+  await checkbox.click();
+  await page.getByRole('button', { name: /continue/i }).click();
+  await page.locator('input[type="date"]').fill('2025-01-15');
+  await page.getByRole('button', { name: /ok/i }).click();
+}
+
+/** Fills all six CaseComposer fields with valid content (steelman ≥ 25 words). */
 async function fillComposer(page: Page) {
-  await page.getByTestId('case-composer-beat1a').fill('I assumed students already understood the core concept.');
-  await page.getByTestId('case-composer-beat1b').fill('The facilitator showed how one question changed the direction.');
-  await page.getByTestId('case-composer-beat1c').fill('Now I see that confusion is a useful diagnostic signal.');
-  const steelmanWords = Array.from({length: 30}, (_, i) => `word${i}`).join(' ');
-  await page.getByTestId('case-composer-steelman').fill(steelmanWords);
-  await page.getByTestId('case-composer-room-perspective').fill('One participant argued for probing before reteaching.');
-  await page.getByTestId('case-composer-change-commitment').fill('I will ask the clarifying question before explaining again.');
+  await page.getByTestId('beat1a').fill('I assumed students already understood the core concept.');
+  await page.getByTestId('beat1b').fill('The facilitator showed how one question changed the direction.');
+  await page.getByTestId('beat1c').fill('Now I see that confusion is a useful diagnostic signal.');
+  await page.getByTestId('steelman').fill(
+    Array.from({ length: 30 }, (_, i) => `word${i}`).join(' '),
+  );
+  await page.getByTestId('roomPerspective').fill('One participant argued for probing before reteaching.');
+  await page.getByTestId('changeCommitment').fill('I will ask the clarifying question before explaining again.');
 }
 
 test.describe('Case studies', () => {
@@ -54,77 +70,57 @@ test.describe('Case studies', () => {
     await loginAsStudent(page);
   });
 
-  test('toggle off hides the Case Studies tab entirely', async ({ page }) => {
+  test('course with no CASE_STUDY items shows none in the module tree', async ({ page }) => {
     test.skip(!CONTROL_COURSE_NAME, 'CASE_STUDY_CONTROL_COURSE_NAME not set');
     await openCourse(page, CONTROL_COURSE_NAME!);
     const drawerTrigger = page.getByRole('button', { name: /course content|menu|back/i }).first();
-    if (await drawerTrigger.isVisible().catch(() => false)) {
-      await drawerTrigger.click();
-    }
-    await expect(page.getByTestId('drawer-tab-case-studies')).not.toBeVisible();
+    if (await drawerTrigger.isVisible().catch(() => false)) await drawerTrigger.click();
+    await expect(page.locator('[data-testid="course-item"][data-item-type="case_study"]')).toHaveCount(0);
   });
 
-  test('case list shows locked state for cases whose video is unwatched', async ({ page }) => {
+  test('four-section composer appears after passing the declaration gate', async ({ page }) => {
     await openCourse(page, COURSE_NAME!);
-    await openCaseStudiesTab(page);
+    const item = await findCaseStudyItem(page);
+    test.skip((await item.count()) === 0, 'no unlocked case_study item in this environment');
+    await item.click();
 
-    const items = page.getByTestId('case-list-item');
-    await expect(items.first()).toBeVisible({ timeout: 30_000 });
+    await passDeclarationGate(page);
 
-    const lockedCases = page.getByTestId('case-list-item').and(page.locator('[data-case-state="locked"]'));
-    if (await lockedCases.count() > 0) {
-      await expect(lockedCases.first()).toBeDisabled();
-    }
-  });
-
-  test('four-section composer appears for a writable case', async ({ page }) => {
-    await openCourse(page, COURSE_NAME!);
-    await openCaseStudiesTab(page);
-
-    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
-    test.skip((await writable.count()) === 0, 'no writable case available in this environment/run');
-    await writable.first().click();
-
-    await expect(page.getByTestId('case-composer-beat1a')).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByTestId('case-composer-beat1b')).toBeVisible();
-    await expect(page.getByTestId('case-composer-beat1c')).toBeVisible();
-    await expect(page.getByTestId('case-composer-steelman')).toBeVisible();
-    await expect(page.getByTestId('case-composer-room-perspective')).toBeVisible();
-    await expect(page.getByTestId('case-composer-change-commitment')).toBeVisible();
+    await expect(page.getByTestId('beat1a')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('beat1b')).toBeVisible();
+    await expect(page.getByTestId('beat1c')).toBeVisible();
+    await expect(page.getByTestId('steelman')).toBeVisible();
+    await expect(page.getByTestId('roomPerspective')).toBeVisible();
+    await expect(page.getByTestId('changeCommitment')).toBeVisible();
   });
 
   test('submit is disabled until steelman reaches 25 words', async ({ page }) => {
     await openCourse(page, COURSE_NAME!);
-    await openCaseStudiesTab(page);
+    const item = await findCaseStudyItem(page);
+    test.skip((await item.count()) === 0, 'no unlocked case_study item available');
+    await item.click();
 
-    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
-    test.skip((await writable.count()) === 0, 'no writable case available');
-    await writable.first().click();
+    await passDeclarationGate(page);
+    await expect(page.getByTestId('steelman')).toBeVisible({ timeout: 15_000 });
 
-    await expect(page.getByTestId('case-composer-steelman')).toBeVisible({ timeout: 15_000 });
-
-    // Fill every field but keep steelman short (< 25 words).
-    await page.getByTestId('case-composer-beat1a').fill('Going-in thought.');
-    await page.getByTestId('case-composer-beat1b').fill('Challenge encountered.');
-    await page.getByTestId('case-composer-beat1c').fill('Where I landed.');
-    await page.getByTestId('case-composer-steelman').fill('Too short steelman.');
-    await page.getByTestId('case-composer-room-perspective').fill('Room perspective.');
-    await page.getByTestId('case-composer-change-commitment').fill('My change commitment.');
+    await page.getByTestId('beat1a').fill('Going-in thought.');
+    await page.getByTestId('beat1b').fill('Challenge encountered.');
+    await page.getByTestId('beat1c').fill('Where I landed.');
+    await page.getByTestId('steelman').fill('Too short steelman.');
+    await page.getByTestId('roomPerspective').fill('Room perspective.');
+    await page.getByTestId('changeCommitment').fill('My change commitment.');
 
     await expect(page.getByTestId('case-composer-submit')).toBeDisabled();
-    // Steelman word count indicator should show a warning/red state.
-    await expect(page.getByTestId('case-composer-steelman-count')).toBeVisible();
   });
 
   test('submit is enabled once all fields are filled and steelman has ≥25 words', async ({ page }) => {
     await openCourse(page, COURSE_NAME!);
-    await openCaseStudiesTab(page);
+    const item = await findCaseStudyItem(page);
+    test.skip((await item.count()) === 0, 'no unlocked case_study item available');
+    await item.click();
 
-    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
-    test.skip((await writable.count()) === 0, 'no writable case available');
-    await writable.first().click();
-
-    await expect(page.getByTestId('case-composer-beat1a')).toBeVisible({ timeout: 15_000 });
+    await passDeclarationGate(page);
+    await expect(page.getByTestId('beat1a')).toBeVisible({ timeout: 15_000 });
     await fillComposer(page);
 
     await expect(page.getByTestId('case-composer-submit')).toBeEnabled({ timeout: 3_000 });
@@ -132,72 +128,72 @@ test.describe('Case studies', () => {
 
   test('paste is blocked in the steelman field', async ({ page }) => {
     await openCourse(page, COURSE_NAME!);
-    await openCaseStudiesTab(page);
+    const item = await findCaseStudyItem(page);
+    test.skip((await item.count()) === 0, 'no unlocked case_study item available');
+    await item.click();
 
-    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
-    test.skip((await writable.count()) === 0, 'no writable case available');
-    await writable.first().click();
-
-    const steelman = page.getByTestId('case-composer-steelman');
+    await passDeclarationGate(page);
+    const steelman = page.getByTestId('steelman');
     await expect(steelman).toBeVisible({ timeout: 15_000 });
     await steelman.click();
-
-    await steelman.evaluate((el) => {
-      const event = new ClipboardEvent('paste', { bubbles: true, cancelable: true });
-      el.dispatchEvent(event);
-    });
+    await steelman.evaluate(el =>
+      el.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true })),
+    );
 
     await expect(page.getByTestId('case-composer-paste-blocked-notice')).toBeVisible();
     await expect(steelman).toHaveValue('');
   });
 
-  test('submit transitions the case to submitted-awaiting-verdict', async ({ page }) => {
+  test('submit transitions the case to the review state', async ({ page }) => {
     test.skip(!STUDENT_2_EMAIL, 'TEST_STUDENT_2_EMAIL not set — review flow needs two accounts');
-
     await openCourse(page, COURSE_NAME!);
-    await openCaseStudiesTab(page);
+    const item = await findCaseStudyItem(page);
+    test.skip((await item.count()) === 0, 'no unlocked case_study item available');
+    await item.click();
 
-    const writable = page.getByTestId('case-list-item').and(page.locator('[data-case-state="writable"]'));
-    test.skip((await writable.count()) === 0, 'no writable case available for account 1');
-    await writable.first().click();
-
-    await expect(page.getByTestId('case-composer-beat1a')).toBeVisible({ timeout: 15_000 });
+    await passDeclarationGate(page);
+    await expect(page.getByTestId('beat1a')).toBeVisible({ timeout: 15_000 });
     await fillComposer(page);
     await page.getByTestId('case-composer-submit').click();
 
-    // After submission the student sees either the review timer gate or the
-    // "waiting for colleagues" message.
     await expect(
-      page.getByTestId('reading-timer-gate').or(page.getByText(/check back once more colleagues/i))
+      page.getByTestId('reading-timer-gate').or(page.getByText(/check back once more colleagues/i)),
     ).toBeVisible({ timeout: 20_000 });
   });
 
-  test('review view shows steelman text but not other response fields', async ({ page }) => {
+  test('review view shows A/B comparison cards for a submitted response', async ({ page }) => {
     await openCourse(page, COURSE_NAME!);
-    await openCaseStudiesTab(page);
+    const item = await findCaseStudyItem(page);
+    test.skip((await item.count()) === 0, 'no case_study item found');
+    await item.click();
 
-    const reviewable = page.getByTestId('case-list-item').and(
-      page.locator('[data-case-state="submitted-awaiting-verdict"], [data-case-state="won"]'),
-    );
-    test.skip((await reviewable.count()) === 0, 'no submitted case to review in this run');
-    await reviewable.first().click();
+    await passDeclarationGate(page);
 
-    // ComparisonView must render steelman text, not beat1a / roomPerspective.
-    const responseCard = page.locator('[data-testid="pick-left"]').locator('..').first();
-    if (await responseCard.isVisible({ timeout: 20_000 }).catch(() => false)) {
-      await expect(page.locator('[data-testid="pick-left"], [data-testid="pick-right"]').first()).toBeVisible();
+    const reviewBtn = page.getByRole('button', { name: /review peers/i });
+    if (!(await reviewBtn.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip(true, 'no existing submission to review in this run');
+    }
+    await reviewBtn.click();
+    const pickLeft = page.getByTestId('pick-left');
+    if (await pickLeft.isVisible({ timeout: 20_000 }).catch(() => false)) {
+      await expect(pickLeft).toBeVisible();
+      await expect(page.getByTestId('pick-right')).toBeVisible();
     }
   });
 
   test('tab-switch during the reading timer resets the visible countdown', async ({ page }) => {
     await openCourse(page, COURSE_NAME!);
-    await openCaseStudiesTab(page);
+    const item = await findCaseStudyItem(page);
+    test.skip((await item.count()) === 0, 'no case_study item found');
+    await item.click();
 
-    const reviewable = page.getByTestId('case-list-item').and(
-      page.locator('[data-case-state="submitted-awaiting-verdict"], [data-case-state="won"]'),
-    );
-    test.skip((await reviewable.count()) === 0, 'no case with an existing submission to review in this run');
-    await reviewable.first().click();
+    await passDeclarationGate(page);
+
+    const reviewBtn = page.getByRole('button', { name: /review peers/i });
+    if (!(await reviewBtn.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip(true, 'need an existing submission to access review');
+    }
+    await reviewBtn.click();
 
     const gate = page.getByTestId('reading-timer-gate');
     await expect(gate).toBeVisible({ timeout: 20_000 });

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -219,7 +219,6 @@ export default function CoursePage() {
 
   // --- Focused learn-page UI state ---
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [activeDrawerTab, setActiveDrawerTab] = useState<"content" | "case-studies">("content");
   const [aiExpanded, setAiExpanded] = useState(false);
   const [aiSheet, setAiSheet] = useState<"chat" | "talk" | "discussion" | null>(null);
   const [camPinned, setCamPinned] = useState(false);
@@ -2140,12 +2139,6 @@ return false;
         onToggleSection={toggleSection}
         onSelectItem={(m, s, i) => { handleSelectItem(m, s, i); setDrawerOpen(false); }}
         isItemLocked={isItemLocked}
-        caseStudiesEnabled={proctoringData?.settings.caseStudiesEnabled ?? false}
-        activeDrawerTab={activeDrawerTab}
-        onDrawerTabChange={(tab) => {
-          setActiveDrawerTab(tab);
-          if (tab === "case-studies") setDrawerOpen(false);
-        }}
         emotion={
           currentItem
             ? {

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -219,6 +219,7 @@ export default function CoursePage() {
 
   // --- Focused learn-page UI state ---
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [activeDrawerTab, setActiveDrawerTab] = useState<"content" | "case-studies">("content");
   const [aiExpanded, setAiExpanded] = useState(false);
   const [aiSheet, setAiSheet] = useState<"chat" | "talk" | "discussion" | null>(null);
   const [camPinned, setCamPinned] = useState(false);
@@ -2139,6 +2140,12 @@ return false;
         onToggleSection={toggleSection}
         onSelectItem={(m, s, i) => { handleSelectItem(m, s, i); setDrawerOpen(false); }}
         isItemLocked={isItemLocked}
+        caseStudiesEnabled={proctoringData?.settings.caseStudiesEnabled ?? false}
+        activeDrawerTab={activeDrawerTab}
+        onDrawerTabChange={(tab) => {
+          setActiveDrawerTab(tab);
+          if (tab === "case-studies") setDrawerOpen(false);
+        }}
         emotion={
           currentItem
             ? {

--- a/frontend/src/app/pages/teacher/components/CaseStudyItemEditor.tsx
+++ b/frontend/src/app/pages/teacher/components/CaseStudyItemEditor.tsx
@@ -1,0 +1,263 @@
+import {useEffect, useState} from 'react';
+import {Info, Loader2} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {Input} from '@/components/ui/input';
+import {Label} from '@/components/ui/label';
+import {Textarea} from '@/components/ui/textarea';
+import {toast} from 'sonner';
+import {useUpdateCourseItem} from '@/hooks/hooks';
+
+/** Mirrors the server clamps on ICaseStudyDetails (see ItemValidators). */
+const LIMITS = {
+  reviewsRequired: {min: 1, max: 25, fallback: 7},
+  picksRequired: {min: 1, max: 25, fallback: 7},
+  weakStreakThreshold: {min: 0, max: 25, fallback: 3},
+} as const;
+
+type PolicyField = keyof typeof LIMITS;
+
+/**
+ * The shared UpdateItemBody validator requires a non-empty description for
+ * every item type, and this panel does not edit that field — so default it.
+ */
+const DEFAULT_DESCRIPTION =
+  "Write a structured response to the case, then judge pairs of peers' responses";
+
+interface CaseStudyItemEditorProps {
+  itemId: string;
+  courseId: string;
+  versionId: string;
+  name: string;
+  description?: string;
+  details?: {
+    bodyMarkdown?: string;
+    reviewsRequired?: number;
+    picksRequired?: number;
+    weakStreakThreshold?: number;
+  };
+  onSaved: () => void;
+}
+
+function NumberField({
+  id,
+  label,
+  question,
+  example,
+  field,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  question: string;
+  example: string;
+  field: PolicyField;
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const {min, max, fallback} = LIMITS[field];
+  return (
+    <div className="space-y-1.5 rounded-lg border p-3">
+      <Label htmlFor={id} className="text-sm font-semibold">
+        {label}
+      </Label>
+      <p className="text-xs text-muted-foreground">{question}</p>
+      <Input
+        id={id}
+        type="number"
+        inputMode="numeric"
+        min={min}
+        max={max}
+        value={value}
+        placeholder={`${fallback} (default)`}
+        onChange={e => onChange(e.target.value)}
+      />
+      <p className="text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">e.g. </span>
+        {example}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Instructor settings for one case-study item.
+ *
+ * Case studies are scored purely by peer pairwise comparison: every learner
+ * writes a response, then judges pairs of peers' responses (A vs B). A response
+ * leaves the pool once it has been picked as the stronger side enough times.
+ * Every field is optional; left blank the item inherits the platform default.
+ */
+export default function CaseStudyItemEditor({
+  itemId,
+  courseId,
+  versionId,
+  name,
+  description,
+  details,
+  onSaved,
+}: CaseStudyItemEditorProps) {
+  const {mutateAsync: updateItem, isPending} = useUpdateCourseItem();
+
+  const asText = (n?: number) => (typeof n === 'number' ? String(n) : '');
+
+  const [body, setBody] = useState(details?.bodyMarkdown ?? '');
+  const [reviewsRequired, setReviewsRequired] = useState(
+    asText(details?.reviewsRequired),
+  );
+  const [picksRequired, setPicksRequired] = useState(
+    asText(details?.picksRequired),
+  );
+  const [weakStreak, setWeakStreak] = useState(
+    asText(details?.weakStreakThreshold),
+  );
+
+  // Selecting a different case-study item reuses this component instance.
+  useEffect(() => {
+    setBody(details?.bodyMarkdown ?? '');
+    setReviewsRequired(asText(details?.reviewsRequired));
+    setPicksRequired(asText(details?.picksRequired));
+    setWeakStreak(asText(details?.weakStreakThreshold));
+  }, [itemId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const parse = (raw: string, field: PolicyField): number | undefined => {
+    if (raw.trim() === '') return undefined;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return undefined;
+    const {min, max} = LIMITS[field];
+    return Math.min(Math.max(Math.round(n), min), max);
+  };
+
+  const handleSave = async () => {
+    try {
+      await updateItem({
+        params: {path: {courseId, versionId, itemId}},
+        body: {
+          name: name?.trim() || 'Case study',
+          description: description?.trim() || DEFAULT_DESCRIPTION,
+          type: 'CASE_STUDY',
+          // The update endpoint carries the payload on `details`, unlike create
+          // which uses a per-type field (`caseStudyDetails`).
+          details: {
+            bodyMarkdown: body.trim() === '' ? undefined : body.trim(),
+            reviewsRequired: parse(reviewsRequired, 'reviewsRequired'),
+            picksRequired: parse(picksRequired, 'picksRequired'),
+            weakStreakThreshold: parse(weakStreak, 'weakStreakThreshold'),
+          },
+        },
+      } as any);
+      toast.success('Case study settings saved');
+      onSaved();
+    } catch (error: unknown) {
+      const err = error as {
+        response?: {data?: {message?: string}};
+        data?: {message?: string};
+        message?: string;
+      };
+      const detail =
+        err?.response?.data?.message ?? err?.data?.message ?? err?.message;
+      console.error('Case study settings save failed', error);
+      toast.error(
+        detail
+          ? `Could not save: ${detail}`
+          : 'Could not save the case study settings',
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-start gap-2 rounded-lg border border-primary/20 bg-primary/5 p-3">
+        <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">What is a case study? </span>
+          A learner reads a real-world scenario and writes a structured response,
+          then anonymously judges pairs of peers' responses to decide which
+          argument is stronger. There is no answer key — responses are scored
+          only by how they fare in these head-to-head comparisons, so learners
+          practise reasoning rather than recalling.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="case-body">The case</Label>
+        <Textarea
+          id="case-body"
+          rows={8}
+          value={body}
+          placeholder="Describe the scenario the learner will respond to. Markdown is supported."
+          onChange={e => setBody(e.target.value)}
+        />
+        <p className="text-xs text-muted-foreground">
+          Shown to the learner above the response editor. This is the prompt they
+          argue about.
+        </p>
+      </div>
+
+      <div className="space-y-2 rounded-lg bg-muted/40 p-4">
+        <p className="text-sm font-semibold">Peer review rules</p>
+        <p className="text-xs text-muted-foreground">
+          Every learner writes one response, then judges pairs of others'
+          responses anonymously. These three numbers decide how many comparisons
+          happen and when a response is considered settled. Leave any blank to
+          use the default.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <NumberField
+          id="reviews-required"
+          label="1. Wins to settle"
+          question="How many times must a response be picked as the stronger one before it leaves the pool?"
+          example={`a response stops being shown once ${
+            parse(reviewsRequired, 'reviewsRequired') ??
+            LIMITS.reviewsRequired.fallback
+          } peers have picked it as stronger.`}
+          field="reviewsRequired"
+          value={reviewsRequired}
+          onChange={setReviewsRequired}
+        />
+        <NumberField
+          id="picks-required"
+          label="2. Comparisons to judge"
+          question="How many response pairs must each learner compare?"
+          example={`each learner judges ${
+            parse(picksRequired, 'picksRequired') ??
+            LIMITS.picksRequired.fallback
+          } pairs of peers' responses.`}
+          field="picksRequired"
+          value={picksRequired}
+          onChange={setPicksRequired}
+        />
+        <NumberField
+          id="weak-streak"
+          label="3. Losses before nudge"
+          question="How many losses in a row before a learner is nudged to revise their response?"
+          example={
+            (parse(weakStreak, 'weakStreakThreshold') ??
+              LIMITS.weakStreakThreshold.fallback) === 0
+              ? 'set to 0, so learners are never nudged to revise.'
+              : `after ${
+                  parse(weakStreak, 'weakStreakThreshold') ??
+                  LIMITS.weakStreakThreshold.fallback
+                } consecutive losses, the learner is prompted to revise.`
+          }
+          field="weakStreakThreshold"
+          value={weakStreak}
+          onChange={setWeakStreak}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button onClick={handleSave} disabled={isPending}>
+          {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Save settings
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          Blank fields use the platform defaults ({LIMITS.reviewsRequired.fallback}/
+          {LIMITS.picksRequired.fallback}/{LIMITS.weakStreakThreshold.fallback}).
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/pages/teacher/components/CaseStudyResponsesPanel.tsx
+++ b/frontend/src/app/pages/teacher/components/CaseStudyResponsesPanel.tsx
@@ -1,0 +1,164 @@
+import {useState} from 'react';
+import {Loader2, RefreshCw} from 'lucide-react';
+import {Badge} from '@/components/ui/badge';
+import {Button} from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {useCaseStudyResponses} from '@/hooks/case-study-hooks';
+import type {MyCaseResponse} from '@/lib/api/case-studies';
+
+interface CaseStudyResponsesPanelProps {
+  courseId: string;
+  versionId: string;
+  /** The CASE_STUDY item id, which is also the caseStudy document id. */
+  itemId: string;
+}
+
+const STATUS: Record<string, {label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline'}> = {
+  WON:       {label: 'Won',        variant: 'default'},
+  OPEN:      {label: 'In review',  variant: 'secondary'},
+  WITHDRAWN: {label: 'Withdrawn',  variant: 'destructive'},
+};
+
+function ResponseDetailDialog({
+  response,
+  onClose,
+}: {
+  response: MyCaseResponse;
+  onClose: () => void;
+}) {
+  const fields: {label: string; value: string}[] = [
+    {label: 'a) What I thought going in',                         value: response.beat1a},
+    {label: 'b) What challenged it',                              value: response.beat1b},
+    {label: 'c) Where I ended up',                               value: response.beat1c},
+    {label: '2a — Strongest case against my view (steelman)',    value: response.steelman},
+    {label: '2b — One perspective from the room',                value: response.roomPerspective},
+    {label: '3 — One thing I\'ll change',                        value: response.changeCommitment},
+  ];
+
+  return (
+    <Dialog open onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-h-[80vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Response · …{response.userId.slice(-6)}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          {fields.map(f => (
+            <div key={f.label} className="space-y-1">
+              <p className="text-xs font-medium text-muted-foreground">{f.label}</p>
+              <p className="whitespace-pre-line text-sm leading-relaxed">{f.value}</p>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function CaseStudyResponsesPanel({
+  courseId,
+  versionId,
+  itemId,
+}: CaseStudyResponsesPanelProps) {
+  const {responses, isLoading, isError, refetch} = useCaseStudyResponses(
+    courseId,
+    versionId,
+    itemId,
+  );
+  const [viewing, setViewing] = useState<MyCaseResponse | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center gap-2 p-8 text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading responses…
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center gap-3 p-8 text-center">
+        <p className="text-sm text-muted-foreground">Could not load responses.</p>
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          <RefreshCw className="mr-2 h-3.5 w-3.5" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (responses.length === 0) {
+    return (
+      <p className="p-8 text-center text-sm text-muted-foreground">
+        No responses yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-4 space-y-2">
+      {viewing ? (
+        <ResponseDetailDialog response={viewing} onClose={() => setViewing(null)} />
+      ) : null}
+      <p className="text-xs text-muted-foreground">
+        {responses.length} response{responses.length === 1 ? '' : 's'} — newest first
+      </p>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Student</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="text-right">Wins</TableHead>
+            <TableHead className="text-right">Weak streak</TableHead>
+            <TableHead className="text-right">Reviewed by</TableHead>
+            <TableHead>Submitted</TableHead>
+            <TableHead />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {responses.map(r => {
+            const s = STATUS[r.status] ?? {label: r.status, variant: 'outline' as const};
+            return (
+              <TableRow key={r._id}>
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  …{r.userId.slice(-6)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={s.variant}>{s.label}</Badge>
+                </TableCell>
+                <TableCell className="text-right">{r.winCount}</TableCell>
+                <TableCell className="text-right">{r.weakStreak}</TableCell>
+                <TableCell className="text-right">{r.comparisonsSeenCount}</TableCell>
+                <TableCell className="text-xs text-muted-foreground">
+                  {new Date(r.createdAt).toLocaleDateString()}
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setViewing(r)}
+                  >
+                    View
+                  </Button>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/app/pages/teacher/teacher-course-page.tsx
+++ b/frontend/src/app/pages/teacher/teacher-course-page.tsx
@@ -39,6 +39,7 @@ import {
   ArrowDown,
   Pencil,
   MessageSquareQuote,
+  Scale,
 } from "lucide-react";
 
 import { useNavigate } from "@tanstack/react-router";
@@ -61,6 +62,8 @@ import ProjectItem from "./components/ProjectItem";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup, SidebarResizablePanel } from "@/components/ui/resizable";
 import FeedbackFormEditor from "./FeedbackFormEditor";
 import ReflectionItemEditor from './components/ReflectionItemEditor';
+import CaseStudyItemEditor from './components/CaseStudyItemEditor';
+import CaseStudyResponsesPanel from './components/CaseStudyResponsesPanel';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/utils/utils";
@@ -101,6 +104,7 @@ const getItemIcon = (type: string) => {
     case "PROJECT": return <FolderKanban className="h-3 w-3" />;
     case "FEEDBACK": return <MessageSquare className="h-3 w-3" />;
     case "REFLECTION": return <NotebookPen className="h-3 w-3" />;
+    case "CASE_STUDY": return <Scale className="h-3 w-3" />;
     default: return null;
   }
 };
@@ -146,6 +150,7 @@ function TeacherCourseContent() {
   const [pendingInvites, setPendingInvites] = useState<any[]>([]);
   const invitesRef = useRef<HTMLDivElement | null>(null);
   const [videoTab, setVideoTab] = useState("video");
+  const [caseStudyTab, setCaseStudyTab] = useState("settings");
   const [isReorderEnabled, setIsReorderEnabled] = useState(false);
 
 
@@ -2306,6 +2311,34 @@ function TeacherCourseContent() {
                                                           console.error(err);
                                                         });
                                                     }
+                                                    else if (type === "case_study") {
+                                                      createItemAsync({
+                                                        params: {
+                                                          path: {
+                                                            versionId: versionId!,
+                                                            moduleId: module.moduleId,
+                                                            sectionId: section.sectionId,
+                                                          },
+                                                        },
+                                                        body: {
+                                                          type: "CASE_STUDY",
+                                                          name: "Case study",
+                                                          description: "Write a structured response to the case, then judge pairs of peers' responses",
+                                                          caseStudyDetails: {},
+                                                        } as any,
+                                                      })
+                                                        .then(() => {
+                                                          refetchVersion();
+                                                          if (shouldFetchItems) {
+                                                            refetchItems();
+                                                          }
+                                                          toast.success("Case study added");
+                                                        })
+                                                        .catch((err) => {
+                                                          toast.error("Failed to add case study");
+                                                          console.error(err);
+                                                        });
+                                                    }
                                                     else if (type === "csv_upload") {
                                                       setActiveSectionInfo({ moduleId: module.moduleId, sectionId: section.sectionId });
                                                       setShowCSVUpload(true);
@@ -2335,6 +2368,8 @@ function TeacherCourseContent() {
                                                 <option value="feedback">Feedback Form</option>
 
                                                 <option value="reflection">Reflection (peer reviewed)</option>
+
+                                                <option value="case_study">Case Study (peer reviewed)</option>
 
                                                 <option
                                                   value="project"
@@ -3502,6 +3537,37 @@ function TeacherCourseContent() {
                             refetchItem();
                           }}
                         />
+                      )}
+
+                      {selectedEntity.type === "item" && selectedEntity.data.type === "CASE_STUDY" && (
+                        <Tabs value={caseStudyTab} onValueChange={setCaseStudyTab} className="mb-4">
+                          <TabsList>
+                            <TabsTrigger value="settings">Settings</TabsTrigger>
+                            <TabsTrigger value="responses">Responses</TabsTrigger>
+                          </TabsList>
+                          {caseStudyTab === "settings" && (
+                            <CaseStudyItemEditor
+                              itemId={selectedEntity.data._id}
+                              courseId={courseId!}
+                              versionId={versionId!}
+                              name={selectedEntity.data.name}
+                              description={selectedEntity.data.description}
+                              details={(selectedItemData as any)?.details}
+                              onSaved={() => {
+                                refetchVersion();
+                                refetchItems();
+                                refetchItem();
+                              }}
+                            />
+                          )}
+                          {caseStudyTab === "responses" && (
+                            <CaseStudyResponsesPanel
+                              courseId={courseId!}
+                              versionId={versionId!}
+                              itemId={selectedEntity.data._id}
+                            />
+                          )}
+                        </Tabs>
                       )}
 
                       {selectedEntity.type === "item" && selectedEntity.data.type === "FEEDBACK" && (

--- a/frontend/src/assets/globals.css
+++ b/frontend/src/assets/globals.css
@@ -229,6 +229,19 @@
   }
 }
 
+/* Dark mode: case study pick buttons get visible accent hover highlight */
+.dark .pick-option:not(:disabled):hover {
+  background-color: hsl(var(--accent) / 0.18);
+  border-color: hsl(var(--accent) / 0.55);
+  color: hsl(var(--foreground));
+}
+
+/* Text selection — keep highlight visible in dark mode */
+.dark ::selection {
+  background: hsl(38 95% 60% / 0.45);
+  color: hsl(60 9.1% 97.8%);
+}
+
 /* Custom Scrollbar Styles */
 .custom-scrollbar::-webkit-scrollbar {
   width: 8px;

--- a/frontend/src/components/EditProctoringModal.tsx
+++ b/frontend/src/components/EditProctoringModal.tsx
@@ -94,6 +94,9 @@ export function ProctoringModal({
   const [linearProgressionEnabled, setLinearProgressionEnabled] = useState(true);
   const [seekForwardEnabled, setSeekForwardEnabled] = useState(false);
   const [hpSystemEnabled, setHpSystemEnabled] = useState(false);
+  const [caseStudiesEnabled, setCaseStudiesEnabled] = useState(false);
+  const [caseStudyStrictUnlockEnabled, setCaseStudyStrictUnlockEnabled] = useState(true);
+  const [caseStudyWeakStreakThreshold, setCaseStudyWeakStreakThreshold] = useState(3);
   const [baseHp, setbaseHp] = useState<number>(0);
   const [isPublic, setIsPublic] = useState(false);
   const [isAdditionalSettingsExpanded, setIsAdditionalSettingsExpanded] = useState(false);
@@ -157,6 +160,9 @@ export function ProctoringModal({
           setSeekForwardEnabled(result.settings?.seekForwardEnabled ?? false)
           setIsPublic(result.settings?.isPublic ?? false)
           setHpSystemEnabled(result.settings?.hpSystem ?? false)
+          setCaseStudiesEnabled(result.settings?.caseStudiesEnabled ?? false)
+          setCaseStudyStrictUnlockEnabled(result.settings?.caseStudyStrictUnlockEnabled ?? true)
+          setCaseStudyWeakStreakThreshold(result.settings?.caseStudyWeakStreakThreshold ?? 3)
           setbaseHp(result.settings?.baseHp ?? 0)
           setEnableRandomize(result.settings?.randomizeItems ?? false)
           setCrowdsourcedQuestionSubmissionEnabled(
@@ -204,8 +210,13 @@ export function ProctoringModal({
       }
     }
 
+    if (caseStudiesEnabled && (!Number.isInteger(caseStudyWeakStreakThreshold) || caseStudyWeakStreakThreshold < 1)) {
+      toast.error("The weak-response streak threshold must be a whole number of at least 1.")
+      return
+    }
+
     try {
-      const result = await editSettings(courseId, courseVersionId, detectors, isNew, linearProgressionEnabled, seekForwardEnabled, isPublic, hpSystemEnabled, baseHp, enableRandomize, crowdsourcedQuestionSubmissionEnabled)
+      const result = await editSettings(courseId, courseVersionId, detectors, isNew, linearProgressionEnabled, seekForwardEnabled, isPublic, hpSystemEnabled, baseHp, enableRandomize, crowdsourcedQuestionSubmissionEnabled, caseStudiesEnabled, caseStudyStrictUnlockEnabled, caseStudyWeakStreakThreshold)
 
       // Persist the follow-up invite configuration (separate endpoint).
       await updateFollowUpInvite(courseId, courseVersionId, {
@@ -383,6 +394,49 @@ export function ProctoringModal({
                       <Switch checked={hpSystemEnabled} onCheckedChange={() => setHpSystemEnabled(prev => !prev)} />
                     </div>
                   </div>
+                  <div>
+                    <div className="flex items-center justify-between space-x-3">
+                      <div className="space-y-1">
+                        <Label className="text-sm font-medium">Case Studies</Label>
+                        <p className="text-xs text-muted-foreground">Enable the peer-reviewed case-study write/review activity for this course</p>
+                      </div>
+                      <Switch checked={caseStudiesEnabled} onCheckedChange={() => setCaseStudiesEnabled(prev => !prev)} />
+                    </div>
+                  </div>
+                  {caseStudiesEnabled && (
+                    <>
+                      <div>
+                        <div className="flex items-center justify-between space-x-3">
+                          <div className="space-y-1">
+                            <Label className="text-sm font-medium">Strict Unlock (peer-review gated)</Label>
+                            <p className="text-xs text-muted-foreground">
+                              On: students unlock the next case only after their response wins {" "}
+                              enough peer reviews. Off: the next case unlocks as soon as the {" "}
+                              previous one is submitted.
+                            </p>
+                          </div>
+                          <Switch
+                            checked={caseStudyStrictUnlockEnabled}
+                            onCheckedChange={() => setCaseStudyStrictUnlockEnabled(prev => !prev)}
+                          />
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        <Label className="text-sm font-medium">Weak-Response Streak Threshold</Label>
+                        <p className="text-xs text-muted-foreground">
+                          Notify a student after this many consecutive case-study reviews where peers picked the other response over theirs
+                        </p>
+                        <Input
+                          type="number"
+                          value={caseStudyWeakStreakThreshold}
+                          min={1}
+                          max={20}
+                          onChange={(e) => setCaseStudyWeakStreakThreshold(Number(e.target.value))}
+                          placeholder="Enter streak threshold"
+                        />
+                      </div>
+                    </>
+                  )}
                   {hpSystemEnabled && (
                     <div className="space-y-2">
                       <Label className="text-sm font-medium">Base HP</Label>

--- a/frontend/src/components/Item-container.tsx
+++ b/frontend/src/components/Item-container.tsx
@@ -9,6 +9,7 @@ import type { VideoRef } from "@/types/video.types";
 import type { ItemContainerProps, ItemContainerRef } from '@/types/item-container.types';
 import FeedbackForm from '@/app/pages/student/components/FeedbackForm';
 import ReflectionItemPanel, {type ReflectionItemPanelRef} from '@/components/peer-reviews/ReflectionItemPanel';
+import CaseStudyItemPanel, {type CaseStudyItemPanelRef} from '@/components/case-studies/CaseStudyItemPanel';
 import { useSubmitFeedback } from '@/hooks/hooks';
 
 export interface ISubmitFeedbackBody {
@@ -22,6 +23,7 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
   const articleRef = useRef<ArticleRef>(null);
   const quizRef = useRef<QuizRef>(null);
   const reflectionRef = useRef<ReflectionItemPanelRef>(null);
+  const caseStudyRef = useRef<CaseStudyItemPanelRef>(null);
   const videoRef = useRef<VideoRef>(null);
 
   // ✅ Expose stop function to parent - handles article, quiz, reflection and video
@@ -33,6 +35,8 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
         await quizRef.current.stopItem();
       } else if (reflectionRef.current) {
         await reflectionRef.current.stopItem();
+      } else if (caseStudyRef.current) {
+        await caseStudyRef.current.stopItem();
       } else if (videoRef.current) {
         await videoRef.current.stopItem();
       }
@@ -184,6 +188,20 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
           itemId={item._id.toString()}
           title={item.name}
           prompt={item.details?.prompt}
+          onNext={onNext}
+          isProgressUpdating={isProgressUpdating}
+          isAlreadyWatched={item.isAlreadyWatched || false}
+          completedItemIdsRef={completedItemIdsRef}
+        />;
+
+      case 'case_study':
+        return <CaseStudyItemPanel
+          key={item._id.toString()}
+          ref={caseStudyRef}
+          courseId={courseId}
+          courseVersionId={versionId}
+          itemId={item._id.toString()}
+          title={item.name}
           onNext={onNext}
           isProgressUpdating={isProgressUpdating}
           isAlreadyWatched={item.isAlreadyWatched || false}

--- a/frontend/src/components/case-studies/CaseComposer.tsx
+++ b/frontend/src/components/case-studies/CaseComposer.tsx
@@ -1,0 +1,317 @@
+import {useState} from 'react';
+import {AlertCircle, AlertTriangle, Ban, Loader2, PenLine} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {Input} from '@/components/ui/input';
+import {Textarea} from '@/components/ui/textarea';
+import {cn} from '@/utils/utils';
+import {countWords} from '@/utils/wordCount';
+import {reportCaseStudyAnomaly} from '@/lib/api/anomaly-events';
+import type {CaseResponseInput} from '@/lib/api/case-studies';
+
+// Must match ELEMENT_2A_MIN_WORDS and FIELD_MIN_WORDS in backend/src/modules/caseStudies/constants.ts
+const STEELMAN_MIN_WORDS = 25;
+const FIELD_MIN_WORDS = 5;
+const TOTAL_GUIDANCE_MAX = 200;
+
+interface CaseComposerProps {
+  title: string;
+  bodyMarkdown: string;
+  onSubmit: (response: CaseResponseInput) => Promise<unknown>;
+  isSubmitting?: boolean;
+  anomalyContext: {courseId: string; versionId: string; itemId: string};
+  mode?: 'write' | 'revise' | 'withdrawn';
+  existingResponse?: Partial<CaseResponseInput>;
+}
+
+/**
+ * Four-section write UI (FR-12). Word counter mirrors the server's exact
+ * counting logic (`countWords`). No paste/copy on any field — blocked
+ * visibly so participants notice and retype instead of assuming it worked.
+ */
+export default function CaseComposer({
+  title,
+  bodyMarkdown,
+  onSubmit,
+  isSubmitting = false,
+  anomalyContext,
+  mode = 'write',
+  existingResponse,
+}: CaseComposerProps) {
+  const [beat1a, setBeat1a] = useState(existingResponse?.beat1a ?? '');
+  const [beat1b, setBeat1b] = useState(existingResponse?.beat1b ?? '');
+  const [beat1c, setBeat1c] = useState(existingResponse?.beat1c ?? '');
+  const [steelman, setSteelman] = useState(existingResponse?.steelman ?? '');
+  const [roomPerspective, setRoomPerspective] = useState(existingResponse?.roomPerspective ?? '');
+  const [changeCommitment, setChangeCommitment] = useState(existingResponse?.changeCommitment ?? '');
+  const [blockedNotice, setBlockedNotice] = useState(false);
+
+  const steelmanWords = countWords(steelman);
+  const totalWords =
+    countWords(beat1a) +
+    countWords(beat1b) +
+    countWords(beat1c) +
+    steelmanWords +
+    countWords(roomPerspective) +
+    countWords(changeCommitment);
+
+  const beat1aWords = countWords(beat1a);
+  const beat1bWords = countWords(beat1b);
+  const beat1cWords = countWords(beat1c);
+  const roomWords = countWords(roomPerspective);
+  const changeWords = countWords(changeCommitment);
+
+  const steelmanTooShort = steelmanWords > 0 && steelmanWords < STEELMAN_MIN_WORDS;
+  const singleFieldsTooShort =
+    (beat1a.trim() && beat1aWords < FIELD_MIN_WORDS) ||
+    (beat1b.trim() && beat1bWords < FIELD_MIN_WORDS) ||
+    (beat1c.trim() && beat1cWords < FIELD_MIN_WORDS) ||
+    (roomPerspective.trim() && roomWords < FIELD_MIN_WORDS) ||
+    (changeCommitment.trim() && changeWords < FIELD_MIN_WORDS);
+  const allFilled =
+    beat1aWords >= FIELD_MIN_WORDS && beat1bWords >= FIELD_MIN_WORDS && beat1cWords >= FIELD_MIN_WORDS &&
+    steelman.trim() && roomWords >= FIELD_MIN_WORDS && changeWords >= FIELD_MIN_WORDS;
+  const canSubmit = allFilled && steelmanWords >= STEELMAN_MIN_WORDS && !isSubmitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    await onSubmit({
+      beat1a: beat1a.trim(),
+      beat1b: beat1b.trim(),
+      beat1c: beat1c.trim(),
+      steelman: steelman.trim(),
+      roomPerspective: roomPerspective.trim(),
+      changeCommitment: changeCommitment.trim(),
+    });
+  };
+
+  const handleBlockedAttempt = (e: React.ClipboardEvent | React.MouseEvent) => {
+    e.preventDefault();
+    setBlockedNotice(true);
+    reportCaseStudyAnomaly({
+      type: 'PASTE_ATTEMPTED',
+      courseId: anomalyContext.courseId,
+      versionId: anomalyContext.versionId,
+      itemId: anomalyContext.itemId,
+    });
+    window.setTimeout(() => setBlockedNotice(false), 4000);
+  };
+
+  const blockProps = {
+    onPaste: handleBlockedAttempt,
+    onCopy: handleBlockedAttempt,
+    onCut: handleBlockedAttempt,
+    onContextMenu: handleBlockedAttempt,
+    disabled: isSubmitting,
+  } as const;
+
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
+      {mode === 'revise' ? (
+        <div className="flex items-start gap-3 border-b border-amber-200 bg-amber-50 p-4 dark:border-amber-800/40 dark:bg-amber-950/20">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <p className="text-sm text-amber-800 dark:text-amber-300">
+            Your peers have flagged this response as consistently weak. Revise and resubmit below.
+          </p>
+        </div>
+      ) : null}
+      {mode === 'withdrawn' ? (
+        <div className="flex items-start gap-3 border-b border-destructive/30 bg-destructive/5 p-4">
+          <Ban className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            Your response was flagged as unjudgeable by other reviewers. Please revise and resubmit a clear, substantive response.
+          </p>
+        </div>
+      ) : null}
+
+      <div className="flex items-start gap-3 border-b bg-muted/40 p-5">
+        <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <PenLine className="h-4.5 w-4.5" />
+        </span>
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold leading-snug">{title}</h3>
+          <p className="whitespace-pre-line text-sm text-muted-foreground">{bodyMarkdown}</p>
+        </div>
+      </div>
+
+      <div className="divide-y">
+        {/* Element 1 — Where I landed */}
+        <section className="space-y-3 p-5">
+          <p className="text-sm font-semibold text-foreground">Element 1 — Where I landed</p>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-xs text-muted-foreground">a) What I thought going in</label>
+              {beat1a.trim() && beat1aWords < FIELD_MIN_WORDS && (
+                <span className="text-xs font-medium text-destructive">{beat1aWords}/{FIELD_MIN_WORDS}+ words</span>
+              )}
+            </div>
+            <Input
+              data-testid="beat1a"
+              value={beat1a}
+              onChange={e => setBeat1a(e.target.value)}
+              placeholder="~1 sentence (min 5 words)"
+              aria-label="What I thought going in"
+              className={cn(beat1a.trim() && beat1aWords < FIELD_MIN_WORDS && 'border-destructive/60')}
+              {...blockProps}
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-xs text-muted-foreground">b) What challenged it — or what gave most pause if nothing did</label>
+              {beat1b.trim() && beat1bWords < FIELD_MIN_WORDS && (
+                <span className="text-xs font-medium text-destructive">{beat1bWords}/{FIELD_MIN_WORDS}+ words</span>
+              )}
+            </div>
+            <Input
+              data-testid="beat1b"
+              value={beat1b}
+              onChange={e => setBeat1b(e.target.value)}
+              placeholder="~1 sentence (min 5 words)"
+              aria-label="What challenged my initial view"
+              className={cn(beat1b.trim() && beat1bWords < FIELD_MIN_WORDS && 'border-destructive/60')}
+              {...blockProps}
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-xs text-muted-foreground">c) Where I ended up</label>
+              {beat1c.trim() && beat1cWords < FIELD_MIN_WORDS && (
+                <span className="text-xs font-medium text-destructive">{beat1cWords}/{FIELD_MIN_WORDS}+ words</span>
+              )}
+            </div>
+            <Input
+              data-testid="beat1c"
+              value={beat1c}
+              onChange={e => setBeat1c(e.target.value)}
+              placeholder="~1 sentence (min 5 words)"
+              aria-label="Where I ended up"
+              className={cn(beat1c.trim() && beat1cWords < FIELD_MIN_WORDS && 'border-destructive/60')}
+              {...blockProps}
+            />
+          </div>
+        </section>
+
+        {/* Element 2a — Steelman */}
+        <section className="space-y-3 p-5">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm font-semibold text-foreground">2a — The strongest case against my view</p>
+            <span
+              className={cn(
+                'shrink-0 text-xs tabular-nums',
+                steelmanTooShort ? 'font-medium text-destructive' : 'text-muted-foreground',
+              )}
+            >
+              {steelmanWords} / {STEELMAN_MIN_WORDS}+ words
+            </span>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            The case's turn names what each choice costs — use that framing, not what was said in the breakout.
+          </p>
+          <Textarea
+            data-testid="steelman"
+            value={steelman}
+            onChange={e => setSteelman(e.target.value)}
+            placeholder="Argue the other side as forcefully as you can…"
+            rows={5}
+            aria-label="Steelman — strongest case against my view"
+            className={cn(
+              'resize-y bg-background text-base leading-relaxed',
+              'min-h-28 rounded-lg border-2 shadow-inner',
+              'focus-visible:ring-2 focus-visible:ring-primary/40',
+              steelmanTooShort && 'border-destructive/60',
+            )}
+            {...blockProps}
+          />
+          {steelmanTooShort ? (
+            <p className="text-xs font-medium text-destructive">
+              Steelman needs at least {STEELMAN_MIN_WORDS} words ({STEELMAN_MIN_WORDS - steelmanWords} more to go).
+            </p>
+          ) : null}
+        </section>
+
+        {/* Element 2b — Room perspective */}
+        <section className="space-y-3 p-5">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-foreground">2b — One perspective from the room</p>
+            {roomPerspective.trim() && roomWords < FIELD_MIN_WORDS && (
+              <span className="text-xs font-medium text-destructive">{roomWords}/{FIELD_MIN_WORDS}+ words</span>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            "Room broadly agreed with me" is a valid answer. This is not shown to reviewers.
+          </p>
+          <Input
+            data-testid="roomPerspective"
+            value={roomPerspective}
+            onChange={e => setRoomPerspective(e.target.value)}
+            placeholder="~1 sentence (min 5 words)"
+            aria-label="One perspective from the room"
+            className={cn(roomPerspective.trim() && roomWords < FIELD_MIN_WORDS && 'border-destructive/60')}
+            {...blockProps}
+          />
+        </section>
+
+        {/* Element 3 — Change commitment */}
+        <section className="space-y-3 p-5">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-foreground">3 — One thing I'll change</p>
+            {changeCommitment.trim() && changeWords < FIELD_MIN_WORDS && (
+              <span className="text-xs font-medium text-destructive">{changeWords}/{FIELD_MIN_WORDS}+ words</span>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Answer the cost you named in your steelman above.
+          </p>
+          <Input
+            data-testid="changeCommitment"
+            value={changeCommitment}
+            onChange={e => setChangeCommitment(e.target.value)}
+            placeholder="~1 sentence (min 5 words)"
+            aria-label="One thing I will change"
+            className={cn(changeCommitment.trim() && changeWords < FIELD_MIN_WORDS && 'border-destructive/60')}
+            {...blockProps}
+          />
+        </section>
+      </div>
+
+      <div className="space-y-3 border-t bg-muted/20 p-5">
+        {blockedNotice ? (
+          <p
+            data-testid="case-composer-paste-blocked-notice"
+            className="flex items-center gap-1.5 text-xs font-medium text-destructive"
+          >
+            <AlertCircle className="h-3.5 w-3.5" />
+            Paste/copy is disabled here — please type your own response.
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-between gap-4">
+          <span
+            className={cn(
+              'text-xs tabular-nums',
+              totalWords > TOTAL_GUIDANCE_MAX ? 'font-medium text-amber-600' : 'text-muted-foreground',
+            )}
+          >
+            total: {totalWords} / {TOTAL_GUIDANCE_MAX} words{totalWords > TOTAL_GUIDANCE_MAX ? ' (over guidance)' : ''}
+          </span>
+          <Button
+            data-testid="case-composer-submit"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            size="lg"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {mode === 'revise' || mode === 'withdrawn' ? 'Resubmitting…' : 'Submitting…'}
+              </>
+            ) : mode === 'revise' || mode === 'withdrawn' ? (
+              'Resubmit'
+            ) : (
+              'Submit response'
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/case-studies/CaseStudyItemPanel.tsx
+++ b/frontend/src/components/case-studies/CaseStudyItemPanel.tsx
@@ -1,0 +1,379 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import {AlertCircle, ArrowRight, Loader2} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {Checkbox} from '@/components/ui/checkbox';
+import {Input} from '@/components/ui/input';
+import {useStartItem, useStopItem} from '@/hooks/hooks';
+import {useCourseStore} from '@/store/course-store';
+import {
+  useEnsureCaseForItem,
+  useMyCaseResponse,
+  useNextComparisonPair,
+  useReviseResponse,
+  useSubmitCaseResponse,
+  useSubmitPick,
+} from '@/hooks/case-study-hooks';
+import CaseComposer from './CaseComposer';
+import ComparisonView from './ComparisonView';
+
+interface CaseStudyItemPanelProps {
+  courseId: string;
+  courseVersionId: string;
+  itemId: string;
+  /** Item title, shown as the heading. */
+  title?: string;
+  /** Advances to the next item in the section. */
+  onNext: () => void;
+  isProgressUpdating?: boolean;
+  /** True when this item was already completed on an earlier visit. */
+  isAlreadyWatched?: boolean;
+  /** Shared set of item ids completed this session, to avoid double-stopping. */
+  completedItemIdsRef: React.RefObject<Set<string>>;
+}
+
+export interface CaseStudyItemPanelRef {
+  /** Called by the item container when the learner navigates away. */
+  stopItem: () => Promise<void>;
+}
+
+/**
+ * The learner-facing view of a CASE_STUDY item.
+ *
+ * Writing comes first and reviewing is only offered afterwards. The case
+ * record is synced from the item on open (see useEnsureCaseForItem), so the
+ * peer-review runtime keys on the item's own id. Reviewing never blocks
+ * `onNext` — the pressure is social, not a course gate.
+ */
+const CaseStudyItemPanel = forwardRef<
+  CaseStudyItemPanelRef,
+  CaseStudyItemPanelProps
+>(function CaseStudyItemPanel(
+  {
+    courseId,
+    courseVersionId,
+    itemId,
+    title,
+    onNext,
+    isProgressUpdating = false,
+    isAlreadyWatched = false,
+    completedItemIdsRef,
+  },
+  ref,
+) {
+  const ctxRef = {courseId, versionId: courseVersionId};
+  const anomalyContext = {courseId, versionId: courseVersionId, itemId};
+  const [isReviewing, setIsReviewing] = useState(false);
+  const [isRevising, setIsRevising] = useState(false);
+  const [gateStep, setGateStep] = useState<'declaration' | 'date' | 'composing'>('declaration');
+  const [declared, setDeclared] = useState(false);
+  const [zoomSessionDate, setZoomSessionDate] = useState('');
+
+  // Progress is recorded exactly as an article/reflection records it: started
+  // on arrival, stopped on the way out. Without this the item never completes,
+  // and with linear progression the next lesson stays locked.
+  const {currentCourse, setWatchItemId} = useCourseStore();
+  const startItem = useStartItem();
+  const stopItem = useStopItem();
+  const itemStartedRef = useRef(false);
+  const startSentRef = useRef(false);
+
+  const alreadyDone = () =>
+    isAlreadyWatched || completedItemIdsRef.current?.has(itemId);
+
+  useEffect(() => {
+    if (startSentRef.current || !currentCourse?.itemId || alreadyDone()) return;
+    startSentRef.current = true;
+    startItem.mutate({
+      params: {path: {courseId, courseVersionId}},
+      body: {
+        itemId,
+        moduleId: currentCourse.moduleId ?? '',
+        sectionId: currentCourse.sectionId ?? '',
+        cohortId: currentCourse.cohortId || undefined,
+      },
+    } as any);
+  }, [itemId, currentCourse?.itemId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (
+      startItem.data?.watchItemId &&
+      startSentRef.current &&
+      !itemStartedRef.current
+    ) {
+      setWatchItemId(startItem.data.watchItemId);
+      itemStartedRef.current = true;
+    }
+  }, [startItem.data?.watchItemId, setWatchItemId]);
+
+  useImperativeHandle(ref, () => ({
+    stopItem: async () => {
+      if (!currentCourse?.watchItemId || !itemStartedRef.current) return;
+      if (alreadyDone()) return;
+      await stopItem.mutateAsync({
+        params: {path: {courseId, courseVersionId}},
+        body: {
+          watchItemId: currentCourse.watchItemId,
+          itemId,
+          moduleId: currentCourse.moduleId ?? '',
+          sectionId: currentCourse.sectionId ?? '',
+          cohortId: currentCourse.cohortId || undefined,
+        },
+      } as any);
+      completedItemIdsRef.current?.add(itemId);
+      itemStartedRef.current = false;
+    },
+  }));
+
+  // Sync the case from the item, then drive the runtime by the item's id.
+  const {
+    caseStudy,
+    isLoading: ensuring,
+    isError: ensureError,
+    refetch: refetchEnsure,
+  } = useEnsureCaseForItem(ctxRef, itemId);
+  const {
+    response: mine,
+    eligibleForRevision,
+    picksRequired,
+    picksCompleted,
+    isLoading: mineLoading,
+    isError: mineError,
+    refetch: refetchMine,
+  } = useMyCaseResponse(itemId, Boolean(caseStudy));
+  const submit = useSubmitCaseResponse(ctxRef, itemId);
+  const revise = useReviseResponse(ctxRef, itemId);
+
+  const hasSubmitted = Boolean(mine);
+  const {
+    pair,
+    isLoading: pairLoading,
+    isError: pairError,
+    refetch: refetchPair,
+  } = useNextComparisonPair(itemId, hasSubmitted && isReviewing);
+  const submitPick = useSubmitPick(ctxRef, itemId);
+
+  const shell = (children: React.ReactNode) => (
+    <div className="flex min-h-full justify-center px-4 py-6 sm:py-10">
+      <div className="w-full max-w-2xl space-y-4">
+        {title ? (
+          <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+        ) : null}
+        {children}
+      </div>
+    </div>
+  );
+
+  const errorBox = (message: string, onRetry: () => void) =>
+    shell(
+      <div className="flex flex-col items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-8 text-center">
+        <AlertCircle className="h-6 w-6 text-destructive" />
+        <p className="text-sm text-muted-foreground">{message}</p>
+        <Button variant="outline" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>,
+    );
+
+  if (ensuring || (caseStudy && mineLoading)) {
+    return shell(
+      <div className="flex items-center justify-center gap-2 rounded-lg border p-8 text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading
+      </div>,
+    );
+  }
+
+  if (ensureError) {
+    return errorBox("Couldn't load this case study.", () => refetchEnsure());
+  }
+  // A load failure must not look like "not submitted yet" — otherwise a learner
+  // whose response simply failed to load could submit a second time.
+  if (mineError) {
+    return errorBox(
+      "Couldn't load your response. This is a connection problem, not a lost submission — retry before writing anything new.",
+      () => refetchMine(),
+    );
+  }
+
+  if (!hasSubmitted) {
+    if (gateStep === 'declaration') {
+      return shell(
+        <div className="space-y-6 rounded-xl border bg-card p-6 shadow-sm">
+          <div>
+            <h3 className="text-base font-semibold">Before you begin</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Please confirm your participation before writing your response.
+            </p>
+          </div>
+          <label className="flex cursor-pointer items-start gap-3">
+            <Checkbox
+              id="zoom-declaration"
+              checked={declared}
+              onCheckedChange={v => setDeclared(v === true)}
+              className="mt-0.5"
+            />
+            <span className="text-sm leading-snug">
+              I confirm that I have attended the relevant session and participated
+              in the breakout room discussion for this case study.
+            </span>
+          </label>
+          <Button disabled={!declared} onClick={() => setGateStep('date')}>
+            Continue
+          </Button>
+        </div>,
+      );
+    }
+
+    if (gateStep === 'date') {
+      return shell(
+        <div className="space-y-6 rounded-xl border bg-card p-6 shadow-sm">
+          <div>
+            <h3 className="text-base font-semibold">Session date</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Enter the date of the session in which you did the breakout
+              discussion. We trust what you enter — this is stored for reference.
+            </p>
+          </div>
+          <Input
+            type="date"
+            value={zoomSessionDate}
+            onChange={e => setZoomSessionDate(e.target.value)}
+            className="max-w-xs"
+          />
+          <Button disabled={!zoomSessionDate} onClick={() => setGateStep('composing')}>
+            OK
+          </Button>
+        </div>,
+      );
+    }
+
+    return shell(
+      <CaseComposer
+        title={caseStudy!.title}
+        bodyMarkdown={caseStudy!.bodyMarkdown}
+        isSubmitting={submit.isPending}
+        anomalyContext={anomalyContext}
+        onSubmit={async response => {
+          await submit.mutateAsync({...response, zoomSessionDate});
+          await refetchMine();
+        }}
+      />,
+    );
+  }
+
+  if (isRevising) {
+    return shell(
+      <CaseComposer
+        title={caseStudy!.title}
+        bodyMarkdown={caseStudy!.bodyMarkdown}
+        isSubmitting={revise.isPending}
+        anomalyContext={anomalyContext}
+        mode={mine!.status === 'WITHDRAWN' ? 'withdrawn' : 'revise'}
+        existingResponse={mine!}
+        onSubmit={async response => {
+          await revise.mutateAsync(response);
+          await refetchMine();
+          setIsRevising(false);
+        }}
+      />,
+    );
+  }
+
+  if (isReviewing) {
+    return shell(
+      <div className="space-y-3">
+        {pairError ? (
+          errorBox("Couldn't load the next pair to review.", () => refetchPair())
+        ) : pairLoading ? (
+          <div className="flex items-center justify-center gap-2 rounded-lg border p-8 text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading next pair…
+          </div>
+        ) : pair ? (
+          <ComparisonView
+            key={pair.comparisonId}
+            pair={pair}
+            onPick={async outcome =>
+              submitPick.mutateAsync({comparisonId: pair.comparisonId, outcome})
+            }
+            anomalyContext={anomalyContext}
+          />
+        ) : (
+          <div className="rounded-lg border p-8 text-center text-sm text-foreground/70">
+            Check back once more colleagues have submitted responses to this case.
+          </div>
+        )}
+        <Button variant="ghost" onClick={() => setIsReviewing(false)}>
+          Back to my response
+        </Button>
+      </div>,
+    );
+  }
+
+  return shell(
+    <div className="space-y-3">
+      <div className="rounded-lg border bg-muted/30 p-3 text-sm">
+        <p className="font-medium">Your response</p>
+        <p className="mt-1 text-muted-foreground">
+          {mine!.winCount} win{mine!.winCount === 1 ? '' : 's'} ·{' '}
+          {mine!.status === 'WON'
+            ? 'Completed'
+            : mine!.status === 'WITHDRAWN'
+              ? 'Flagged for revision'
+              : 'In review'}
+        </p>
+      </div>
+
+      {eligibleForRevision && mine!.status === 'WITHDRAWN' ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+          Your response was flagged as unjudgeable by multiple reviewers and removed from the pool.
+          Revise and resubmit to re-enter.
+        </div>
+      ) : eligibleForRevision ? (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400">
+          Reviewers have picked other responses over yours several times in a row.
+          You can revise it for another cycle.
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Button className="flex-1" onClick={() => setIsReviewing(true)}>
+          {picksRequired > 0
+            ? picksCompleted >= picksRequired
+              ? `Review peers (${picksCompleted}/${picksRequired} done)`
+              : `Review peers (${picksCompleted}/${picksRequired})`
+            : 'Review peers'}
+        </Button>
+        {eligibleForRevision ? (
+          <Button
+            variant="outline"
+            className="flex-1"
+            onClick={() => setIsRevising(true)}
+          >
+            Revise my response
+          </Button>
+        ) : null}
+        <Button
+          variant="secondary"
+          className="flex-1"
+          onClick={onNext}
+          disabled={isProgressUpdating}
+        >
+          {isProgressUpdating ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : null}
+          Continue
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </div>
+    </div>,
+  );
+});
+
+export default CaseStudyItemPanel;

--- a/frontend/src/components/case-studies/ComparisonView.tsx
+++ b/frontend/src/components/case-studies/ComparisonView.tsx
@@ -1,0 +1,150 @@
+import {useState} from 'react';
+import {AlertTriangle, Flag, Loader2, ThumbsUp} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {cn} from '@/utils/utils';
+import type {PickOutcome, PickResult, ServedPair, ServedPairSide} from '@/lib/api/case-studies';
+import ReadingTimerGate from './ReadingTimerGate';
+
+interface ComparisonViewProps {
+  pair: ServedPair;
+  onPick: (outcome: PickOutcome) => Promise<PickResult>;
+  anomalyContext: {courseId: string; versionId: string; itemId: string};
+}
+
+function Field({label, value}: {label: string; value: string}) {
+  return (
+    <div className="space-y-0.5">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <p className="whitespace-pre-line text-sm leading-relaxed">{value}</p>
+    </div>
+  );
+}
+
+function ResponseCard({side, label}: {side: ServedPairSide; label: string}) {
+  return (
+    <div className="flex-1 space-y-4 rounded-lg border bg-card p-4">
+      <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</span>
+      <div className="space-y-3 border-t pt-3">
+        <Field label="What I thought going in" value={side.beat1a} />
+        <Field label="What challenged it" value={side.beat1b} />
+        <Field label="Where I ended up" value={side.beat1c} />
+      </div>
+      <div className="space-y-0.5 border-t pt-3">
+        <p className="text-xs font-medium text-muted-foreground">Strongest case against my view</p>
+        <p className="whitespace-pre-line text-sm leading-relaxed">{side.steelman}</p>
+      </div>
+      <div className="space-y-3 border-t pt-3">
+        <Field label="One perspective from the room" value={side.roomPerspective} />
+        <Field label="One thing I'll change" value={side.changeCommitment} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Split-view pair showing all six response fields for both sides. Pick buttons
+ * stay disabled until `ReadingTimerGate` clears; that is UX only — the server
+ * independently re-validates the real elapsed time (§4.8).
+ */
+export default function ComparisonView({pair, onPick, anomalyContext}: ComparisonViewProps) {
+  const [locked, setLocked] = useState(true);
+  const [pending, setPending] = useState<PickOutcome | null>(null);
+  const [result, setResult] = useState<PickResult | null>(null);
+
+  const handlePick = async (outcome: PickOutcome) => {
+    // FLAGGED can fire while locked — a broken/unreadable pair can't be "read"
+    if (pending || (locked && outcome !== 'FLAGGED')) return;
+    setPending(outcome);
+    try {
+      const r = await onPick(outcome);
+      setResult(r);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  if (result) {
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-xl border bg-card p-8 text-center">
+        <ThumbsUp className="h-6 w-6 text-primary" />
+        <p className="font-medium">Verdict recorded</p>
+        {result.totalJudged > 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {result.agreementCount} of {result.totalJudged} reader{result.totalJudged === 1 ? '' : 's'} who have
+            judged this pair so far chose the same one.
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <ReadingTimerGate
+        servedAt={pair.servedAt}
+        minimumScreenTimeSeconds={pair.minimumScreenTimeSeconds}
+        anomalyContext={anomalyContext}
+        onLockChange={setLocked}
+      />
+
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <ResponseCard side={pair.left} label="Response A" />
+        <ResponseCard side={pair.right} label="Response B" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <Button
+          data-testid="pick-left"
+          variant="outline"
+          disabled={locked || Boolean(pending)}
+          onClick={() => handlePick(pair.left.outcome)}
+          className={cn('h-auto py-3 pick-option')}
+        >
+          {pending === pair.left.outcome ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Response A is better
+        </Button>
+        <Button
+          data-testid="pick-right"
+          variant="outline"
+          disabled={locked || Boolean(pending)}
+          onClick={() => handlePick(pair.right.outcome)}
+          className={cn('h-auto py-3 pick-option')}
+        >
+          {pending === pair.right.outcome ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Response B is better
+        </Button>
+        <Button
+          data-testid="pick-both-weak"
+          variant="outline"
+          disabled={locked || Boolean(pending)}
+          onClick={() => handlePick('BOTH_WEAK')}
+          className={cn('h-auto py-3 pick-option')}
+        >
+          {pending === 'BOTH_WEAK' ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Both are too weak
+        </Button>
+        <Button
+          data-testid="pick-flagged"
+          variant="outline"
+          disabled={Boolean(pending)}
+          onClick={() => handlePick('FLAGGED')}
+          className={cn('h-auto gap-1.5 py-3 text-muted-foreground hover:text-foreground')}
+        >
+          {pending === 'FLAGGED' ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Flag className="h-4 w-4" />
+          )}
+          Report as unreadable
+        </Button>
+      </div>
+
+      {locked ? (
+        <p className="flex items-center justify-center gap-1.5 text-center text-xs font-medium text-amber-600 dark:text-amber-400">
+          <AlertTriangle className="h-3.5 w-3.5" />
+          Leaving this tab restarts the reading timer.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/case-studies/ReadingTimerGate.tsx
+++ b/frontend/src/components/case-studies/ReadingTimerGate.tsx
@@ -1,0 +1,106 @@
+import {useEffect, useRef, useState} from 'react';
+import {Clock} from 'lucide-react';
+import {reportCaseStudyAnomaly} from '@/lib/api/anomaly-events';
+
+interface ReadingTimerGateProps {
+  /** ISO timestamp — the server-anchored timer origin (PLANNING.md §4.6). */
+  servedAt: string;
+  minimumScreenTimeSeconds: number;
+  anomalyContext: {courseId: string; versionId: string; itemId: string};
+  /** Fires whenever the locked/unlocked state changes, so the parent can gate its pick buttons. */
+  onLockChange: (locked: boolean) => void;
+}
+
+/**
+ * The countdown/lock overlay. Ticks down from a server-anchored origin, so a
+ * page refresh can't shorten the wait — but per PLANNING.md §4.6, switching
+ * away and back (`visibilitychange`) restarts the *visible* countdown rather
+ * than resuming it, as a deterrent against reading elsewhere mid-timer. This
+ * is UX friction, not the real gate: `submitPick` re-validates the true
+ * elapsed time server-side regardless of what this component displays
+ * (§4.8) — a client bug here can make the button unlock early or late but
+ * can never make the server accept a premature pick.
+ */
+export default function ReadingTimerGate({
+  servedAt,
+  minimumScreenTimeSeconds,
+  anomalyContext,
+  onLockChange,
+}: ReadingTimerGateProps) {
+  const servedAtMs = useRef(new Date(servedAt).getTime());
+  const [lockedUntilMs, setLockedUntilMs] = useState(
+    () => servedAtMs.current + minimumScreenTimeSeconds * 1000,
+  );
+  const [remainingSeconds, setRemainingSeconds] = useState(() =>
+    Math.max(0, Math.ceil((lockedUntilMs - Date.now()) / 1000)),
+  );
+  const wasHiddenRef = useRef(false);
+  const lastReportedLocked = useRef<boolean | null>(null);
+
+  // A new served pair resets both the countdown origin and any prior restart.
+  useEffect(() => {
+    servedAtMs.current = new Date(servedAt).getTime();
+    setLockedUntilMs(servedAtMs.current + minimumScreenTimeSeconds * 1000);
+  }, [servedAt, minimumScreenTimeSeconds]);
+
+  useEffect(() => {
+    const tick = () => {
+      const remaining = Math.max(0, Math.ceil((lockedUntilMs - Date.now()) / 1000));
+      setRemainingSeconds(remaining);
+      const locked = remaining > 0;
+      if (lastReportedLocked.current !== locked) {
+        lastReportedLocked.current = locked;
+        onLockChange(locked);
+      }
+    };
+    tick();
+    const interval = setInterval(tick, 250);
+    return () => clearInterval(interval);
+  }, [lockedUntilMs]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        wasHiddenRef.current = true;
+        return;
+      }
+      if (!wasHiddenRef.current) return;
+      wasHiddenRef.current = false;
+      // Restart, don't resume — PLANNING.md §4.6's "next time when I come to
+      // the screen, the timer will restart" behaviour.
+      setLockedUntilMs(Date.now() + minimumScreenTimeSeconds * 1000);
+      reportCaseStudyAnomaly({
+        type: 'TAB_SWITCH_DURING_REVIEW',
+        courseId: anomalyContext.courseId,
+        versionId: anomalyContext.versionId,
+        itemId: anomalyContext.itemId,
+      });
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [minimumScreenTimeSeconds, anomalyContext.courseId, anomalyContext.versionId, anomalyContext.itemId]);
+
+  const minutes = Math.floor(remainingSeconds / 60);
+  const seconds = remainingSeconds % 60;
+  const locked = remainingSeconds > 0;
+
+  return (
+    <div
+      data-testid="reading-timer-gate"
+      data-locked={locked}
+      data-remaining-seconds={remainingSeconds}
+      className="flex items-center justify-center gap-2 rounded-lg border bg-muted/40 px-4 py-2.5 text-sm"
+      role="status"
+      aria-live="polite"
+    >
+      <Clock className={locked ? 'h-4 w-4 text-muted-foreground' : 'h-4 w-4 text-primary'} />
+      {locked ? (
+        <span className="tabular-nums text-muted-foreground">
+          Read both responses fully — picks unlock in {minutes}:{seconds.toString().padStart(2, '0')}
+        </span>
+      ) : (
+        <span className="font-medium text-primary">You can make your pick now</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/learn/CourseDrawer.tsx
+++ b/frontend/src/components/learn/CourseDrawer.tsx
@@ -90,6 +90,15 @@ type Props = {
   isItemLocked: (moduleId: string, sectionId: string, itemId: string) => boolean;
 
   emotion?: EmotionConfig;
+
+  /**
+   * Case Studies tab — additive, only rendered when the course setting is on.
+   * Omitting these (existing callers) renders exactly as before: no tab
+   * switcher, module tree as the only content, zero visible change.
+   */
+  caseStudiesEnabled?: boolean;
+  activeDrawerTab?: "content" | "case-studies";
+  onDrawerTabChange?: (tab: "content" | "case-studies") => void;
 };
 
 // Theme-aware row transition (works in light & dark).
@@ -119,6 +128,9 @@ export function CourseDrawer({
   onSelectItem,
   isItemLocked,
   emotion,
+  caseStudiesEnabled = false,
+  activeDrawerTab = "content",
+  onDrawerTabChange,
 }: Props) {
   const supportHref = (() => {
     if (!supportLink) return null;

--- a/frontend/src/components/learn/CourseDrawer.tsx
+++ b/frontend/src/components/learn/CourseDrawer.tsx
@@ -29,6 +29,8 @@ const getItemIcon = (type: string) => {
     case "form":
     case "feedback":
       return <FileEdit className="h-3 w-3" />;
+    case "case_study":
+      return <FileEdit className="h-3 w-3" />;
     default:
       return <FileText className="h-3 w-3" />;
   }
@@ -51,6 +53,8 @@ const typeLabel = (type: string) => {
       return "Feedback";
     case "project":
       return "Project";
+    case "case_study":
+      return "Case Study";
     default:
       return type || "Item";
   }
@@ -90,15 +94,6 @@ type Props = {
   isItemLocked: (moduleId: string, sectionId: string, itemId: string) => boolean;
 
   emotion?: EmotionConfig;
-
-  /**
-   * Case Studies tab — additive, only rendered when the course setting is on.
-   * Omitting these (existing callers) renders exactly as before: no tab
-   * switcher, module tree as the only content, zero visible change.
-   */
-  caseStudiesEnabled?: boolean;
-  activeDrawerTab?: "content" | "case-studies";
-  onDrawerTabChange?: (tab: "content" | "case-studies") => void;
 };
 
 // Theme-aware row transition (works in light & dark).
@@ -128,9 +123,6 @@ export function CourseDrawer({
   onSelectItem,
   isItemLocked,
   emotion,
-  caseStudiesEnabled = false,
-  activeDrawerTab = "content",
-  onDrawerTabChange,
 }: Props) {
   const supportHref = (() => {
     if (!supportLink) return null;

--- a/frontend/src/hooks/case-study-hooks.ts
+++ b/frontend/src/hooks/case-study-hooks.ts
@@ -1,0 +1,111 @@
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {toast} from 'sonner';
+import {
+  caseStudyApi,
+  type CaseResponseInput,
+  type CourseVersionRef,
+  type PickOutcome,
+} from '@/lib/api/case-studies';
+
+export const caseStudyKeys = {
+  myResponse: (caseStudyId: string) => ['case-studies', 'mine', caseStudyId],
+  nextPair: (caseStudyId: string) => ['case-studies', 'pair', caseStudyId],
+};
+
+/**
+ * Syncs the case record backing a CASE_STUDY item and returns its content.
+ * Runs once when the learner opens the item; the peer-review hooks below then
+ * key on the item's own id.
+ */
+export function useEnsureCaseForItem(ref: CourseVersionRef, itemId: string, enabled = true) {
+  const result = useQuery({
+    queryKey: ['case-studies', 'ensure', itemId],
+    queryFn: () => caseStudyApi.ensureCase(ref, itemId),
+    enabled: enabled && Boolean(ref.courseId && ref.versionId && itemId),
+    staleTime: Infinity,
+  });
+  return {...result, caseStudy: result.data ?? null};
+}
+
+export function useMyCaseResponse(caseStudyId: string, enabled = true) {
+  const result = useQuery({
+    queryKey: caseStudyKeys.myResponse(caseStudyId),
+    queryFn: () => caseStudyApi.getMyResponse(caseStudyId),
+    enabled: enabled && Boolean(caseStudyId),
+  });
+  return {
+    ...result,
+    response: result.data?.response ?? null,
+    eligibleForRevision: result.data?.eligibleForRevision ?? false,
+    picksRequired: result.data?.picksRequired ?? 0,
+    picksCompleted: result.data?.picksCompleted ?? 0,
+  };
+}
+
+export function useSubmitCaseResponse(ref: CourseVersionRef, caseStudyId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (response: CaseResponseInput) => caseStudyApi.submitResponse(caseStudyId, response),
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: caseStudyKeys.myResponse(caseStudyId)});
+      toast.success('Response submitted');
+    },
+    onError: (error: Error) => toast.error(error.message || 'Could not submit your response'),
+  });
+}
+
+/**
+ * The next pair to review. Not cached across picks — every successful pick
+ * invalidates this so the next call serves a fresh pair, mirroring
+ * useNextReflectionToReview's staleTime:0 contract.
+ */
+export function useNextComparisonPair(caseStudyId: string, enabled = true) {
+  const result = useQuery({
+    queryKey: caseStudyKeys.nextPair(caseStudyId),
+    queryFn: () => caseStudyApi.getNextPair(caseStudyId),
+    enabled: enabled && Boolean(caseStudyId),
+    staleTime: 0,
+  });
+  return {...result, pair: result.data?.pair ?? null};
+}
+
+export function useSubmitPick(ref: CourseVersionRef, caseStudyId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {comparisonId: string; outcome: PickOutcome}) =>
+      caseStudyApi.submitPick(input.comparisonId, input.outcome),
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: caseStudyKeys.nextPair(caseStudyId)});
+      // Refresh my-response so the "reviews done" counter advances after a pick.
+      queryClient.invalidateQueries({queryKey: caseStudyKeys.myResponse(caseStudyId)});
+    },
+    onError: (error: Error) => toast.error(error.message || 'Could not submit your pick'),
+  });
+}
+
+export function useReviseResponse(ref: CourseVersionRef, caseStudyId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (response: CaseResponseInput) => caseStudyApi.reviseResponse(caseStudyId, response),
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: caseStudyKeys.myResponse(caseStudyId)});
+      toast.success('Response resubmitted');
+    },
+    onError: (error: Error) => toast.error(error.message || 'Could not revise your response'),
+  });
+}
+
+export function useCaseStudyResponses(
+  courseId: string,
+  versionId: string,
+  itemId: string,
+  enabled = true,
+) {
+  const result = useQuery({
+    queryKey: ['case-studies', 'instructor-responses', itemId],
+    queryFn: () => caseStudyApi.listResponses(courseId, versionId, itemId),
+    enabled: enabled && Boolean(courseId && versionId && itemId),
+  });
+  return {...result, responses: result.data?.responses ?? []};
+}
+

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2162,6 +2162,9 @@ export function useEditProctoringSettings() {
     baseHp: number,
     randomizeItems: boolean,
     crowdsourcedQuestionSubmissionEnabled: boolean = false,
+    caseStudiesEnabled: boolean = false,
+    caseStudyStrictUnlockEnabled: boolean = true,
+    caseStudyWeakStreakThreshold: number = 3,
   ) => {
     setLoading(true);
     setError(null);
@@ -2184,6 +2187,9 @@ export function useEditProctoringSettings() {
         baseHp,
         randomizeItems,
         crowdsourcedQuestionSubmissionEnabled,
+        caseStudiesEnabled,
+        caseStudyStrictUnlockEnabled,
+        caseStudyWeakStreakThreshold,
       };
 
       const res = await fetch(url, {

--- a/frontend/src/lib/api/anomaly-events.ts
+++ b/frontend/src/lib/api/anomaly-events.ts
@@ -1,0 +1,44 @@
+/**
+ * Best-effort reporting for the two case-studies proctoring signals
+ * (TAB_SWITCH_DURING_REVIEW, PASTE_ATTEMPTED — PLANNING.md §4.9).
+ *
+ * Reuses the existing `POST /anomalies/record/image` route rather than
+ * adding a new one: `AnomalyService.recordAnomaly` already treats its file
+ * argument as optional, so posting a plain JSON body with no attachment logs
+ * a fileless anomaly through the same path the camera/audio detectors use.
+ * A case-study pair/response id slots into `itemId` with no schema change,
+ * exactly as PLANNING.md's proctoring-reuse note describes.
+ *
+ * This is a deterrent/log signal, not proof of anything (a paste can't be
+ * proven server-side) — see PLANNING.md §4.8. It must never block the
+ * learner's flow, so failures are swallowed.
+ */
+
+const BASE_URL = `${import.meta.env.VITE_BASE_URL}/anomalies`;
+
+function getAuthHeaders(): HeadersInit {
+  const token = localStorage.getItem('firebase-auth-token');
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? {Authorization: `Bearer ${token}`} : {}),
+  };
+}
+
+export type CaseStudyAnomalyType = 'TAB_SWITCH_DURING_REVIEW' | 'PASTE_ATTEMPTED';
+
+export function reportCaseStudyAnomaly(body: {
+  type: CaseStudyAnomalyType;
+  courseId: string;
+  versionId: string;
+  /** A case-study/comparison/response id — any valid ObjectId slots in here. */
+  itemId: string;
+}): void {
+  fetch(`${BASE_URL}/record/image`, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    credentials: 'include',
+    body: JSON.stringify(body),
+  }).catch(() => {
+    // Best-effort: a lost integrity signal must never block the learner.
+  });
+}

--- a/frontend/src/lib/api/case-studies.ts
+++ b/frontend/src/lib/api/case-studies.ts
@@ -1,0 +1,160 @@
+/**
+ * Client for the case-studies API.
+ *
+ * Written by hand, matching `lib/api/peer-reviews.ts`'s shape exactly — same
+ * reasoning: these routes are new and not yet in the committed OpenAPI spec,
+ * and this can be swapped for generated bindings later without touching the
+ * hooks that consume it.
+ */
+
+const BASE_URL = `${import.meta.env.VITE_BASE_URL}/case-studies`;
+
+function getAuthHeaders(): HeadersInit {
+  const token = localStorage.getItem('firebase-auth-token');
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? {Authorization: `Bearer ${token}`} : {}),
+  };
+}
+
+async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...options,
+    headers: {...getAuthHeaders(), ...(options?.headers || {})},
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    const errData = await res.json().catch(() => ({}));
+    throw new Error(errData.message || `Request failed (${res.status})`);
+  }
+  return res.json();
+}
+
+export interface CourseVersionRef {
+  courseId: string;
+  versionId: string;
+}
+
+/** The six structured response fields the student writes, plus optional Zoom declaration metadata. */
+export interface CaseResponseInput {
+  beat1a: string;
+  beat1b: string;
+  beat1c: string;
+  steelman: string;
+  roomPerspective: string;
+  changeCommitment: string;
+  /** ISO date string (YYYY-MM-DD) from the Zoom declaration gate — stored verbatim, not validated. */
+  zoomSessionDate?: string;
+}
+
+export interface MyCaseResponse {
+  _id: string;
+  userId: string;
+  courseVersionId: string;
+  caseStudyId: string;
+  beat1a: string;
+  beat1b: string;
+  beat1c: string;
+  steelman: string;
+  roomPerspective: string;
+  changeCommitment: string;
+  status: 'OPEN' | 'WON' | 'WITHDRAWN';
+  winCount: number;
+  weakStreak: number;
+  comparisonsSeenCount: number;
+  flagCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type PickOutcome = 'A' | 'B' | 'BOTH_WEAK' | 'FLAGGED';
+
+/** One side of a served pair — all response fields are exposed to reviewers. */
+export interface ServedPairSide {
+  responseId: string;
+  beat1a: string;
+  beat1b: string;
+  beat1c: string;
+  steelman: string;
+  roomPerspective: string;
+  changeCommitment: string;
+  wordCount: number;
+  /**
+   * Submit exactly this value as the pick outcome when the participant picks
+   * this side. Sides are randomised left/right per serve, so never assume
+   * "left" means outcome 'A' — always read it off the side itself.
+   */
+  outcome: 'A' | 'B';
+}
+
+export interface ServedPair {
+  comparisonId: string;
+  caseStudyId: string;
+  left: ServedPairSide;
+  right: ServedPairSide;
+  /** ISO timestamp — the server-anchored timer origin, never a client-invented one. */
+  servedAt: string;
+  minimumScreenTimeSeconds: number;
+}
+
+export interface PickResult {
+  outcome: PickOutcome;
+  /** Readers of this exact pair (any reviewer) who chose the same outcome, this pick included. */
+  agreementCount: number;
+  /** Readers of this exact pair who gave a substantive verdict (A/B/BOTH_WEAK) — FLAGGED excluded. */
+  totalJudged: number;
+}
+
+const coursePath = (r: CourseVersionRef) => `${BASE_URL}/courses/${r.courseId}/versions/${r.versionId}`;
+
+export const caseStudyApi = {
+  /** Sync + fetch the case backing a CASE_STUDY course item. Idempotent. */
+  ensureCase(ref: CourseVersionRef, itemId: string) {
+    return apiFetch<{caseStudyId: string; title: string; bodyMarkdown: string}>(
+      `${coursePath(ref)}/items/${itemId}/ensure`,
+      {method: 'POST'},
+    );
+  },
+
+  getMyResponse(caseStudyId: string) {
+    return apiFetch<{
+      response: MyCaseResponse | null;
+      eligibleForRevision: boolean;
+      /** Reviews the learner is asked to complete for this case (per-item config). */
+      picksRequired: number;
+      /** Substantive reviews (A/B/BOTH_WEAK) this learner has already submitted. */
+      picksCompleted: number;
+    }>(`${BASE_URL}/${caseStudyId}/my-response`);
+  },
+
+  submitResponse(caseStudyId: string, response: CaseResponseInput) {
+    return apiFetch<{responseId: string}>(`${BASE_URL}/${caseStudyId}/responses`, {
+      method: 'POST',
+      body: JSON.stringify(response),
+    });
+  },
+
+  getNextPair(caseStudyId: string) {
+    return apiFetch<{pair: ServedPair | null}>(`${BASE_URL}/${caseStudyId}/pairs/next`);
+  },
+
+  submitPick(comparisonId: string, outcome: PickOutcome) {
+    return apiFetch<PickResult>(`${BASE_URL}/pairs/${comparisonId}/pick`, {
+      method: 'POST',
+      body: JSON.stringify({outcome}),
+    });
+  },
+
+  reviseResponse(caseStudyId: string, response: CaseResponseInput) {
+    return apiFetch<{responseId: string}>(`${BASE_URL}/${caseStudyId}/responses`, {
+      method: 'PATCH',
+      body: JSON.stringify(response),
+    });
+  },
+
+  listResponses(courseId: string, versionId: string, itemId: string) {
+    return apiFetch<{responses: MyCaseResponse[]}>(
+      `${BASE_URL}/courses/${courseId}/versions/${versionId}/items/${itemId}/responses`,
+    );
+  },
+};

--- a/frontend/src/types/video.types.ts
+++ b/frontend/src/types/video.types.ts
@@ -131,6 +131,9 @@ export interface StudentProctoringSettings {
     };
     linearProgressionEnabled: boolean;
     seekForwardEnabled: boolean;
+    caseStudiesEnabled?: boolean;
+    caseStudyStrictUnlockEnabled?: boolean;
+    caseStudyWeakStreakThreshold?: number;
   };
 }
 

--- a/frontend/src/utils/time.test.ts
+++ b/frontend/src/utils/time.test.ts
@@ -7,6 +7,7 @@ import {
   digitsToSeconds,
   parsePastedTime,
   formatWatchDuration,
+  formatTimeAgo,
 } from './time';
 
 describe('formatTime', () => {
@@ -178,5 +179,28 @@ describe('formatWatchDuration', () => {
     expect(formatWatchDuration(0)).toBe('0m');
     expect(formatWatchDuration(-5)).toBe('0m');
     expect(formatWatchDuration(NaN)).toBe('0m');
+  });
+});
+
+describe('formatTimeAgo', () => {
+  it('reads anything under a minute as current', () => {
+    expect(formatTimeAgo(new Date())).toBe('just now');
+    expect(formatTimeAgo(Date.now() - 30_000)).toBe('just now');
+  });
+
+  it('steps up through minutes, hours and days', () => {
+    expect(formatTimeAgo(Date.now() - 12 * 60_000)).toBe('12m ago');
+    expect(formatTimeAgo(Date.now() - 3 * 3600_000)).toBe('3h ago');
+    expect(formatTimeAgo(Date.now() - 2 * 86400_000)).toBe('2d ago');
+  });
+
+  it('treats a future timestamp as current rather than negative', () => {
+    // Clock skew between the server and the viewer must not render as
+    // "-1m ago" on a figure that was just recomputed.
+    expect(formatTimeAgo(Date.now() + 30_000)).toBe('just now');
+  });
+
+  it('returns an empty string for an unusable date', () => {
+    expect(formatTimeAgo('not a date')).toBe('');
   });
 });

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -174,3 +174,30 @@ export function parsePastedTime(text: string): number | null {
 
   return null;
 }
+
+/**
+ * How long ago a moment was, coarsely — `just now`, `12m ago`, `3h ago`.
+ *
+ * For figures the backend recomputes on a schedule rather than per request.
+ * The exact second is never the point; a teacher only wants to know whether
+ * the number in front of them is current or from a while back, so the
+ * granularity stops at days.
+ */
+export function formatTimeAgo(when: Date | string | number): string {
+  const then = new Date(when).getTime();
+  if (!Number.isFinite(then)) return '';
+
+  const seconds = Math.floor((Date.now() - then) / 1000);
+  // Clock skew between the server and the viewer can put a fresh timestamp
+  // slightly in the future, which should read as current rather than negative.
+  if (seconds < 60) return 'just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/frontend/src/utils/wordCount.ts
+++ b/frontend/src/utils/wordCount.ts
@@ -1,0 +1,10 @@
+/**
+ * Must match `backend/src/modules/caseStudies/constants.ts`'s `countWords`
+ * exactly, so the displayed count never disagrees with what the server will
+ * accept. Case-study text mixes Hindi and English freely, so this counts
+ * runs of letters/combining-marks/digits rather than splitting on spaces.
+ */
+export function countWords(text: string): number {
+  const matches = text.trim().match(/[\p{L}\p{M}\p{N}]+/gu);
+  return matches ? matches.length : 0;
+}


### PR DESCRIPTION
## Summary

- Adds a new `CASE_STUDY` course item type (mirrors `REFLECTION`) backed by a full `caseStudies` backend module (service, repository, controller, DI container, constants, validators, transformers, tests)
- Students write a structured 6-field response (3-beat arc + steelman + room perspective + change commitment), then judge A-vs-B peer comparison pairs; win-count model exits responses from the review pool at a configurable threshold
- Flag-based withdrawal: two `FLAGGED` verdicts flip a response to `WITHDRAWN`, notify the author via `case_response_withdrawn`, and unlock the revise UI; weak-streak path works the same via `case_response_weak_streak`
- Anomaly signals (`TAB_SWITCH_DURING_REVIEW`, `PASTE_ATTEMPTED`) wired into the existing anomaly module
- Proctoring settings (`caseStudiesEnabled`, `caseStudyStrictUnlockEnabled`, `caseStudyWeakStreakThreshold`) added to `CourseSetting`
- Teacher-facing: `CaseStudyItemEditor` for inline authoring, `CaseStudyResponsesPanel` for response moderation
- API-key-gated integration endpoint: `GET /integrations/courses/:courseId/versions/:versionId/case-studies/progress`

## Test plan

- [ ] Teacher: add a `CASE_STUDY` item to a course section — editor renders with title + body fields
- [ ] Student: open the item, complete declaration + session date gate, submit a valid response (steelman ≥ 25 words)
- [ ] Student: submit a second response as a different user, then open peer review — A/B comparison cards appear with reading-time lock
- [ ] Submit a pick after the timer clears — win/loss counts update on the response
- [ ] Trigger weak streak (3 consecutive losses) — amber banner + "Revise my response" button appear
- [ ] Trigger flag withdrawal (2 FLAGGED verdicts) — red banner + revise button appear; revise flow re-enters response as OPEN
- [ ] Proctoring settings modal shows case study toggles and saves correctly
- [ ] `GET /integrations/.../case-studies/progress` returns roster with correct win/status data

🤖 Generated with [Claude Code](https://claude.com/claude-code)