### PR TITLE
fix(users): let the watch-time recovery sweep close BLOG rows with no heartbeat (main-v1 backport)

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -2983,6 +2983,11 @@ class ProgressService extends BaseService {
    * and stays incomplete, so this recovers lost progress without handing out
    * completions and without weakening linear progression.
    *
+   * BLOG is the one exception to needing a heartbeat at all: isValidWatchTime
+   * never checks duration for it (no minimum reading time exists in the live
+   * path either), so a blog read fast enough to lose its stop call before the
+   * first 15s heartbeat still gets closed here, falling back to startTime.
+   *
    * Safe to run concurrently across instances and safe to re-run: closing is
    * guarded on the row still being open, and the pointer only moves when it is
    * still parked on the recovered item.
@@ -3024,19 +3029,27 @@ class ProgressService extends BaseService {
       const cohortId = orphan.cohortId?.toString();
 
       try {
-        // Without a heartbeat there is no evidence of time spent, so there is
-        // nothing to justify a completion.
-        if (!orphan.lastSeenAt) {
-          rejectedIds.push(orphan._id);
-          summary.skipped++;
-          continue;
-        }
-
         const item = await this.itemRepo.readItemById(itemId);
 
         // QUIZ and PROJECT completion depends on a submission this job must
         // not invent; only watch-duration items can be judged from timestamps.
         if (!item || !WATCH_TIME_RECOVERABLE_ITEMS.has(item.type)) {
+          rejectedIds.push(orphan._id);
+          summary.skipped++;
+          continue;
+        }
+
+        // Without a heartbeat there is no evidence of time spent -- for VIDEO
+        // that is nothing to justify a completion against, since its
+        // isValidWatchTime check depends on measuring elapsed time. BLOG is
+        // different: isValidWatchTime never checks duration for it at all
+        // ("no minimum reading time exists in the live path either" -- see
+        // that check), so requiring a heartbeat here is stricter than the
+        // rule this job is supposed to mirror. A blog read fast enough to
+        // lose its stop call before the first 15s heartbeat would otherwise
+        // never be recoverable. Fall back to startTime (0 measured duration)
+        // for BLOG, matching what the live path already accepts unconditionally.
+        if (!orphan.lastSeenAt && item.type !== 'BLOG') {
           rejectedIds.push(orphan._id);
           summary.skipped++;
           continue;
@@ -3058,7 +3071,7 @@ class ProgressService extends BaseService {
           continue;
         }
 
-        const endTime = new Date(orphan.lastSeenAt);
+        const endTime = new Date(orphan.lastSeenAt ?? orphan.startTime);
 
         if (!this.isValidWatchTime({...orphan, endTime}, item)) {
           rejectedIds.push(orphan._id);

--- a/backend/src/modules/users/tests/ProgressService.watchTimeRecovery.test.ts
+++ b/backend/src/modules/users/tests/ProgressService.watchTimeRecovery.test.ts
@@ -27,6 +27,12 @@ const VIDEO_ITEM = {
   details: {startTime: '00:00:00', endTime: '00:10:00'},
 };
 
+const BLOG_ITEM = {
+  _id: ITEM_ID,
+  type: 'BLOG',
+  details: {},
+};
+
 const START = new Date('2026-08-19T10:00:00Z');
 const secondsAfterStart = (n: number) =>
   new Date(START.getTime() + n * 1000);
@@ -154,7 +160,7 @@ describe('ProgressService.recoverOrphanedWatchTimes', () => {
     expect(calls.markedAttempted).toEqual([record._id.toString()]);
   });
 
-  it('skips a session with no heartbeat, since nothing evidences time spent', async () => {
+  it('skips a video session with no heartbeat, since nothing evidences time spent', async () => {
     const record = orphan({lastSeenAt: undefined});
     const {service, calls} = makeService({orphans: [record]});
 
@@ -163,6 +169,21 @@ describe('ProgressService.recoverOrphanedWatchTimes', () => {
     expect(summary).toMatchObject({scanned: 1, closed: 0, skipped: 1});
     expect(calls.closed).toHaveLength(0);
     expect(calls.markedAttempted).toEqual([record._id.toString()]);
+  });
+
+  it('closes a blog session with no heartbeat, since BLOG has no minimum reading time', async () => {
+    // Read fast enough to lose the stop call before the first 15s heartbeat
+    // ever fired -- exactly the case the live path already accepts
+    // unconditionally for BLOG, but which the heartbeat-required check used
+    // to make permanently unrecoverable here.
+    const record = orphan({lastSeenAt: undefined});
+    const {service, calls} = makeService({orphans: [record], item: BLOG_ITEM});
+
+    const summary = await service.recoverOrphanedWatchTimes();
+
+    expect(summary).toMatchObject({scanned: 1, closed: 1, advanced: 1, skipped: 0, rejected: 0});
+    // Falls back to startTime -- there's no heartbeat to close it at.
+    expect(calls.closed[0].endTime).toEqual(record.startTime);
   });
 
   it('never fabricates completion for submission-based items', async () => {


### PR DESCRIPTION
## Summary
Same fix as #1383, targeting `main-v1`.

`isValidWatchTime` never checks duration for BLOG items, but the recovery sweep required at least one `lastSeenAt` heartbeat before touching any row, regardless of type. Heartbeats only start firing 15s after an item is opened, so a student who read an article in under 15s and lost their stop call had zero heartbeats on file and could never be recovered.

## Fix
Move the item-type lookup ahead of the heartbeat check and skip the heartbeat requirement for BLOG specifically, falling back to `startTime` as the close time. VIDEO is unaffected.

## Test plan
- [x] Live-verified this exact change — see #1383 for full details.
- [x] Confirmed `main-v1`'s `ProgressService.ts` and test file had identical pre-fix content, so the same fix applies cleanly.

Closes #1382