### PR TITLE
fix(student): make video stopItem a real awaited promise instead of fire-and-forget (main-v1 backport)

### DIFF
--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -646,9 +646,7 @@ const Video = forwardRef<VideoRef, VideoProps>(function Video({ URL, source, ass
   }, [handleStopItem]);
 
   useImperativeHandle(ref, () => ({
-    stopItem: () => {
-      void stopIfInProgress();
-    },
+    stopItem: () => stopIfInProgress(),
   }), [stopIfInProgress]);
 
   // Pause/resume video based on doGesture

--- a/frontend/src/types/video.types.ts
+++ b/frontend/src/types/video.types.ts
@@ -47,7 +47,7 @@ export interface VideoProps {
  * the parent can await a stop before navigating away from an in-progress video.
  */
 export interface VideoRef {
-  stopItem: () => void;
+  stopItem: () => Promise<void>;
 }
 
 


### PR DESCRIPTION
## Summary
Same fix as #1365, targeting `main-v1`.

- `VideoRef.stopItem` was typed and implemented as fire-and-forget (`() => void`, discarding the underlying promise with `void`), so the caller that does `await videoRef.current.stopItem()` before navigating to the next lesson was awaiting a value that resolved instantly, not the real completion request.
- The page could then tear down the video and load the next lesson while the stop call was still in flight, and the browser would sometimes cancel it outright.
- An item only counts as complete once its watchTime row gets an `endTime`, written solely by that stop call — when it's lost, the item never completes, and with linear progression on, every lesson after it stays locked even though the student actually finished it.

## Fix
`stopItem` is now typed and implemented as a real `Promise<void>`, so the existing caller genuinely waits for the request to settle before navigating.

## Test plan
- [x] Live-verified this exact change on a fork deployment (revert/reproduce/restore cycle) — see #1365 for details.
- [x] Confirmed `main-v1`'s `video.tsx`/`video.types.ts` had the identical pre-fix code, so the same patch applies cleanly.

Closes #1364