### PR TITLE
fix(auth): add unique index on firebaseUID to close duplicate-account race (main-v1 backport)

### DIFF
--- a/backend/src/modules/auth/tests/googleSignupRace.test.ts
+++ b/backend/src/modules/auth/tests/googleSignupRace.test.ts
@@ -1,0 +1,118 @@
+import { Container } from 'inversify';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { sharedContainerModule } from '#root/container.js';
+import { authContainerModule } from '#auth/container.js';
+import { usersContainerModule } from '#users/container.js';
+import { coursesContainerModule } from '#root/modules/courses/container.js';
+import { quizzesContainerModule } from '#root/modules/quizzes/container.js';
+import { notificationsContainerModule } from '#root/modules/notifications/container.js';
+import { anomaliesContainerModule } from '#root/modules/anomalies/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
+import { settingContainerModule } from '#root/modules/setting/container.js';
+
+import { AUTH_TYPES } from '#auth/types.js';
+import { FirebaseAuthService } from '#auth/services/FirebaseAuthService.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+
+// Reproduces the suspected root cause of the "duplicate firebaseUID accounts"
+// incident (SASTRA report D-05): a brand-new Google SSO user's first-ever
+// authenticated request goes through FirebaseAuthService.getCurrentUserFromToken
+// -> googleSignup, which checks "does a Mongo user exist for this
+// firebaseUID/email?" and, if not, creates one -- a plain check-then-create
+// with no unique index and no locking. A real SPA fires several authenticated
+// requests in parallel on first load, each hitting this same lazy-provisioning
+// path independently. This test fires that same race directly against the
+// real service/repository code (mocking only the Firebase Admin SDK call),
+// against a real MongoDB (mongodb-memory-server), and reports how many user
+// documents actually got created for one firebaseUID.
+describe('Google SSO lazy-provisioning race (duplicate account reproduction)', () => {
+  let authService: FirebaseAuthService;
+  let db: MongoDatabase;
+
+  const fixedUid = 'race-test-uid-' + Date.now();
+  const fixedEmail = `race-test-${Date.now()}@example.com`;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+
+    const container = new Container();
+    await container.load(
+      sharedContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      coursesContainerModule,
+      quizzesContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      projectsContainerModule,
+      hpSystemContainerModule,
+      courseRegistrationContainerModule,
+      reportsContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+      settingContainerModule,
+    );
+
+    authService = container.get<FirebaseAuthService>(AUTH_TYPES.AuthService);
+    db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
+
+    // Stub only the Firebase Admin SDK boundary -- verifyIdToken always
+    // resolves to the SAME brand-new user, exactly like N concurrent browser
+    // requests all carrying the same freshly-issued Google ID token.
+    (authService as any).auth = {
+      verifyIdToken: async () => ({ uid: fixedUid, email: fixedEmail }),
+      getUser: async () => ({
+        uid: fixedUid,
+        email: fixedEmail,
+        displayName: 'Race Test User',
+      }),
+    };
+  });
+
+  it('does not create more than one user document under concurrent first-login requests', async () => {
+    const CONCURRENCY = 10;
+
+    const results = await Promise.allSettled(
+      Array.from({ length: CONCURRENCY }, () =>
+        authService.getCurrentUserFromToken('fake-token'),
+      ),
+    );
+
+    const succeeded = results.filter(r => r.status === 'fulfilled').length;
+    const failed = results.filter(r => r.status === 'rejected').length;
+
+    const usersCollection = await (db as any).getCollection('users');
+    const matchingUsers = await usersCollection
+      .find({ firebaseUID: fixedUid })
+      .toArray();
+
+    console.log(
+      `[race repro] concurrency=${CONCURRENCY} succeeded=${succeeded} failed=${failed} ` +
+        `documents created for firebaseUID=${fixedUid}: ${matchingUsers.length}`,
+    );
+    if (matchingUsers.length > 1) {
+      console.log(
+        '[race repro] duplicate _ids:',
+        matchingUsers.map((u: any) => u._id.toString()),
+      );
+    }
+
+    expect(matchingUsers.length).toBe(1);
+  });
+});

--- a/backend/src/modules/users/tests/UserRepository.duplicateIndexSafety.test.ts
+++ b/backend/src/modules/users/tests/UserRepository.duplicateIndexSafety.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { MongoDatabase } from '#shared/database/providers/mongo/MongoDatabase.js';
+import { UserRepository } from '#shared/database/providers/mongo/repositories/UserRepository.js';
+
+/**
+ * Answers a real question before deploying the D-05 unique-index fix to a
+ * database that (unlike this fork's test data) already has pre-existing
+ * duplicate firebaseUID documents, like the real incident: does
+ * UserRepository.init()'s un-awaited createIndex({firebaseUID:1},
+ * {unique:true}) call -- which will fail against data that already
+ * violates uniqueness -- crash the process (unhandled rejection), throw
+ * back to the caller, or fail silently and leave existing reads/writes
+ * working?
+ */
+describe('UserRepository unique-index creation against pre-existing duplicates', () => {
+  let db: MongoDatabase;
+  const sharedFirebaseUID = 'pre-existing-dup-uid-' + Date.now();
+  const dupUserAId = new ObjectId();
+  const dupUserBId = new ObjectId();
+
+  beforeAll(async () => {
+    db = new MongoDatabase(process.env.DB_URL, 'dup_index_safety_test');
+    await db.connect();
+
+    // Seed the exact pre-existing-duplicate scenario production has: two
+    // user documents already sharing one firebaseUID, inserted BEFORE any
+    // repository (and therefore its index-creation attempt) ever runs.
+    const usersCollection = await db.getCollection('users');
+    await usersCollection.insertMany([
+      {
+        _id: dupUserAId,
+        firebaseUID: sharedFirebaseUID,
+        email: 'dup-a@example.com',
+        firstName: 'Dup',
+        lastName: 'A',
+        roles: 'user',
+      },
+      {
+        _id: dupUserBId,
+        firebaseUID: sharedFirebaseUID,
+        email: 'dup-b@example.com',
+        firstName: 'Dup',
+        lastName: 'B',
+        roles: 'user',
+      },
+    ] as any);
+  });
+
+  afterAll(async () => {
+    await db.disconnect();
+  });
+
+  it('catches the index-build failure internally instead of an unhandled rejection, and normal reads still work', async () => {
+    let caughtRejection: unknown = null;
+    const onUnhandledRejection = (reason: unknown) => {
+      caughtRejection = reason;
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const repo = new UserRepository(db);
+
+      // Triggers init(), which fires the un-awaited createIndex calls.
+      const found = await repo.findByFirebaseUID(sharedFirebaseUID);
+
+      // Give the background createIndex promise a tick to settle/reject.
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      // The index build genuinely fails against pre-existing duplicates
+      // (E11000), but it must be caught internally by UserRepository, not
+      // escape as an unhandled rejection -- that's what would crash the
+      // process on a real deploy.
+      expect(caughtRejection).toBeNull();
+
+      // A normal read for an EXISTING (even duplicated) user must still work.
+      expect(found).not.toBeNull();
+      expect(['dup-a@example.com', 'dup-b@example.com']).toContain(
+        (found as any)?.email,
+      );
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+});

--- a/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
@@ -40,7 +40,35 @@ export class UserRepository implements IUserRepository {
   private async init(): Promise<void> {
     if (!this.usersCollection) {
       this.usersCollection = await this.db.getCollection<IUser>('users');
-      this.usersCollection.createIndex({email: 1, firebaseUID: 1});
+      this.usersCollection
+        .createIndex({email: 1, firebaseUID: 1})
+        .catch(err =>
+          console.error('Failed to create users email+firebaseUID index:', err),
+        );
+      // create()'s upsert (findOneAndUpdate + $setOnInsert, keyed on
+      // firebaseUID) only prevents concurrent duplicate inserts if the
+      // database actually enforces uniqueness -- without this index, MongoDB
+      // has no reason to serialize concurrent upserts matching the same
+      // filter, and each one just inserts its own document. Confirmed live:
+      // 10 concurrent first-logins for one brand-new Google SSO user (a real
+      // SPA's normal burst of parallel authenticated requests on first load)
+      // created 3 separate user documents sharing one firebaseUID before this
+      // index existed.
+      // .catch(), not await: if the database already has pre-existing
+      // duplicate firebaseUID documents (the exact state this fix targets),
+      // the build fails with E11000 -- confirmed live that an un-awaited,
+      // unhandled rejection here crashes the whole process on startup
+      // (Node's default unhandledRejection behavior). Catching logs it
+      // instead so the app keeps serving existing users while the
+      // duplicates get cleaned up server-side.
+      this.usersCollection
+        .createIndex({firebaseUID: 1}, {unique: true})
+        .catch(err =>
+          console.error(
+            'Failed to create unique firebaseUID index (likely pre-existing duplicate firebaseUID documents -- new duplicates are NOT yet prevented until these are cleaned up and this index builds successfully):',
+            err,
+          ),
+        );
     }
   }
 


### PR DESCRIPTION
## Summary
Same fix as #1377, targeting `main-v1`.

Reproduced live: 10 concurrent first-login requests for one brand-new Google SSO user (mirroring a real SPA's normal burst of parallel authenticated requests on first page load) created 3 separate user documents sharing one `firebaseUID`, all reporting success.

**Root cause:** `getCurrentUserFromToken` → `googleSignup` lazily provisions a user via a check-then-create. `UserRepository.create()` already uses an atomic-looking upsert (`findOneAndUpdate` + `$setOnInsert`, keyed on `firebaseUID`) — but that only serializes concurrent inserts if the database enforces uniqueness on the key. Without an index, MongoDB has no reason to conflict two upserts matching the same filter.

## Fix
Added a unique index on `firebaseUID`. Re-running the same reproduction afterward produced exactly one document, all 10 requests still succeeded (existing transaction retry logic in `BaseService._withTransaction` absorbs the conflict transparently).

**Important deploy note:** both `createIndex` calls are caught rather than awaited, since production may already have existing duplicate `firebaseUID` documents — an un-awaited `createIndex()` failing against them is an unhandled promise rejection that crashes the process on startup under Node's default behavior (confirmed live). Catching it logs a warning instead. Recommend checking for and cleaning up existing duplicate `firebaseUID` accounts so the unique index actually activates.

## Test plan
- [x] Live-verified this exact change — see #1377 for full details.
- [x] Confirmed `main-v1`'s `UserRepository.ts` had the identical pre-fix code, so the same fix applies cleanly.
- [x] Same two regression tests included: `googleSignupRace.test.ts` and `UserRepository.duplicateIndexSafety.test.ts`.

Closes #1376