### PR TITLE
fix(teacher): un-disable the Linear Course Progression toggle (main-v1 backport)

### DIFF
--- a/frontend/src/components/EditProctoringModal.tsx
+++ b/frontend/src/components/EditProctoringModal.tsx
@@ -352,7 +352,6 @@ export function ProctoringModal({
                     </div>
                     <Switch checked={linearProgressionEnabled}
                      onCheckedChange={()=>setLinearProgressionEnabled(prev=>!prev)}
-                     disabled 
                      />
                   </div>
 


### PR DESCRIPTION
## Summary
Same fix as #1374, targeting `main-v1`.

Every click on the "Linear Course Progression" switch in the course settings modal was a no-op — the `<Switch>` had a hardcoded `disabled` prop, unlike every other toggle in the same modal (Seek Forward, Make Public, Hp System, Randomize Content, Student Question Submission, Follow-up Course Invite), none of which are disabled.

## Fix
Remove the hardcoded `disabled` prop, matching every other switch in the modal.

## Test plan
- [x] Live-verified this exact change on a fork deployment — see #1374 for details.
- [x] Confirmed `main-v1`'s `EditProctoringModal.tsx` had the identical pre-fix code, so the same patch applies cleanly.

Closes #1373