### PR TITLE
fix(student): make video stopItem a real awaited promise instead of fire-and-forget

### DIFF
--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -646,9 +646,7 @@ const Video = forwardRef<VideoRef, VideoProps>(function Video({ URL, source, ass
   }, [handleStopItem]);
 
   useImperativeHandle(ref, () => ({
-    stopItem: () => {
-      void stopIfInProgress();
-    },
+    stopItem: () => stopIfInProgress(),
   }), [stopIfInProgress]);
 
   // Pause/resume video based on doGesture

--- a/frontend/src/types/video.types.ts
+++ b/frontend/src/types/video.types.ts
@@ -47,7 +47,7 @@ export interface VideoProps {
  * the parent can await a stop before navigating away from an in-progress video.
  */
 export interface VideoRef {
-  stopItem: () => void;
+  stopItem: () => Promise<void>;
 }
 
 


### PR DESCRIPTION
## Summary
- `VideoRef.stopItem` was typed and implemented as fire-and-forget (`() => void`, discarding the underlying promise with `void`), so the caller that does `await videoRef.current.stopItem()` before navigating to the next lesson was awaiting a value that resolved instantly, not the real completion request.
- The page could then tear down the video and load the next lesson while the stop call was still in flight, and the browser would sometimes cancel it outright.
- An item only counts as complete once its watchTime row gets an `endTime`, written solely by that stop call — when it's lost, the item never completes, and with linear progression on, every lesson after it stays locked even though the student actually finished it.

## Fix
`stopItem` is now typed and implemented as a real `Promise<void>`, so the existing caller genuinely waits for the request to settle before navigating.

## Test plan
- [x] Live-verified on a fork deployment: reverted this exact change, confirmed clicking "Next Lesson" navigated instantly with no wait for the save (reproducing the bug), then restored the fix and confirmed the expected wait/processing behavior returns.
- [x] Confirmed no other callers of `VideoRef.stopItem` depend on the old synchronous (`void`) signature.

Closes #1364