### PR TITLE
fix(users): thread transaction session into recalculateStudentProgress (main-v1 backport)

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -2679,11 +2679,17 @@ class ProgressService extends BaseService {
         percentCompleted >= FOLLOW_UP_INVITE_THRESHOLD;
 
       if (percentCompleted > 99) {
+        // session must be passed here: without it, this recalculation reads
+        // student-completion data from outside the still-open transaction,
+        // missing the very item completion that triggered it, and its own
+        // write then silently overwrites the correct percentCompleted step
+        // 10 just computed with a stale, too-low value.
         await this.recalculateStudentProgress(
           userId,
           courseId,
           courseVersionId,
           cohortId,
+          session,
         );
       }
 
@@ -4932,7 +4938,8 @@ class ProgressService extends BaseService {
     userId: string,
     courseId: string,
     versionId: string,
-    cohortId?: string
+    cohortId?: string,
+    session?: ClientSession,
   ): Promise<string> {
     if (!userId || !courseId || !versionId) {
       throw new BadRequestError('userId, courseId and versionId are required');
@@ -4943,7 +4950,8 @@ class ProgressService extends BaseService {
       userId,
       courseId,
       versionId,
-      cohortId
+      cohortId,
+      session,
     );
 
     if (!progress) {
@@ -4956,10 +4964,20 @@ class ProgressService extends BaseService {
     }
 
     // 2. Fetch required data's in parallel
+    // session is threaded through the student-state reads (progress,
+    // completed items, enrollment) so a caller running inside an open
+    // transaction (stopItem, when a completion pushes past 99%) sees its own
+    // not-yet-committed writes instead of racing ahead of them -- confirmed
+    // live: without it, this recalculation is blind to the very item
+    // completion that triggered it, and its unconditional write below then
+    // overwrites the correct percentCompleted stopItem had just computed
+    // with a stale, too-low value. courseRepo.readVersion reads course
+    // structure, which nothing in this same transaction is concurrently
+    // editing, so it's left as-is.
     const [completedItemIds, courseVersion, enrollment] = await Promise.all([
-      this.progressRepository.getCompletedItems(userId, courseId, versionId, cohortId),
+      this.progressRepository.getCompletedItems(userId, courseId, versionId, cohortId, session),
       this.courseRepo.readVersion(versionId),
-      this.resolveEnrollment(userId, courseId, versionId, cohortId),
+      this.resolveEnrollment(userId, courseId, versionId, cohortId, session),
     ]);
 
     if (!courseVersion) {
@@ -4978,6 +4996,7 @@ class ProgressService extends BaseService {
         guruProgress.percentCompleted,
         guruProgress.completedItemsCount,
         cohortId,
+        session,
       );
       return 'Progress recalculated successfully';
     }
@@ -5004,7 +5023,7 @@ class ProgressService extends BaseService {
     let missedItemIds = allRelevantItemIds.filter(
       itemId => !completedItemSet.has(itemId),
     );
-    const hiddenItems = await this.progressRepository.getHiddenOrDeletedItems(versionId);
+    const hiddenItems = await this.progressRepository.getHiddenOrDeletedItems(versionId, session);
     const hiddenSet = new Set(hiddenItems.map(i => i.itemId.toString()));
     missedItemIds = missedItemIds.filter(itemId => !hiddenSet.has(itemId));
     // 3. Backfill missed watch-time records
@@ -5014,7 +5033,8 @@ class ProgressService extends BaseService {
         courseId,
         versionId,
         missedItemIds,
-        cohortId
+        cohortId,
+        session,
       );
     }
 
@@ -5070,6 +5090,7 @@ class ProgressService extends BaseService {
       percentCompleted,
       totalCompletedItemsCount,
       enrollment.cohort,
+      session,
     );
 
     return 'Progress recalculated successfully';

--- a/backend/src/modules/users/tests/ProgressRepository.staleReadInsideTransaction.test.ts
+++ b/backend/src/modules/users/tests/ProgressRepository.staleReadInsideTransaction.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { MongoDatabase } from '#shared/database/providers/mongo/MongoDatabase.js';
+import { ProgressRepository } from '#shared/database/providers/mongo/repositories/ProgressRepository.js';
+
+/**
+ * Reproduces the mechanism behind D-06 (SASTRA incident report): inside
+ * ProgressService.stopItem's transaction, recalculateStudentProgress is
+ * called WITHOUT the transaction's session (ProgressService.ts:2681-2688),
+ * right after a correct, session-aware percentCompleted write (step 10,
+ * ~2666). recalculateStudentProgress's own reads (ProgressRepository
+ * .getCompletedItems, called without session) then compute a fresh
+ * percentCompleted and unconditionally overwrite that correct value --
+ * using data read from OUTSIDE the still-open transaction.
+ *
+ * This test isolates that exact mechanism with the real repository code:
+ * does an un-sessioned read see a write made moments earlier inside a
+ * still-open (uncommitted) transaction on the same document? MongoDB's
+ * transaction isolation is a hard guarantee, not a timing-dependent race
+ * like the D-05 duplicate-account bug -- so this is deterministic, not
+ * probabilistic.
+ */
+describe('Un-sessioned read cannot see an open transaction\'s own write (D-06 mechanism)', () => {
+  let db: MongoDatabase;
+  let progressRepo: ProgressRepository;
+
+  const userId = new ObjectId();
+  const courseId = new ObjectId();
+  const courseVersionId = new ObjectId();
+  const itemId = new ObjectId();
+  const watchTimeId = new ObjectId();
+
+  beforeAll(async () => {
+    db = new MongoDatabase(process.env.DB_URL, 'stale_read_test');
+    await db.connect();
+    progressRepo = new ProgressRepository(db);
+
+    const watchTimeCollection = await db.getCollection('watchTime');
+    await watchTimeCollection.insertOne({
+      _id: watchTimeId,
+      userId,
+      courseId,
+      courseVersionId,
+      itemId,
+      startTime: new Date(),
+      // No endTime yet -- this is the "student is about to finish their
+      // last item" state, right before stopItem's transaction runs.
+      isDeleted: false,
+    } as any);
+  });
+
+  afterAll(async () => {
+    await db.disconnect();
+  });
+
+  it('getCompletedItems (no session) does not see stopItemTracking\'s write from a still-open transaction', async () => {
+    const client = await db.getClient();
+    const session = client.startSession();
+    session.startTransaction();
+
+    try {
+      // Mirrors stopItem step 1: close the watchTime row inside the
+      // transaction (this is what makes the item "completed").
+      const stopped = await progressRepo.stopItemTracking(
+        watchTimeId.toString(),
+        session,
+      );
+      expect(stopped).not.toBeNull();
+
+      // Mirrors recalculateStudentProgress's un-sessioned read, called
+      // moments later from inside the SAME still-open transaction.
+      const completedItemsSeenWithoutSession = await progressRepo.getCompletedItems(
+        userId.toString(),
+        courseId.toString(),
+        courseVersionId.toString(),
+      );
+
+      // For comparison: the same read, done correctly WITH the session --
+      // this is what step 10 (percentCompleted, ~ProgressService.ts:2633)
+      // does, and it DOES see the item as completed.
+      const completedItemsSeenWithSession = await progressRepo.getCompletedItems(
+        userId.toString(),
+        courseId.toString(),
+        courseVersionId.toString(),
+        undefined,
+        session,
+      );
+
+      console.log(
+        `[D-06 repro] completed items visible WITHOUT session: ${completedItemsSeenWithoutSession.length}, ` +
+          `WITH session: ${completedItemsSeenWithSession.length}`,
+      );
+
+      await session.commitTransaction();
+
+      // The bug: recalculateStudentProgress's un-sessioned read misses the
+      // item that was JUST completed inside the still-open transaction --
+      // so a recalculation triggered at >99% completion computes stale,
+      // too-low numbers and unconditionally overwrites the correct value
+      // step 10 had just written.
+      expect(completedItemsSeenWithoutSession).toHaveLength(0);
+      expect(completedItemsSeenWithSession).toHaveLength(1);
+    } finally {
+      if (session.inTransaction()) await session.abortTransaction();
+      await session.endSession();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Same fix as #1380, targeting `main-v1`.

Inside `stopItem`'s transaction, when a completion pushes a student past 99%, a correct, session-aware `percentCompleted` write is immediately followed by a call to `recalculateStudentProgress` with no session passed. That function's own reads (`getCompletedItems` in particular) then run outside the still-open transaction, missing the very item completion that triggered the recalculation, and its unconditional write silently overwrites the correct value with a stale, too-low one — deterministically, every time this code path runs, per MongoDB's transaction isolation guarantees.

## Fix
Thread `session` through the calls that touch student-completion state (`findProgress`, `getCompletedItems`, `resolveEnrollment`, `getHiddenOrDeletedItems`, `addBulkWatchTime`, the two `updateProgressPercentById` writes) and pass it from `stopItem`'s call site. Course-structure reads are unaffected by the same transaction and left as-is.

## Test plan
- [x] Live-verified this exact mechanism — see #1380 for full details.
- [x] Confirmed `main-v1`'s `ProgressService.ts` had the identical pre-fix code at every touched location, so the same fix applies cleanly.
- [x] Same regression test included: `ProgressRepository.staleReadInsideTransaction.test.ts`.

Closes #1379