### PR TITLE
fix(teacher): un-disable the Linear Course Progression toggle

### DIFF
--- a/frontend/src/components/EditProctoringModal.tsx
+++ b/frontend/src/components/EditProctoringModal.tsx
@@ -352,7 +352,6 @@ export function ProctoringModal({
                     </div>
                     <Switch checked={linearProgressionEnabled}
                      onCheckedChange={()=>setLinearProgressionEnabled(prev=>!prev)}
-                     disabled 
                      />
                   </div>
 


### PR DESCRIPTION
## Summary
Every click on the "Linear Course Progression" switch in the course settings modal was a no-op — the `<Switch>` had a hardcoded `disabled` prop, unlike every other toggle in the same modal (Seek Forward, Make Public, Hp System, Randomize Content, Student Question Submission, Follow-up Course Invite), none of which are disabled. No comment or surrounding logic explained the restriction, so it reads as leftover/accidental rather than intentional — instructors had no way to ever change this setting once a course was created with it off.

## Fix
Remove the hardcoded `disabled` prop, matching every other switch in the modal.

## Test plan
- [x] Live-verified on a fork deployment: confirmed the toggle was a no-op before the fix (checked via authenticated API calls that `linearProgressionEnabled` never changed regardless of clicking/saving), then confirmed after the fix that clicking + saving actually flips the setting server-side.

Closes #1373