### PR TITLE
fix(student): require the paired video to be completed before unlocking its quiz

### DIFF
--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1769,11 +1769,17 @@ const handleGoToNextItem = async () => {
   // even for already-completed items. Unknown position must not imply locked.
   if (currentItemIndex === -1) return false;
 
-  // Only unlock next item if it's a QUIZ paired with current VIDEO
+  // Unlock the paired quiz only once the video is actually completed. The
+  // backend serves it on the same condition, so unlocking earlier hands the
+  // student a link that 403s mid-video.
   if (itemIndex === currentItemIndex + 1) {
     const currentItemInList = sectionItemsList[currentItemIndex] as any;
     const thisItem = sectionItemsList[itemIndex] as any;
-    if (currentItemInList?.type === 'VIDEO' && thisItem?.type === 'QUIZ') {
+    if (
+      currentItemInList?.type === 'VIDEO' &&
+      thisItem?.type === 'QUIZ' &&
+      currentItemInList?.isCompleted
+    ) {
       return false; // unlock paired quiz
     }
     return true; // lock everything else


### PR DESCRIPTION
## Summary
- The sidebar rendered a quiz paired with the current video as unlocked as soon as the video was reached, not once it was actually completed, while the backend enforces completion before serving that quiz — so a student could click a link the UI presented as available and have it 403 mid-video.
- The unlock condition checked only that the quiz was positionally next after its video (`itemIndex === currentItemIndex + 1`), with no check on the video's own completion state.

## Fix
Unlock now also requires the video's `isCompleted` flag, matching what the backend already enforces.

## Test plan
- [x] Live-verified on a fork deployment: reverted this exact change, confirmed a quiz paired with a genuinely incomplete video showed as unlocked and was directly clickable straight into the quiz (reproducing the bug), then restored the fix.
- [x] Confirmed the change is scoped to `isItemLocked`'s unlock condition only — unrelated to and independent of #1365/#1366 and #1368/#1369.

Closes #1370